### PR TITLE
Passing cookiecutter context to hooks using os.environ #60

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -178,7 +178,7 @@ def generate_files(repo_dir, context=None, output_dir="."):
 
     # run pre-gen hook from repo_dir
     with work_in(repo_dir):
-        run_hook('pre_gen_project', project_dir)
+        run_hook('pre_gen_project', context, project_dir)
 
     with work_in(template_dir):
         env = Environment()
@@ -196,4 +196,4 @@ def generate_files(repo_dir, context=None, output_dir="."):
 
     # run post-gen hook from repo_dir
     with work_in(repo_dir):
-        run_hook('post_gen_project', project_dir)
+        run_hook('post_gen_project', context, project_dir)

--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -42,12 +42,14 @@ def find_hooks():
     return r
 
 
-def _run_hook(script_path, cwd='.'):
+def _run_hook(script_path, context, cwd='.'):
     '''
     Run a sigle external script located at `script_path` (path should be
     absolute).
     If `cwd` is provided, the script will be run from that directory.
     '''
+    if 'cookiecutter' in context:
+        os.environ.update(context['cookiecutter'])
     run_thru_shell = sys.platform.startswith('win')
     proc = subprocess.Popen(
         script_path,
@@ -56,7 +58,7 @@ def _run_hook(script_path, cwd='.'):
     )
     proc.wait()
 
-def run_hook(hook_name, project_dir):
+def run_hook(hook_name, context, project_dir):
     '''
     Try and find a script mapped to `hook_name` in the current working directory,
     and execute it from `project_dir`.
@@ -65,4 +67,4 @@ def run_hook(hook_name, project_dir):
     if script is None:
         logging.debug("No hooks found")
         return
-    return _run_hook(script, project_dir)
+    return _run_hook(script, context, project_dir)

--- a/tests/test-hooks/hooks/post_gen_project.sh
+++ b/tests/test-hooks/hooks/post_gen_project.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 echo 'post generation hook';
-touch 'shell_post.txt'
+touch 'shell_post.txt';
+echo $test > 'shell_post.txt'

--- a/tests/test-hooks/hooks/pre_gen_project.py
+++ b/tests/test-hooks/hooks/pre_gen_project.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+import os
 
 print('pre generation hook')
 f = open('python_pre.txt', 'w')
+f.write(os.environ['test'])
 f.close()
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -51,13 +51,13 @@ class TestExternalHooks(unittest.TestCase):
 
     def test_run_hook(self):
         '''execute a hook script, independently of project generation'''
-        hooks._run_hook(os.path.join(self.hooks_path, 'post_gen_project.sh'))
+        hooks._run_hook(os.path.join(self.hooks_path, 'post_gen_project.sh'), {})
         self.assertTrue(os.path.isfile('shell_post.txt'))
 
     def test_run_hook_cwd(self):
         '''Change directory before running hook'''
         hooks._run_hook(os.path.join(self.hooks_path, 'post_gen_project.sh'), 
-                        'tests')
+                        {}, 'tests')
         self.assertTrue(os.path.isfile('tests/shell_post.txt'))
         self.assertFalse('tests' in os.getcwd())
         
@@ -65,11 +65,19 @@ class TestExternalHooks(unittest.TestCase):
         '''Execute hook from specified template in specified output directory'''
         tests_dir = os.path.join(self.repo_path, 'input{{hooks}}')
         with utils.work_in(self.repo_path):
-            hooks.run_hook('pre_gen_project', tests_dir)
+            hooks.run_hook('pre_gen_project', 
+                           {'cookiecutter': {'test': 'test'}}, 
+                           tests_dir)
             self.assertTrue(os.path.isfile(os.path.join(tests_dir, 'python_pre.txt')))
+            f = open(os.path.join(tests_dir, 'python_pre.txt'))
+            self.assertEqual(f.readline(), 'test')
 
-            hooks.run_hook('post_gen_project', tests_dir)
+            hooks.run_hook('post_gen_project', 
+                           {'cookiecutter': {'test': 'test'}},
+                           tests_dir)
             self.assertTrue(os.path.isfile(os.path.join(tests_dir, 'shell_post.txt')))
+            f = open(os.path.join(tests_dir, 'shell_post.txt'))
+            self.assertEqual(f.readline(), 'test\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Started using [pydanny's](https://github.com/pydanny) [cookiecutter-djangopackage](https://github.com/pydanny/cookiecutter-djangopackage) for my projects about a month back and noticed that it did not include a demo project. I wanted the following directory structure:
- repo_name
  - docs
  - tests
  - app_name
  - --- lots of files ---
  - demo (django project)
    - demo
    - **symbolic link to ../app_name**

I failed to implement the above scenario because I did not have access to the cookiecutter context in my hooks and therefore `app_name`. 

I looked up the code and found that:
- `generate.generate_files` function was calling the `hook.run_hook` function
- `generate.generate_files` function had cookiecutter context that was required in the hooks.
- Finally, the environment variables passed to the process initiated by the `subprocess.Popen` function can be controlled by setting `os.environ` dictionary - [Reference](http://stackoverflow.com/questions/4906977/python-environment-variables)

The implementation that followed seems simple and elegant. I am now able to write the symbolic link command that accesses `app_name` from cookiecutter context by extracting it from `os.environ`. All the tests are passing. If you approve, I will update the documentation to reflect this feature.

N. B. This is my first pull-request. I have tried to follow the instructions chalked out in `contribution guide` but there is a chance I may have missed a point or two. I am eager to improve upon this.
