### PR TITLE
Use the current Python interpreter to run python hooks.

### DIFF
--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -49,8 +49,12 @@ def _run_hook(script_path, cwd='.'):
     If `cwd` is provided, the script will be run from that directory.
     '''
     run_thru_shell = sys.platform.startswith('win')
+    if script_path.endswith('.py'):
+        script_command = [sys.executable, script_path]
+    else:
+        script_command = [script_path]
     proc = subprocess.Popen(
-        script_path,
+        script_command,
         shell=run_thru_shell,
         cwd=cwd
     )


### PR DESCRIPTION
This helps when slinging virtualenvs around.
