### PR TITLE
added an option to consider local repo like a remote

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -27,7 +27,7 @@ from .vcs import git_clone
 logger = logging.getLogger(__name__)
 
 
-def cookiecutter(input_dir, local_is_ref=False):
+def cookiecutter(input_dir, no_input=False):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -35,21 +35,14 @@ def cookiecutter(input_dir, local_is_ref=False):
         or a URL to git repo.
     """
 
-    # If it's a git repo, clone and prompt
+    # If it's a git repo, clone and if local repo, copy
     if input_dir.endswith('.git'):
-        got_repo_arg = True
         repo_dir = git_clone(input_dir)
-        project_template = find_template(repo_dir)
     else:
-        if local_is_ref:
-            got_repo_arg = True
-            repo_dir = './__cookiecutter_tmpdir'
-            shutil.copytree(input_dir, repo_dir)
-            project_template = find_template(repo_dir)
-        else:
-            got_repo_arg = False
-            project_template = find_template(input_dir)
+        repo_dir = './__cookiecutter_tmpdir'
+        shutil.copytree(input_dir, repo_dir)
 
+    project_template = find_template(repo_dir)
     config_file = os.path.join(os.path.dirname(project_template),
                                'cookiecutter.json')
     logging.debug('config_file is {0}'.format(config_file))
@@ -58,9 +51,9 @@ def cookiecutter(input_dir, local_is_ref=False):
         config_file=config_file
     )
 
-    # If the context came from a repo, prompt the user to manually configure
-    # at the command line.
-    if got_repo_arg:
+    # prompt the user to manually configure at the command line.
+    # except when 'no-input' flag is set
+    if not no_input:
         cookiecutter_dict = prompt_for_config(context)
         context['cookiecutter'] = cookiecutter_dict
 
@@ -72,9 +65,8 @@ def cookiecutter(input_dir, local_is_ref=False):
 
     # Remove repo if Cookiecutter cloned it in the first place.
     # Here the user just wants a project, not a project template.
-    if got_repo_arg:
-        generated_project = context['cookiecutter']['repo_name']
-        remove_repo(repo_dir, generated_project)
+    generated_project = context['cookiecutter']['repo_name']
+    remove_repo(repo_dir, generated_project)
 
 
 def parse_cookiecutter_args(args):
@@ -84,10 +76,10 @@ def parse_cookiecutter_args(args):
         description='Create a project from a Cookiecutter project template.'
     )
     parser.add_argument(
-        '--local-is-reference',
+        '--no-input',
         action="store_true",
-        help='consider local repository like a remote (git) directory:'
-             'clone into a new one and asks for parameters')
+        help='Do not prompt for parameters and only use cookiecutter.json '
+             'file content')
     parser.add_argument(
         'input_dir',
         help='Cookiecutter project dir, e.g. cookiecutter-pypackage/'
@@ -104,7 +96,7 @@ def main():
 
     args = parse_cookiecutter_args(sys.argv[1:])
 
-    cookiecutter(args.input_dir, args.local_is_reference)
+    cookiecutter(args.input_dir, args.no_input)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
with this option, cookiecutter now ask for confirming the parameters and copy the repo before appliying the templates and then remove the copy leaving the new repo alone without touching the 'reference local repository'.

(I was not so inspired for the argument name...)
