### PR TITLE
prompt and result for (raw_)input do not need encoding

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -29,11 +29,7 @@ def prompt_for_config(context):
     for key, val in iteritems(context['cookiecutter']):
         prompt = "{0} (default is \"{1}\")? ".format(key, val)
 
-        if PY3:
-            new_val = input(prompt)
-        else:
-            new_val = input(prompt.encode('utf-8')).decode('utf-8')
-
+        new_val = input(prompt)
         new_val = new_val.strip()
 
         if new_val == '':


### PR DESCRIPTION
The original code seems to assume that raw_input in Python 2 takes a byte string and returns a byte string. This isn't right - the prompt and result are always (logically) strings and should need no encoding or decoding - the I/O layer will take care of that.
