### PR TITLE
Add template for the kivy python-framework to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,7 @@ Python
 * `cookiecutter-quokka-module`_: A template to create a blueprint module for Quokka Flask CMS.
 * `cookiecutter-django-lborgav`_: Another cookiecutter template for Django project with Booststrap 3 and FontAwesome 4.
 * `cookiecutter-django-paas`_: Django template ready to use in SAAS platforms like Heroku, OpenShift, etc..
+* `cookiecutter-kivy`_: A template for NUI applications built upon the kivy python-framework.
 
 C
 ~~
@@ -200,6 +201,7 @@ HTML
 .. _`cookiecutter-quokka-module`: https://github.com/pythonhub/cookiecutter-quokka-module
 .. _`cookiecutter-django-lborgav`: https://github.com/lborgav/cookiecutter-django
 .. _`cookiecutter-django-paas`: https://github.com/pbacterio/cookiecutter-django-paas
+.. _`cookiecutter-kivy`: https://github.com/hackebrot/cookiecutter-kivy
 .. _`bootstrap.c`: https://github.com/vincentbernat/bootstrap.c
 .. _`cookiecutter-openstack`: https://github.com/openstack-dev/cookiecutter
 .. _`cookiecutter-component`: https://github.com/audreyr/cookiecutter-component


### PR DESCRIPTION
This will simply add my cookiecutter for kivy to the list of python templates.
