### PR TITLE
Added: Path templates will be rendered when copy_without_render used

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -323,6 +323,7 @@ def generate_files(
             for copy_dir in copy_dirs:
                 indir = os.path.normpath(os.path.join(root, copy_dir))
                 outdir = os.path.normpath(os.path.join(project_dir, indir))
+                outdir = env.from_string(outdir).render(**context)
                 logger.debug('Copying dir %s to %s without rendering', indir, outdir)
                 shutil.copytree(indir, outdir)
 

--- a/docs/advanced/copy_without_render.rst
+++ b/docs/advanced/copy_without_render.rst
@@ -15,3 +15,14 @@ To avoid rendering directories and files of a cookiecutter, the `_copy_without_r
             "rendered_dir/not_rendered_file.ini"
         ]
     }
+
+**Note**: Only the content of the files will be copied without being rendered. The paths are subject to rendering. This allows you to write::
+
+    {
+        "project_slug": "sample",
+        "_copy_without_render": [
+            "{{cookiecutter.repo_name}}/templates/*.html",
+        ]
+    }
+
+In this example, `{{cookiecutter.repo_name}}` will be rendered as expected but the html file content will be copied without rendering.

--- a/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.md
+++ b/tests/test-generate-copy-without-render/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.md
@@ -1,0 +1,3 @@
+# Fake Project
+
+{{cookiecutter.render_test}}

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -31,6 +31,7 @@ def test_generate_copy_without_render_extensions():
                     '*not-rendered',
                     'rendered/not_rendered.yml',
                     '*.txt',
+                    '{{cookiecutter.repo_name}}-rendered/README.md',
                 ],
             }
         },
@@ -39,7 +40,7 @@ def test_generate_copy_without_render_extensions():
 
     dir_contents = os.listdir('test_copy_without_render')
 
-    assert '{{cookiecutter.repo_name}}-not-rendered' in dir_contents
+    assert 'test_copy_without_render-not-rendered' in dir_contents
     assert 'test_copy_without_render-rendered' in dir_contents
 
     with open('test_copy_without_render/README.txt') as f:
@@ -59,9 +60,16 @@ def test_generate_copy_without_render_extensions():
         assert 'I have been rendered' in f.read()
 
     with open(
-        'test_copy_without_render/{{cookiecutter.repo_name}}-not-rendered/README.rst'
+        'test_copy_without_render/'
+        'test_copy_without_render-not-rendered/'
+        'README.rst'
     ) as f:
         assert '{{cookiecutter.render_test}}' in f.read()
 
     with open('test_copy_without_render/rendered/not_rendered.yml') as f:
+        assert '{{cookiecutter.render_test}}' in f.read()
+
+    with open(
+        'test_copy_without_render/' 'test_copy_without_render-rendered/' 'README.md'
+    ) as f:
         assert '{{cookiecutter.render_test}}' in f.read()


### PR DESCRIPTION
This pull-request ensures paths variables are rendered when using `_copy_without_render`.

It should fix #456.

It does not keep the existing behavior as it was inconsistent, different for files and directories (matched files had their path rendered but not the matched directories).
If this behavior should be kept, I'll update this pull-request with a boolean option like `_copy_without_render_paths`.
