### PR TITLE
Do not provide an unneeded/invalid encoding argument to json.load

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -45,7 +45,7 @@ def generate_context(context_file='cookiecutter.json', default_context=None):
     context = {}
 
     file_handle = open(context_file)
-    obj = json.load(file_handle, encoding='utf-8', object_pairs_hook=OrderedDict)
+    obj = json.load(file_handle, object_pairs_hook=OrderedDict)
 
     # Add the Python object to the context dictionary
     file_name = os.path.split(context_file)[1]


### PR DESCRIPTION
The `json.load` function in Python's standard library has no documented encoding argument. And although `simplejson.load` does, it's documented as only needed "If the contents of fp are encoded with an ASCII based encoding other than UTF-8" - in other words, specifying UTF-8 is redundant.
