### PR TITLE
Add support for --context-file flag

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -89,8 +89,13 @@ def validate_extra_context(ctx, param, value):
     u'--default-config', is_flag=True,
     help=u'Do not load a config file. Use the defaults instead'
 )
+@click.option(
+    u'--context-file',
+    help=u'Override cookiecutter.json with a user defined json file',
+)
 def main(template, extra_context, no_input, checkout, verbose, replay,
-         overwrite_if_exists, output_dir, config_file, default_config):
+         overwrite_if_exists, output_dir, config_file, default_config,
+         context_file):
     """Create a project from a Cookiecutter project template (TEMPLATE)."""
     if verbose:
         logging.basicConfig(
@@ -115,6 +120,7 @@ def main(template, extra_context, no_input, checkout, verbose, replay,
 
         cookiecutter(
             template, checkout, no_input,
+            context_file=context_file,
             extra_context=extra_context,
             replay=replay,
             overwrite_if_exists=overwrite_if_exists,

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def cookiecutter(
         template, checkout=None, no_input=False, extra_context=None,
         replay=False, overwrite_if_exists=False, output_dir='.',
-        config_file=USER_CONFIG_PATH):
+        config_file=USER_CONFIG_PATH, context_file=None):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -35,6 +35,8 @@ def cookiecutter(
         or a URL to a git repository.
     :param checkout: The branch, tag or commit ID to checkout after clone.
     :param no_input: Prompt the user at command line for manual configuration?
+    :param context_file: Alternative context file, instead of the template's
+        cookiecutter.json
     :param extra_context: A dictionary of context that overrides default
         and user configuration.
     :param: overwrite_if_exists: Overwrite the contents of output directory
@@ -66,7 +68,8 @@ def cookiecutter(
     if replay:
         context = load(config_dict['replay_dir'], template_name)
     else:
-        context_file = os.path.join(repo_dir, 'cookiecutter.json')
+        context_file = context_file or os.path.join(repo_dir,
+                                                    'cookiecutter.json')
         logging.debug('context_file is {0}'.format(context_file))
 
         context = generate_context(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,6 +95,7 @@ def test_cli_replay(mocker, cli_runner):
         overwrite_if_exists=False,
         output_dir='.',
         config_file=config.USER_CONFIG_PATH,
+        context_file=None,
         extra_context=None
     )
 
@@ -126,6 +127,7 @@ def test_cli_exit_on_noinput_and_replay(mocker, cli_runner):
         overwrite_if_exists=False,
         output_dir='.',
         config_file=config.USER_CONFIG_PATH,
+        context_file=None,
         extra_context=None
     )
 
@@ -156,6 +158,7 @@ def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
         overwrite_if_exists=True,
         output_dir='.',
         config_file=config.USER_CONFIG_PATH,
+        context_file=None,
         extra_context=None
     )
 
@@ -214,6 +217,7 @@ def test_cli_output_dir(mocker, cli_runner, output_dir_flag, output_dir):
         overwrite_if_exists=False,
         output_dir=output_dir,
         config_file=config.USER_CONFIG_PATH,
+        context_file=None,
         extra_context=None
     )
 
@@ -251,6 +255,7 @@ def test_user_config(mocker, cli_runner, user_config_path):
         overwrite_if_exists=False,
         output_dir='.',
         config_file=user_config_path,
+        context_file=None,
         extra_context=None
     )
 
@@ -277,6 +282,7 @@ def test_default_user_config_overwrite(mocker, cli_runner, user_config_path):
         overwrite_if_exists=False,
         output_dir='.',
         config_file=None,
+        context_file=None,
         extra_context=None
     )
 
@@ -298,6 +304,7 @@ def test_default_user_config(mocker, cli_runner):
         overwrite_if_exists=False,
         output_dir='.',
         config_file=None,
+        context_file=None,
         extra_context=None
     )
 
@@ -374,3 +381,26 @@ def test_cli_extra_context_invalid_format(cli_runner):
     assert result.exit_code == 2
     assert 'Error: Invalid value for "extra_context"' in result.output
     assert 'should contain items of the form key=value' in result.output
+
+
+@pytest.mark.usefixtures('remove_fake_project_dir')
+def test_cli_context_file(mocker, cli_runner):
+    mock_cookiecutter = mocker.patch(
+        'cookiecutter.cli.cookiecutter'
+    )
+
+    template_path = 'tests/fake-repo-pre/'
+    result = cli_runner(template_path, '--context-file', 'xxx')
+
+    assert result.exit_code == 0
+    mock_cookiecutter.assert_called_once_with(
+        template_path,
+        None,
+        False,
+        replay=False,
+        overwrite_if_exists=False,
+        output_dir='.',
+        config_file=config.USER_CONFIG_PATH,
+        context_file='xxx',
+        extra_context=None
+    )


### PR DESCRIPTION
http://stackoverflow.com/q/39143409/647991

We have the file `cookiecutter.json`, which defines the default context for a template. I would like to specify, via a command flag, something like:

```
cookiecutter --no-input --context-file cookiecutter.json <cookiecutter-template>
```

So that the same template can be used to generate different projects, without having to enter the data manually on the input prompts. There is a workaround to achieve this:
1. clone the template repo locally
2. modify the `cookiecutter.json` in the template repo
3. specify as template the local clone, and not the github clone

This is less than ideal, because it requires modifying a repository, does not allow for independent storage of the context files, and does not allow to use the same template to easily create different projects.

Is there a way to specify the context to cookiecutter, on the command line?
