### PR TITLE
input_context parameter form main.cookiecutter()

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -16,7 +16,6 @@ import argparse
 import logging
 import os
 import sys
-import shutil
 
 from .config import get_user_config
 from .prompt import prompt_for_config
@@ -26,18 +25,26 @@ from .vcs import clone
 
 logger = logging.getLogger(__name__)
 
-def cookiecutter(input_dir, checkout=None, no_input=False):
+def cookiecutter(input_dir, checkout=None, no_input=False, input_context={}):
     """
     API equivalent to using Cookiecutter at the command line.
 
     :param input_dir: A directory containing a project template dir,
         or a URL to git repo.
     :param checkout: The branch, tag or commit ID to checkout after clone
+    :param no_input: Whether the user will be promptet for input on the CLI
+    :param input_context: Additional input dictionary that will override
+        any other values from cookiecutter.json or the user config.
     """
 
     # Get user config from ~/.cookiecutterrc or equivalent
     # If no config file, sensible defaults from config.DEFAULT_CONFIG are used
     config_dict = get_user_config()
+    
+    # Get default context by updating config_dict with input_context. I.e.
+    # input_context will allways overide possibly existing values from
+    # config_dict
+    default_context = dict(config_dict['default_context'], **input_context)
 
     # TODO: find a better way to tell if it's a repo URL
     if "git@" in input_dir or "https://" in input_dir:
@@ -55,7 +62,7 @@ def cookiecutter(input_dir, checkout=None, no_input=False):
 
     context = generate_context(
         context_file=context_file,
-        default_context=config_dict['default_context']
+        default_context=default_context
     )
 
     # prompt the user to manually configure at the command line.

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -68,4 +68,20 @@ This is useful if, for example, you're writing a web framework and need to
 provide developers with a tool similar to `django-admin.py startproject` or
 `npm init`.
 
+It is also possible, to add an dictionary of additional input configurations 
+that will override any other values from cookiecutter.json or the user config
+`.cookiecutterrc`::
+   
+    cookiecutter('cookiecutter-pypackage/', 
+                 input_context={'project_name': 'TheGreatest'})
+
+If you combine that with the no_input parameter, you can programmatically 
+create the project, with a set list of context parameters and without any 
+command line prompts for the users.::
+   
+    cookiecutter('cookiecutter-pypackage/', 
+                 no_input=True,
+                 input_context={'project_name': 'TheGreatest'})
+
+
 See the :ref:`API Reference` for more details.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,6 +58,27 @@ class TestCookiecutterLocalNoInput(CookiecutterCleanSystemTestCase):
         if os.path.isdir('fake-project'):
             shutil.rmtree('fake-project')
 
+class TestCookiecutterLocalNoInputWithInputContext(CookiecutterCleanSystemTestCase):
+
+    def test_cookiecutter(self):
+        main.cookiecutter('tests/fake-repo-pre/', no_input=True, input_context={'repo_name':'fake-with-input-context-project'})
+        self.assertTrue(os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}'))
+        self.assertFalse(os.path.isdir('tests/fake-repo-pre/fake-with-input-context-project'))
+        self.assertTrue(os.path.isdir('fake-with-input-context-project'))
+        self.assertTrue(os.path.isfile('fake-with-input-context-project/README.rst'))
+        self.assertFalse(os.path.exists('fake-with-input-context-project/json/'))
+
+    def test_cookiecutter_no_slash(self):
+        main.cookiecutter('tests/fake-repo-pre', no_input=True, input_context={'repo_name':'fake-with-input-context-project'})
+        self.assertTrue(os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}'))
+        self.assertFalse(os.path.isdir('tests/fake-repo-pre/fake-with-input-context-project'))
+        self.assertTrue(os.path.isdir('fake-with-input-context-project'))
+        self.assertTrue(os.path.isfile('fake-with-input-context-project/README.rst'))
+        self.assertFalse(os.path.exists('fake-with-input-context-project/json/'))
+
+    def tearDown(self):
+        if os.path.isdir('fake-with-input-context-project'):
+            shutil.rmtree('fake-with-input-context-project')
 
 class TestCookiecutterLocalWithInput(CookiecutterCleanSystemTestCase):
 
@@ -76,6 +97,25 @@ class TestCookiecutterLocalWithInput(CookiecutterCleanSystemTestCase):
     def tearDown(self):
         if os.path.isdir('fake-project'):
             shutil.rmtree('fake-project')
+
+
+class TestCookiecutterLocalWithInputWithInputContext(CookiecutterCleanSystemTestCase):
+
+    @patch(input_str, lambda x: '\n')
+    def test_cookiecutter_local_with_input(self):
+        if not PY3:
+            sys.stdin = StringIO("\n\n\n\n\n\n\n\n\n\n\n\n")
+
+        main.cookiecutter('tests/fake-repo-pre/', no_input=False, input_context={'repo_name':'fake-with-input-context-project'})
+        self.assertTrue(os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}'))
+        self.assertFalse(os.path.isdir('tests/fake-repo-pre/fake-with-input-context-project'))
+        self.assertTrue(os.path.isdir('fake-with-input-context-project'))
+        self.assertTrue(os.path.isfile('fake-with-input-context-project/README.rst'))
+        self.assertFalse(os.path.exists('fake-with-input-context-project/json/'))
+
+    def tearDown(self):
+        if os.path.isdir('fake-with-input-context-project'):
+            shutil.rmtree('fake-with-input-context-project')
 
 
 class TestArgParsing(unittest.TestCase):


### PR DESCRIPTION
The input_context paramter for main.cookiecutter will override any other values from cookiecutter.json or the user config. This enables you to programmatically create the project, with a set list of context parameters. 

If have added unitt tests and updated the docs.
