### PR TITLE
updates 2.6 requirements to fix issue #174.

### DIFF
--- a/requirements/test_26.txt
+++ b/requirements/test_26.txt
@@ -4,4 +4,4 @@
 mock
 unittest2
 ordereddict
-simplejson
+simplejson>2.1


### PR DESCRIPTION
simplejson.load() prior 2.1 does not accept `object_pairs_hook` argument
