### PR TITLE
Add ability to pass in a context file

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -26,7 +26,7 @@ from .vcs import clone
 
 logger = logging.getLogger(__name__)
 
-def cookiecutter(input_dir, checkout=None, no_input=False):
+def cookiecutter(input_dir, checkout=None, no_input=False, context_file=None):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -50,7 +50,8 @@ def cookiecutter(input_dir, checkout=None, no_input=False):
         # If it's a local repo, no need to clone or copy to your cookiecutters_dir
         repo_dir = input_dir
 
-    context_file = os.path.join(repo_dir, 'cookiecutter.json')
+    if not context_file:
+        context_file = os.path.join(repo_dir, 'cookiecutter.json')
     logging.debug('context_file is {0}'.format(context_file))
 
     context = generate_context(
@@ -83,6 +84,9 @@ def parse_cookiecutter_args(args):
         help='Do not prompt for parameters and only use cookiecutter.json '
              'file content')
     parser.add_argument(
+        '--context-file'
+        help='Location of JSON context file to use for prompt values.')
+    parser.add_argument(
         'input_dir',
         help='Cookiecutter project dir, e.g. cookiecutter-pypackage/'
     )
@@ -112,7 +116,8 @@ def main():
             level=logging.INFO
         )
     
-    cookiecutter(args.input_dir, args.checkout, args.no_input)
+    cookiecutter(
+        args.input_dir, args.checkout, args.no_input, args.context_file)
 
 
 if __name__ == '__main__':

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -51,6 +51,16 @@ Possible settings are:
 * cookiecutters_dir: Directory where your cookiecutters are cloned to when you
   use Cookiecutter with a repo argument.
 
+Overriding Prompts with a Context File
+--------------------------------------
+
+If you would like to generate a new project without being prompted for
+values, but you do not want to use the default values in the cookiecutter's
+`cookiecutter.json` file, you can provide your own json file with the input
+values filed in using the `--context-file` option. The format of the file is
+exactly like the format of the `cookiecutter.json` file. To get unattended
+creation, you'll still need to supply `--no-input`.
+
 Calling Cookiecutter Functions From Python
 ------------------------------------------
 


### PR DESCRIPTION
If cookiecutter is used inside of a project creation automation, you
want to not only give --no-input, but also supply input values other
than the ones in the default file.

Add a command line option, --context-file, which allows overriding the
default location for default values.
