### PR TITLE
Include tests and documentation in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,5 @@ include README.rst
 recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+
+recursive-include docs *.rst conf.py Makefile make.bat


### PR DESCRIPTION
This is quite useful when making distribution packages. I would need it for Debian since 0.7.0 tarball does not include tests nor documentation. A 0.7.1 release would also be appreciated for this purpose! :)
