### PR TITLE
Add a link to cookieforms.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,8 @@ Here is a list of **cookiecutters** (aka Cookiecutter project templates) for you
 
 Make your own, then submit a pull request adding yours to this list!
 
+Don't hesitate to try them online: http://diecutter.io/cookieforms/
+
 Python
 ~~~~~~
 


### PR DESCRIPTION
I've started the link between cookiecutter and diecutter.

Please have a try here : http://diecutter.io/cookieforms/
