### PR TITLE
Update the cookiecutter-openstack link to point at the new location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,7 @@ HTML
 .. _`cookiecutter-django`: https://github.com/pydanny/cookiecutter-django
 .. _`cookiecutter-djangopackage`: https://github.com/pydanny/cookiecutter-djangopackage
 .. _`bootstrap.c`: https://github.com/vincentbernat/bootstrap.c
-.. _`cookiecutter-openstack`: https://github.com/emonty/cookiecutter-openstack
+.. _`cookiecutter-openstack`: https://github.com/openstack-dev/cookiecutter
 .. _`cookiecutter-component`: https://github.com/audreyr/cookiecutter-component
 .. _`cookiecutter-docopt`: https://github.com/sloria/cookiecutter-docopt
 .. _`docopt`: http://docopt.org/


### PR DESCRIPTION
It now lives on an official OpenStack org.
