### PR TITLE
New context format

### DIFF
--- a/cookiecutter/context.py
+++ b/cookiecutter/context.py
@@ -183,19 +183,19 @@ class Variable(object):
 
 
 class CookiecutterTemplate(object):
-    def __init__(self, name, description, variables, **info):
+    def __init__(self, name, variables, **info):
         # mandatory fields
         self.name = name
-        self.description = description
         self.variables = [Variable(**v) for v in variables]
 
         # optional fields
         self.authors = info.get('authors', [])
         self.cookiecutter_version = info.get('cookiecutter_version', None)
+        self.description = info.get('description', None)
         self.keywords = info.get('keywords', [])
         self.license = info.get('license', None)
-        self.version = info.get('version', None)
         self.url = info.get('url', None)
+        self.version = info.get('version', None)
 
     def __repr__(self):
         return "<{class_name} {template_name}>".format(

--- a/cookiecutter/context.py
+++ b/cookiecutter/context.py
@@ -23,6 +23,7 @@ def prompt_string(variable, default):
     return click.prompt(
         variable.prompt,
         default=default,
+        hide_input=variable.hide_input,
         type=click.STRING,
     )
 
@@ -31,6 +32,7 @@ def prompt_boolean(variable, default):
     return click.prompt(
         variable.prompt,
         default=default,
+        hide_input=variable.hide_input,
         type=click.BOOL,
     )
 
@@ -39,6 +41,7 @@ def prompt_int(variable, default):
     return click.prompt(
         variable.prompt,
         default=default,
+        hide_input=variable.hide_input,
         type=click.INT,
     )
 
@@ -63,6 +66,7 @@ def prompt_json(variable, default):
     return click.prompt(
         variable.prompt,
         default=DEFAULT_JSON,
+        hide_input=variable.hide_input,
         type=click.STRING,
         value_proc=process_json,
     )
@@ -77,6 +81,7 @@ def prompt_yes_no(variable, default):
     return click.prompt(
         variable.prompt,
         default=default_display,
+        hide_input=variable.hide_input,
         type=click.BOOL,
     )
 
@@ -98,10 +103,12 @@ def prompt_choice(variable, default):
 
     user_choice = click.prompt(
         prompt,
-        type=click.Choice(choices),
         default=default,
+        hide_input=variable.hide_input,
+        type=click.Choice(choices),
     )
     return choice_map[user_choice]
+
 
 PROMPTS = {
     'string': prompt_string,
@@ -151,6 +158,7 @@ class Variable(object):
         # optional fields
         self.description = info.get('description', None)
         self.prompt = info.get('prompt', DEFAULT_PROMPT.format(variable=self))
+        self.hide_input = info.get('hide_input', False)
 
         self.var_type = info.get('type', 'string')
         if self.var_type not in VALID_TYPES:

--- a/cookiecutter/context.py
+++ b/cookiecutter/context.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+
+import codecs
+import collections
+import json
+import pprint
+
+import click
+from jinja2 import Environment
+
+DEFAULT_PROMPT = 'Please enter a value for "{variable.name}"'
+
+VALID_TYPES = [
+    'boolean',
+    'yes_no',
+    'int',
+    'json',
+    'string',
+]
+
+
+def prompt_string(variable, default):
+    return click.prompt(
+        variable.prompt,
+        default=default,
+        type=click.STRING,
+    )
+
+
+def prompt_boolean(variable, default):
+    return click.prompt(
+        variable.prompt,
+        default=default,
+        type=click.BOOL,
+    )
+
+
+def prompt_int(variable, default):
+    return click.prompt(
+        variable.prompt,
+        default=default,
+        type=click.INT,
+    )
+
+
+def prompt_json(variable, default):
+    user_value = click.prompt(
+        variable.prompt,
+        default='default',
+        type=click.STRING,
+    )
+    if user_value == 'default':
+        return default
+
+    return json.loads(
+        user_value,
+        object_pairs_hook=collections.OrderedDict,
+    )
+
+
+def prompt_yes_no(variable, default):
+    if default is True:
+        default_display = 'y'
+    else:
+        default_display = 'n'
+
+    return click.prompt(
+        variable.prompt,
+        default=default_display,
+        type=click.BOOL,
+    )
+
+
+def prompt_choice(variable, default):
+    """Returns prompt, default and callback for a choice variable"""
+    choice_map = collections.OrderedDict(
+        (u'{}'.format(i), value)
+        for i, value in enumerate(variable.choices, 1)
+    )
+    choices = choice_map.keys()
+
+    prompt = u'\n'.join((
+        variable.prompt,
+        u'\n'.join([u'{} - {}'.format(*c) for c in choice_map.items()]),
+        u'Choose from {}'.format(u', '.join(choices)),
+    ))
+    default = str(variable.choices.index(default) + 1)
+
+    user_choice = click.prompt(
+        prompt,
+        type=click.Choice(choices),
+        default=default,
+    )
+    return choice_map[user_choice]
+
+PROMPTS = {
+    'string': prompt_string,
+    'boolean': prompt_boolean,
+    'int': prompt_int,
+    'json': prompt_json,
+    'yes_no': prompt_yes_no,
+}
+
+
+def deserialize_string(value):
+    return str(value)
+
+
+def deserialize_boolean(value):
+    return bool(value)
+
+
+def deserialize_yes_no(value):
+    return bool(value)
+
+
+def deserialize_int(value):
+    return int(value)
+
+
+def deserialize_json(value):
+    return value
+
+
+DESERIALIZERS = {
+    'string': deserialize_string,
+    'boolean': deserialize_boolean,
+    'int': deserialize_int,
+    'json': deserialize_json,
+    'yes_no': deserialize_yes_no,
+}
+
+
+class Variable(object):
+    def __init__(self, name, default, **info):
+
+        # mandatory fields
+        self.name = name
+        self.default = default
+
+        # optional fields
+        self.description = info.get('description', None)
+        self.prompt = info.get('prompt', DEFAULT_PROMPT.format(variable=self))
+
+        self.var_type = info.get('type', 'string')
+        if self.var_type not in VALID_TYPES:
+            msg = 'Invalid type {var_type} for variable'
+            raise ValueError(msg.format(var_type=self.var_type))
+
+        self.skip_if = info.get('skip_if', '')
+        if not isinstance(self.skip_if, str):
+            # skip_if was specified in cookiecutter.json
+            msg = 'Field skip_if is required to be a str, got {value}'
+            raise ValueError(msg.format(value=self.skip_if))
+
+        self.prompt_user = info.get('prompt_user', True)
+        if not isinstance(self.prompt_user, bool):
+            # prompt_user was specified in cookiecutter.json
+            msg = 'Field prompt_user is required to be a bool, got {value}'
+            raise ValueError(msg.format(value=self.prompt_user))
+
+        # choices are somewhat special as they can of every type
+        self.choices = info.get('choices', [])
+        if self.choices and default not in self.choices:
+            msg = 'Invalid default value {default} for choice variable'
+            raise ValueError(msg.format(default=self.default))
+
+    def __repr__(self):
+        return "<{class_name} {variable_name}>".format(
+            class_name=self.__class__.__name__,
+            variable_name=self.name,
+        )
+
+
+class CookiecutterTemplate(object):
+    def __init__(self, name, description, variables, **info):
+        # mandatory fields
+        self.name = name
+        self.description = description
+        self.variables = [Variable(**v) for v in variables]
+
+        # optional fields
+        self.authors = info.get('authors', [])
+        self.cookiecutter_version = info.get('cookiecutter_version', None)
+        self.keywords = info.get('keywords', [])
+        self.license = info.get('license', None)
+        self.version = info.get('version', None)
+        self.url = info.get('url', None)
+
+    def __repr__(self):
+        return "<{class_name} {template_name}>".format(
+            class_name=self.__class__.__name__,
+            template_name=self.name,
+        )
+
+    def __iter__(self):
+        for v in self.variables:
+            yield v
+
+
+def load_context(json_object, verbose):
+    env = Environment(extensions=['jinja2_time.TimeExtension'])
+    context = collections.OrderedDict({})
+
+    for variable in CookiecutterTemplate(**json_object):
+        if variable.skip_if:
+            skip_template = env.from_string(variable.skip_if)
+            if skip_template.render(cookiecutter=context) == 'True':
+                continue
+
+        default = variable.default
+
+        if isinstance(default, str):
+            template = env.from_string(default)
+            default = template.render(cookiecutter=context)
+
+        deserialize = DESERIALIZERS[variable.var_type]
+
+        if not variable.prompt_user:
+            context[variable.name] = deserialize(default)
+            continue
+
+        if variable.choices:
+            prompt = prompt_choice
+        else:
+            prompt = PROMPTS[variable.var_type]
+
+        if verbose and variable.description:
+            click.echo(variable.description)
+
+        value = prompt(variable, default)
+
+        if verbose:
+            width, _ = click.get_terminal_size()
+            click.echo('-' * width)
+
+        context[variable.name] = deserialize(value)
+
+    return context
+
+
+def main(file_path):
+    """Load the json object and prompt the user for input"""
+
+    with codecs.open(file_path, 'r', encoding='utf8') as f:
+        json_object = json.load(f, object_pairs_hook=collections.OrderedDict)
+
+    pprint.pprint(load_context(json_object, True))
+
+if __name__ == '__main__':
+    main('tests/new-context/cookiecutter.json')

--- a/cookiecutter/context.py
+++ b/cookiecutter/context.py
@@ -183,14 +183,14 @@ class Variable(object):
 
 
 class CookiecutterTemplate(object):
-    def __init__(self, name, variables, **info):
+    def __init__(self, name, cookiecutter_version, variables, **info):
         # mandatory fields
         self.name = name
+        self.cookiecutter_version = cookiecutter_version
         self.variables = [Variable(**v) for v in variables]
 
         # optional fields
         self.authors = info.get('authors', [])
-        self.cookiecutter_version = info.get('cookiecutter_version', None)
         self.description = info.get('description', None)
         self.keywords = info.get('keywords', [])
         self.license = info.get('license', None)

--- a/cookiecutter/context.py
+++ b/cookiecutter/context.py
@@ -44,17 +44,27 @@ def prompt_int(variable, default):
 
 
 def prompt_json(variable, default):
-    user_value = click.prompt(
-        variable.prompt,
-        default='default',
-        type=click.STRING,
-    )
-    if user_value == 'default':
-        return default
+    # The JSON object from cookiecutter.json might be very large
+    # We only show 'default'
+    DEFAULT_JSON = 'default'
 
-    return json.loads(
-        user_value,
-        object_pairs_hook=collections.OrderedDict,
+    def process_json(user_value):
+        if user_value == DEFAULT_JSON:
+            # Return the given default w/o any processing
+            return default
+
+        try:
+            hook = collections.OrderedDict
+            return json.loads(user_value, object_pairs_hook=hook)
+        except json.decoder.JSONDecodeError:
+            # Leave it up to click to ask the user again
+            raise click.UsageError('Unable to decode to JSON.')
+
+    return click.prompt(
+        variable.prompt,
+        default=DEFAULT_JSON,
+        type=click.STRING,
+        value_proc=process_json,
     )
 
 

--- a/cookiecutter/context.py
+++ b/cookiecutter/context.py
@@ -52,24 +52,27 @@ def prompt_json(variable, default):
     DEFAULT_JSON = 'default'
 
     def process_json(user_value):
-        if user_value == DEFAULT_JSON:
-            # Return the given default w/o any processing
-            return default
-
         try:
-            hook = collections.OrderedDict
-            return json.loads(user_value, object_pairs_hook=hook)
+            return json.loads(
+                user_value,
+                object_pairs_hook=collections.OrderedDict,
+            )
         except json.decoder.JSONDecodeError:
             # Leave it up to click to ask the user again
             raise click.UsageError('Unable to decode to JSON.')
 
-    return click.prompt(
+    dict_value = click.prompt(
         variable.prompt,
         default=DEFAULT_JSON,
         hide_input=variable.hide_input,
         type=click.STRING,
         value_proc=process_json,
     )
+
+    if dict_value == DEFAULT_JSON:
+        # Return the given default w/o any processing
+        return default
+    return dict_value
 
 
 def prompt_yes_no(variable, default):

--- a/tests/new-context/cookiecutter.json
+++ b/tests/new-context/cookiecutter.json
@@ -1,0 +1,102 @@
+{
+    "name": "cookiecutter-pytest-plugin",
+    "version": "0.1.0",
+    "description": "a cookiecutter to create pytest plugins with ease.",
+    "authors": [
+        "Raphael Pierzina <raphael@hackebrot.de>",
+        "Audrey Roy Greenfeld <aroy@alum.mit.edu>"
+    ],
+    "cookiecutter_version": "2.0.0",
+    "license": "MIT",
+    "keywords": [
+        "pytest",
+        "python",
+        "plugin"
+    ],
+    "url": "https://github.com/pytest-dev/cookiecutter-pytest-plugin",
+    "variables": [
+        {
+            "name": "full_name",
+            "default": "Raphael Pierzina",
+            "prompt": "What's your full name?",
+            "description": "Please enter your full name. It will be displayed on the README file and used for the PyPI package definition.",
+            "type": "string"
+        },
+        {
+            "name": "email",
+            "default": "raphael@hackebrot.de",
+            "prompt": "What's your email?",
+            "description": "Please enter an email address for the meta information in setup.py.",
+            "type": "string"
+        },
+        {
+            "name": "plugin_name",
+            "default": "emoji",
+            "prompt": "What should be the name for your plugin?",
+            "description": "Please enter a name for your plugin. We will prepend the name with 'pytest-'",
+            "type": "string"
+        },
+        {
+            "name": "module_name",
+            "default": "{{cookiecutter.plugin_name|lower|replace('-','_')}}",
+            "prompt": "Please enter a name for your base python module",
+            "type": "string",
+            "validation": "^[a-z_]+$"
+        },
+        {
+            "name": "license",
+            "default": "MIT",
+            "prompt": "Please choose a license!",
+            "description": "Cookiecutter will add an according LICENSE file for you and set the according classifier in setup.py.",
+            "type": "string",
+            "choices": [
+                "MIT",
+                "BSD-3",
+                "GNU GPL v3.0",
+                "Apache Software License 2.0",
+                "Mozilla Public License 2.0"
+            ]
+        },
+        {
+            "name": "docs",
+            "default": true,
+            "prompt": "Do you want to generate a base for docs?",
+            "description": "Would you like to generate documentation for your plugin? You will be able to choose from a number of generators.",
+            "type": "yes_no"
+        },
+        {
+            "name": "docs_tool",
+            "default": "mkdocs",
+            "prompt": "Which tool do you want to choose for generating docs?",
+            "description": "There are a number of options for documentation generators. Please choose one. We will create a separate folder for you",
+            "type": "string",
+            "choices": [
+                "mkdocs",
+                "sphinx"
+            ],
+            "skip_if": "{{cookiecutter.docs == False}}"
+        },
+        {
+            "name": "year",
+            "default": "{% now 'utc', '%Y' %}",
+            "prompt_user": false,
+            "type": "string"
+        },
+        {
+            "name": "fixtures",
+            "default": {
+                "foo": {
+                    "scope": "session",
+                    "autouse": true
+                },
+                "bar": {
+                    "scope": "function",
+                    "autouse": false
+                }
+            },
+            "description": "Please enter a valid JSON string to set up fixtures for your plugin.",
+            "prompt_user": true,
+            "type": "json"
+        }
+    ]
+}

--- a/tests/new-context/cookiecutter.json
+++ b/tests/new-context/cookiecutter.json
@@ -30,6 +30,13 @@
             "type": "string"
         },
         {
+            "name": "secret_token",
+            "default": null,
+            "prompt": "Please enter your secret token",
+            "type": "string",
+            "hide_input": true
+        },
+        {
             "name": "plugin_name",
             "default": "emoji",
             "prompt": "What should be the name for your plugin?",

--- a/tests/new-context/cookiecutter.json
+++ b/tests/new-context/cookiecutter.json
@@ -14,6 +14,11 @@
         "plugin"
     ],
     "url": "https://github.com/pytest-dev/cookiecutter-pytest-plugin",
+    "environment_settings": {
+        "keep_trailing_newline": true,
+        "comment_start_string": "{##",
+        "comment_end_string": "##}"
+    },
     "variables": [
         {
             "name": "full_name",


### PR DESCRIPTION
This is a proof-of-concept implementation for loading a new format for **cookiecutter.json** 😄 

There are a number of features missing from this, but it should be sufficient to allow feedback on the specification. You can run the example via ``$ python cookiecutter/context.py``. Nothing will be generated, but the prompting is done (hardcoded to *verbose*) and the resulting context as an OrderedDict is pprinted.

@audreyr @pydanny @michaeljoseph 👋 

Please let me know your thoughts and I'll happily make changes to the spec.
