### PR TITLE
Bool config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,8 @@ Did someone say features?
             "project_short_description": "Refreshingly simple static site generator.",
             "release_date": "2013-07-10",
             "year": "2013",
-            "version": "0.1.1"
+            "version": "0.1.1",
+            "some_boolean": true
         }
 
 * Unless you suppress it with `--no-input`, you are prompted for input:

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -126,7 +126,10 @@ def prompt_for_config(context, no_input=False):
             val = render_variable(env, raw, cookiecutter_dict)
 
             if not no_input:
-                val = read_user_variable(key, val)
+                if isinstance(raw, bool):
+                    val = read_user_yes_no(key, val)
+                else:
+                    val = read_user_variable(key, val)
 
         cookiecutter_dict[key] = val
     return cookiecutter_dict

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -179,6 +179,24 @@ Or, if the user gives `Yet Another New Project`, the values will be:
 * `yet-another-new-project`
 * `yetanothernewproject`
 
+
+booleans in cookiecutter.json
+-----------------------------
+
+If you have a boolean value in your `cookiecutter.json`, the input overriding
+the default will also be converted to a boolean. For example, given this
+config:
+
+.. code-block:: json
+
+    {
+        "some_bool_val": true
+    }
+
+If you override the default with the string `"false"`, it will be converted
+to the boolean `False`.
+
+
 Copy without Render
 -------------------
 

--- a/tests/test-generate-context/choices_template.json
+++ b/tests/test-generate-context/choices_template.json
@@ -3,6 +3,5 @@
     "github_username": "hackebrot",
     "project_name": "Kivy Project",
     "repo_name": "{{cookiecutter.project_name|lower}}",
-    "orientation": ["all", "landscape", "portrait"],
-    "is_alive": true
+    "orientation": ["all", "landscape", "portrait"]
 }

--- a/tests/test-generate-context/choices_template.json
+++ b/tests/test-generate-context/choices_template.json
@@ -3,5 +3,6 @@
     "github_username": "hackebrot",
     "project_name": "Kivy Project",
     "repo_name": "{{cookiecutter.project_name|lower}}",
-    "orientation": ["all", "landscape", "portrait"]
+    "orientation": ["all", "landscape", "portrait"],
+    "is_alive": true
 }

--- a/tests/test-generate-context/test-bool.json
+++ b/tests/test-generate-context/test-bool.json
@@ -1,0 +1,4 @@
+{
+    "default_true": true,
+    "default_false": false
+}

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -101,13 +101,69 @@ def test_generate_context_with_json_decoding_error():
     assert path in str(excinfo.value)
 
 
+def bool_context_data():
+    context = (
+        {
+            'context_file': 'tests/test-generate-context/test-bool.json'
+        },
+        {
+            'test-bool': {'default_true': True, 'default_false': False}
+        }
+    )
+
+    context_with_default = (
+        {
+            'context_file': 'tests/test-generate-context/test-bool.json',
+            'default_context': {'default_true': False}
+        },
+        {
+            'test-bool': {'default_true': False, 'default_false': False}
+        }
+    )
+
+    context_with_extra = (
+        {
+            'context_file': 'tests/test-generate-context/test-bool.json',
+            'extra_context': {'default_true': True}
+        },
+        {
+            'test-bool': {'default_true': True, 'default_false': False}
+        }
+    )
+
+    context_with_default_and_extra = (
+        {
+            'context_file': 'tests/test-generate-context/test-bool.json',
+            'default_context': {'default_true': False},
+            'extra_context': {'default_false': True}
+        },
+        {
+            'test-bool': {'default_true': False, 'default_false': True}
+        }
+    )
+
+    yield context
+    yield context_with_default
+    yield context_with_extra
+    yield context_with_default_and_extra
+
+
+@pytest.mark.usefixtures('clean_system')
+@pytest.mark.parametrize('input_params, expected_context', bool_context_data())
+def test_generate_bool_context(input_params, expected_context):
+    """
+    Test the generated context for several input parameters against the
+    according expected context.
+    """
+    assert generate.generate_context(**input_params) == expected_context
+
+
 @pytest.fixture
 def default_context():
     return {
         'not_in_template': 'foobar',
         'project_name': 'Kivy Project',
         'orientation': 'landscape',
-        'is_alive': False,
     }
 
 
@@ -135,7 +191,6 @@ def test_choices(context_file, default_context, extra_context):
             ('project_name', 'Kivy Project'),
             ('repo_name', '{{cookiecutter.project_name|lower}}'),
             ('orientation', ['landscape', 'all', 'portrait']),
-            ('is_alive', False),
         ])
     }
 
@@ -154,7 +209,6 @@ def template_context():
         ('project_name', 'Kivy Project'),
         ('repo_name', '{{cookiecutter.project_name|lower}}'),
         ('orientation', ['all', 'landscape', 'portrait']),
-        ('is_alive', True),
     ])
 
 

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -106,7 +106,8 @@ def default_context():
     return {
         'not_in_template': 'foobar',
         'project_name': 'Kivy Project',
-        'orientation': 'landscape'
+        'orientation': 'landscape',
+        'is_alive': False,
     }
 
 
@@ -134,6 +135,7 @@ def test_choices(context_file, default_context, extra_context):
             ('project_name', 'Kivy Project'),
             ('repo_name', '{{cookiecutter.project_name|lower}}'),
             ('orientation', ['landscape', 'all', 'portrait']),
+            ('is_alive', False),
         ])
     }
 
@@ -152,6 +154,7 @@ def template_context():
         ('project_name', 'Kivy Project'),
         ('repo_name', '{{cookiecutter.project_name|lower}}'),
         ('orientation', ['all', 'landscape', 'portrait']),
+        ('is_alive', True),
     ])
 
 

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -163,7 +163,7 @@ def default_context():
     return {
         'not_in_template': 'foobar',
         'project_name': 'Kivy Project',
-        'orientation': 'landscape',
+        'orientation': 'landscape'
     }
 
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -212,7 +212,16 @@ class TestPromptChoiceForConfig(object):
     def context(self, choices):
         return {
             'cookiecutter': {
-                'orientation': choices
+                'orientation': choices,
+                'is_alive': True,
+            }
+        }
+
+    @pytest.fixture
+    def bool_context(self, choices):
+        return {
+            'cookiecutter': {
+                'is_alive': True,
             }
         }
 
@@ -247,3 +256,32 @@ class TestPromptChoiceForConfig(object):
         )
         read_choice.assert_called_once_with('orientation', choices)
         assert expected_choice == actual_choice
+
+    def test_should_read_yes_no(self, mocker, bool_context):
+        key = 'is_alive'
+        expected_bool = False
+
+        read_bool = mocker.patch('cookiecutter.prompt.read_user_yes_no')
+        read_bool.return_value = expected_bool
+
+        config = prompt.prompt_for_config(
+            bool_context,
+            False  # Ask the user for input
+        )
+        read_bool.assert_called_once_with(key, 'True')
+        assert config[key] == expected_bool
+
+    def test_should_read_yes_no_false(self, mocker, bool_context):
+        key = 'is_alive'
+        expected_bool = True
+
+        read_bool = mocker.patch('cookiecutter.prompt.read_user_yes_no')
+        read_bool.return_value = expected_bool
+
+        bool_context['cookiecutter'][key] = False
+        config = prompt.prompt_for_config(
+            bool_context,
+            False  # Ask the user for input
+        )
+        read_bool.assert_called_once_with(key, 'False')
+        assert config[key] == expected_bool


### PR DESCRIPTION
If the default value of an entry in `cookiecutter.json` is a boolean then preserve further user input as boolean using read_user_yes_no.

For example, the json:

``` json
{
    "is_foo": true
}
```

would result in a prompt like

``` sh
is_foo [True]:
```

Then if a user input "false", "False", "n", etc it would result in a False value in python.

Fixes #126
