### PR TITLE
Do not convert input prompt to bytes

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -30,7 +30,7 @@ def prompt_for_config(context):
         prompt = "{0} (default is \"{1}\")? ".format(key, val)
 
         if PY3:
-            new_val = input(prompt.encode('utf-8'))
+            new_val = input(prompt)
         else:
             new_val = input(prompt.encode('utf-8')).decode('utf-8')
 


### PR DESCRIPTION
Fix for #98.

Python 3 `input()` takes str objects. Encoding the prompt makes it a bytestring, resulting the `b''` format.
