### PR TITLE
tests: add an environment variable to disable network tests

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -37,6 +37,11 @@ try:
 except KeyError:
     travis = False
 
+try:
+    nonetwork = os.environ[u'DISABLE_NETWORK_TESTS']
+except KeyError:
+    nonetwork = False
+
 from cookiecutter import config, utils
 from tests import force_delete, CookiecutterCleanSystemTestCase
 
@@ -45,6 +50,7 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 
 
 @unittest.skipIf(condition=travis, reason='Works locally with tox but fails on Travis.')
+@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub.')
 class TestPyPackage(CookiecutterCleanSystemTestCase):
 
 
@@ -79,6 +85,7 @@ class TestPyPackage(CookiecutterCleanSystemTestCase):
 
 
 @unittest.skipIf(condition=travis, reason='Works locally with tox but fails on Travis.')
+@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub.')
 class TestJQuery(CookiecutterCleanSystemTestCase):
 
 
@@ -113,6 +120,7 @@ class TestJQuery(CookiecutterCleanSystemTestCase):
 
 
 @unittest.skipIf(condition=travis, reason='Works locally with tox but fails on Travis.')
+@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub.')
 class TestExamplesRepoArg(CookiecutterCleanSystemTestCase):
 
     def tearDown(self):
@@ -138,6 +146,7 @@ class TestExamplesRepoArg(CookiecutterCleanSystemTestCase):
 
 
 @unittest.skipIf(condition=travis, reason='Works locally with tox but fails on Travis.')
+@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub.')
 class TestGitBranch(CookiecutterCleanSystemTestCase):
 
     def tearDown(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,6 +31,11 @@ else:
     input_str = '__builtin__.raw_input'
     from cStringIO import StringIO
 
+try:
+    nonetwork = os.environ[u'DISABLE_NETWORK_TESTS']
+except KeyError:
+    nonetwork = False
+
 
 # Log debug and above to console
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
@@ -91,6 +96,7 @@ class TestArgParsing(unittest.TestCase):
         self.assertEqual(args.checkout, 'develop')
 
 
+@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub/Bitbucket.')
 class TestCookiecutterRepoArg(CookiecutterCleanSystemTestCase):
 
     def tearDown(self):

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -28,6 +28,11 @@ else:
 
 from cookiecutter import utils, vcs
 
+try:
+    nonetwork = os.environ[u'DISABLE_NETWORK_TESTS']
+except KeyError:
+    nonetwork = False
+
 
 # Log debug and above to console
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
@@ -53,6 +58,7 @@ class TestIdentifyRepo(unittest.TestCase):
         self.assertEqual(vcs.identify_repo(repo_url), "hg")
 
 
+@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub/Bitbucket.')
 class TestVCS(unittest.TestCase):
 
     def test_git_clone(self):
@@ -111,6 +117,7 @@ class TestVCS(unittest.TestCase):
             shutil.rmtree('cookiecutter-trytonmodule')
 
 
+@unittest.skipIf(condition=nonetwork, reason='Needs a network connection to GitHub/Bitbucket.')
 class TestVCSPrompt(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This is useful when we want to test the package on an environement
without networking. This can happen on some buildbots, like the Debian
builders.
