### PR TITLE
Added a tox ini file that uses py.test

### DIFF
--- a/tox_pytest.ini
+++ b/tox_pytest.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist = py26, py27, py33, py34, pypy
+
+[testenv]
+commands = py.test tests {posargs}
+deps = pytest
+
+[testenv:py26]
+deps =
+    {[testenv]deps}
+    mock
+    unittest2
+    ordereddict
+    simplejson>2.1
+
+[testenv:py27]
+deps =
+    {[testenv]deps}
+    mock
+
+[testenv:pypy]
+deps =
+    {[testenv]deps}
+    mock


### PR DESCRIPTION
This is basically a convenience PR. It adds an extra `tox` configuration file that uses `py.test` to run the tests. The benefit is that the `py.test` output can be easier to read when looking for failure information (which has been a problem while trying to diagnose the Windows failures).

I actually much prefer `py.test` for testing, and I think it would be useful to use it for the actual tests - but that's not what this PR does, the existing tests are unchanged here.

To use this file, just do `tox -c tox_pytest.ini`.
