### PR TITLE
Increase flexibility of prompted options

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -68,7 +68,7 @@ def expand_abbreviations(template, config_dict):
 
 
 def cookiecutter(
-        template, checkout=None, no_input=False, extra_context=None,
+        template, checkout=None, no_input=False, bypass_options=(), extra_context=None,
         replay=False, overwrite_if_exists=False, output_dir='.',
         config_file=USER_CONFIG_PATH):
     """
@@ -131,7 +131,7 @@ def cookiecutter(
 
         # prompt the user to manually configure at the command line.
         # except when 'no-input' flag is set
-        context['cookiecutter'] = prompt_for_config(context, no_input)
+        context['cookiecutter'] = prompt_for_config(context, no_input, bypass_options)
 
         dump(config_dict['replay_dir'], template_name, context)
 

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -68,9 +68,9 @@ def expand_abbreviations(template, config_dict):
 
 
 def cookiecutter(
-        template, checkout=None, no_input=False, bypass_options=(), extra_context=None,
-        replay=False, overwrite_if_exists=False, output_dir='.',
-        config_file=USER_CONFIG_PATH):
+        template, checkout=None, no_input=False, bypass_options=(), 
+        extra_context=None, replay=False, overwrite_if_exists=False, 
+        output_dir='.', config_file=USER_CONFIG_PATH):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -131,7 +131,8 @@ def cookiecutter(
 
         # prompt the user to manually configure at the command line.
         # except when 'no-input' flag is set
-        context['cookiecutter'] = prompt_for_config(context, no_input, bypass_options)
+        context['cookiecutter'] = prompt_for_config(context, no_input, 
+                                                    bypass_options)
 
         dump(config_dict['replay_dir'], template_name, context)
 

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -68,8 +68,8 @@ def expand_abbreviations(template, config_dict):
 
 
 def cookiecutter(
-        template, checkout=None, no_input=False, bypass_options=(), 
-        extra_context=None, replay=False, overwrite_if_exists=False, 
+        template, checkout=None, no_input=False, bypass_options=(),
+        extra_context=None, replay=False, overwrite_if_exists=False,
         output_dir='.', config_file=USER_CONFIG_PATH):
     """
     API equivalent to using Cookiecutter at the command line.
@@ -131,8 +131,8 @@ def cookiecutter(
 
         # prompt the user to manually configure at the command line.
         # except when 'no-input' flag is set
-        context['cookiecutter'] = prompt_for_config(context, no_input, 
-                                                    bypass_options)
+        context['cookiecutter'] = prompt_for_config(context,
+                                  no_input, bypass_options)
 
         dump(config_dict['replay_dir'], template_name, context)
 

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -94,7 +94,7 @@ def render_variable(env, raw, cookiecutter_dict):
     return rendered_template
 
 
-def prompt_choice_for_config(cookiecutter_dict, env, key, options, no_input, bypass_options):
+def prompt_choice_for_config(cookiecutter_dict, env, key, options, no_input, bypass_options=()):
     """Prompt the user which option to choose from the given. Each of the
     possible choices is rendered beforehand.
     """
@@ -107,7 +107,7 @@ def prompt_choice_for_config(cookiecutter_dict, env, key, options, no_input, byp
     return read_user_choice(key, rendered_options)
 
 
-def prompt_for_config(context, no_input=False, bypass_options=None):
+def prompt_for_config(context, no_input=False, bypass_options=()):
     """
     Prompts the user to enter new config, using context as a source for the
     field names and sample values.
@@ -126,7 +126,7 @@ def prompt_for_config(context, no_input=False, bypass_options=None):
             if isinstance(raw, list):
                 # We are dealing with a choice variable
                 val = prompt_choice_for_config(
-                    cookiecutter_dict, env, key, raw, no_input
+                    cookiecutter_dict, env, key, raw, no_input, bypass_options
                 )
             else:
                 # We are dealing with a regular variable

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -94,7 +94,7 @@ def render_variable(env, raw, cookiecutter_dict):
     return rendered_template
 
 
-def prompt_choice_for_config(cookiecutter_dict, env, key, options, 
+def prompt_choice_for_config(cookiecutter_dict, env, key, options,
                              no_input, bypass_options=()):
     """Prompt the user which option to choose from the given. Each of the
     possible choices is rendered beforehand.
@@ -114,7 +114,7 @@ def prompt_for_config(context, no_input=False, bypass_options=()):
     field names and sample values.
 
     :param no_input: Prompt the user at command line for manual configuration?
-    :param bypass_options: Options to be bypassed at the prompy whe no_input=False
+    :param bypass_options: Options not to be prompted when no_input=False.
     """
     cookiecutter_dict = {}
     env = StrictEnvironment(context=context)
@@ -128,7 +128,7 @@ def prompt_for_config(context, no_input=False, bypass_options=()):
             if isinstance(raw, list):
                 # We are dealing with a choice variable
                 val = prompt_choice_for_config(
-                    cookiecutter_dict, env, key, raw, 
+                    cookiecutter_dict, env, key, raw,
                     no_input, bypass_options
                 )
             else:

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -94,7 +94,7 @@ def render_variable(env, raw, cookiecutter_dict):
     return rendered_template
 
 
-def prompt_choice_for_config(cookiecutter_dict, env, key, options, no_input):
+def prompt_choice_for_config(cookiecutter_dict, env, key, options, no_input, bypass_options):
     """Prompt the user which option to choose from the given. Each of the
     possible choices is rendered beforehand.
     """
@@ -102,12 +102,12 @@ def prompt_choice_for_config(cookiecutter_dict, env, key, options, no_input):
         render_variable(env, raw, cookiecutter_dict) for raw in options
     ]
 
-    if no_input:
+    if no_input or key in bypass_options:
         return rendered_options[0]
     return read_user_choice(key, rendered_options)
 
 
-def prompt_for_config(context, no_input=False):
+def prompt_for_config(context, no_input=False, bypass_options=None):
     """
     Prompts the user to enter new config, using context as a source for the
     field names and sample values.
@@ -132,7 +132,7 @@ def prompt_for_config(context, no_input=False):
                 # We are dealing with a regular variable
                 val = render_variable(env, raw, cookiecutter_dict)
 
-                if not no_input:
+                if not no_input and key not in bypass_options:
                     val = read_user_variable(key, val)
         except UndefinedError as err:
             msg = "Unable to render variable '{}'".format(key)

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -94,7 +94,8 @@ def render_variable(env, raw, cookiecutter_dict):
     return rendered_template
 
 
-def prompt_choice_for_config(cookiecutter_dict, env, key, options, no_input, bypass_options=()):
+def prompt_choice_for_config(cookiecutter_dict, env, key, options, 
+                             no_input, bypass_options=()):
     """Prompt the user which option to choose from the given. Each of the
     possible choices is rendered beforehand.
     """
@@ -113,6 +114,7 @@ def prompt_for_config(context, no_input=False, bypass_options=()):
     field names and sample values.
 
     :param no_input: Prompt the user at command line for manual configuration?
+    :param bypass_options: Options to be bypassed at the prompy whe no_input=False
     """
     cookiecutter_dict = {}
     env = StrictEnvironment(context=context)
@@ -126,7 +128,8 @@ def prompt_for_config(context, no_input=False, bypass_options=()):
             if isinstance(raw, list):
                 # We are dealing with a choice variable
                 val = prompt_choice_for_config(
-                    cookiecutter_dict, env, key, raw, no_input, bypass_options
+                    cookiecutter_dict, env, key, raw, 
+                    no_input, bypass_options
                 )
             else:
                 # We are dealing with a regular variable


### PR DESCRIPTION
This adds a list of options to be bypassed so that some options can be bypassed even with no_input=False. This adds flexibility when triggering a cookiecutter project in a post_gen hook of another cookiecutter project. 

Currently, the no_input parameter controls whether the user will be prompted for all or none of the options. This PR makes it so the user can be prompted for another percentage of the options.
