### PR TITLE
added the possibility of directly executing the binary without installing

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -11,10 +11,18 @@ Main `cookiecutter` CLI.
 from __future__ import unicode_literals
 
 import os
+import os.path
 import sys
 import logging
 
 import click
+
+if __name__ == "__main__":
+    # resolve symlink if any
+    current_filename = os.path.realpath(__file__)
+    # insert parent path in sys.path
+    sys.path.insert(0, os.path.join(os.path.dirname(current_filename), ".."))
+
 
 from cookiecutter import __version__
 from cookiecutter.main import cookiecutter
@@ -27,7 +35,7 @@ def print_version(context, param, value):
         return
     click.echo('Cookiecutter %s from %s (Python %s)' % (
         __version__,
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
         sys.version[:3]
     ))
     context.exit()
@@ -68,3 +76,7 @@ def main(template, no_input, checkout, verbose):
         )
 
     cookiecutter(template, checkout, no_input)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 from click.testing import CliRunner
 
@@ -23,3 +24,9 @@ def test_cli_verbose():
     result = runner.invoke(main, ['tests/fake-repo-pre/', '--no-input', '-v'])
     assert result.exit_code == 0
     assert os.path.isdir('fake-project')
+
+
+def test_shell_execution():
+    errlvl = subprocess.call(["python", os.path.join("cookiecutter", "cli.py"),
+                              "--version"])
+    assert errlvl == 0


### PR DESCRIPTION
Hum, this doesn't seem to be a great deal, but it allows for very simple and straightforward usage of an
uninstalled deployed git repos. Very handy for test or using your git as installed repos.

If this doesn't make unicorn cry, please consider adding these 2 lines.

After this, a simple `ln -sf cookiecutter/cli.py /usr/local/bin/cookiecutter` will work out of the box (if of course, 'cookiecutter' module is accessible in the PYTHONPATH)

Not a very big deal, but nice to have.
