### PR TITLE
First cut at issue 35: single file templates

### DIFF
--- a/cookiecutter/exceptions.py
+++ b/cookiecutter/exceptions.py
@@ -75,6 +75,14 @@ class OutputDirExistsException(CookiecutterException):
     """
 
 
+class OutputFileExistsException(CookiecutterException):
+    """
+    Raised when a template file exists already. For example when using _target.
+    """
+    def __init__(self, name):
+        self.name = name
+
+
 class InvalidModeException(CookiecutterException):
     """
     Raised when cookiecutter is called with both `no_input==True` and

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -221,7 +221,7 @@ def render_and_create_dir(dirname, context, output_dir, environment,
         if output_dir_exists:
             msg = 'Error: "{}" directory already exists'.format(dir_to_create)
             raise OutputDirExistsException(msg)
-    else: #pragma: no cover
+    else:  # pragma: no cover
         # This code is unreachable
         raise ValueError(exists_action)
 

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -221,7 +221,8 @@ def render_and_create_dir(dirname, context, output_dir, environment,
         if output_dir_exists:
             msg = 'Error: "{}" directory already exists'.format(dir_to_create)
             raise OutputDirExistsException(msg)
-    else:
+    else: #pragma: no cover
+        # This code is unreachable
         raise ValueError(exists_action)
 
     make_sure_path_exists(dir_to_create)

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -29,6 +29,7 @@ from .hooks import run_hook
 
 logger = logging.getLogger(__name__)
 
+
 class ExistsAction(object):
     LEAVE = 'exists'
     OVERWRITE = 'overwrite'
@@ -121,7 +122,7 @@ def generate_context(context_file='cookiecutter.json', default_context=None,
 
 
 def generate_file(project_dir, infile, context, env,
-        overwrite_if_exists=False):
+                  overwrite_if_exists=False):
     """Render filename of infile as name of outfile, handle infile correctly.
 
     Dealing with infile appropriately:
@@ -222,7 +223,6 @@ def render_and_create_dir(dirname, context, output_dir, environment,
             raise OutputDirExistsException(msg)
     else:
         raise ValueError(exists_action)
-
 
     make_sure_path_exists(dir_to_create)
     return dir_to_create
@@ -379,7 +379,12 @@ def generate_files(repo_dir, context=None, output_dir='.',
                         shutil.copymode(infile, outfile)
                     continue
                 try:
-                    generate_file(project_dir, infile, context, env, overwrite_if_exists)
+                    generate_file(
+                        project_dir,
+                        infile,
+                        context,
+                        env,
+                        overwrite_if_exists)
                 except UndefinedError as err:
                     # Don't delete pre-existing directories
                     if not target_dir:

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -31,7 +31,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExistsAction(object):
-    LEAVE = 'exists'
+    "Enum of actions to carry out if a file exists"
+    LEAVE = 'leave'
     OVERWRITE = 'overwrite'
     ERROR = 'error'
 

--- a/docs/advanced/index.rst
+++ b/docs/advanced/index.rst
@@ -20,3 +20,4 @@ Various advanced topics regarding cookiecutter usage.
    choice_variables
    dict_variables
    template_extensions
+   single_file_templates

--- a/docs/advanced/single_file_templates.rst
+++ b/docs/advanced/single_file_templates.rst
@@ -1,6 +1,6 @@
 .. _single-file-templates:
 
-Single file templates
+Single File Templates
 ---------------------
 
 *New in dev master*

--- a/docs/advanced/single_file_templates.rst
+++ b/docs/advanced/single_file_templates.rst
@@ -17,5 +17,5 @@ current directory::
         "_target": ".",
     }
 
-A directory of the form `{{cookiecutter.<X>}}` must be created to keep the
-templates, but its value is ignored.
+A top-level directory of the form `{{cookiecutter.<X>}}` must be created to keep the
+templates and files as for standard-templates, but its name is ignored.

--- a/docs/advanced/single_file_templates.rst
+++ b/docs/advanced/single_file_templates.rst
@@ -1,0 +1,21 @@
+.. _single-file-templates:
+
+Single file templates
+---------------------
+
+*New in dev master*
+
+Sometimes you want to create individual files within a repository, rather than
+creating a complete project. This can be achieved with the `_target` key,
+which specifies which directory template files should be placed in.
+
+For example, the following places all files in the template into the
+current directory.::
+
+    {
+        "project_slug": "sample",
+        "_target": ".",
+    }
+
+A directory of the form `{{cookiecutter.<X>}}` must be created to keep the
+templates, but its value is ignored.

--- a/docs/advanced/single_file_templates.rst
+++ b/docs/advanced/single_file_templates.rst
@@ -10,7 +10,7 @@ creating a complete project. This can be achieved with the `_target` key,
 which specifies which directory template files should be placed in.
 
 For example, the following places all files in the template into the
-current directory.::
+current directory::
 
     {
         "project_slug": "sample",

--- a/tests/test_generate_file.py
+++ b/tests/test_generate_file.py
@@ -114,7 +114,8 @@ def test_generate_file_verbose_template_syntax_error(env, expected_msg):
             project_dir=".",
             infile='tests/files/syntax_error.txt',
             context={'syntax_error': 'syntax_error'},
-            env=env
+            env=env,
+            overwrite_if_exists=True
         )
     except TemplateSyntaxError as exception:
         assert str(exception) == expected_msg

--- a/tests/test_generate_files.py
+++ b/tests/test_generate_files.py
@@ -147,6 +147,7 @@ def test_generate_files_output_dir():
     )
     assert os.path.isfile('tests/custom_output_dir/inputpizzä/simple.txt')
 
+
 @pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
 def test_generate_files_target_dir():
     os.mkdir('tests/custom_output_dir')
@@ -160,15 +161,16 @@ def test_generate_files_target_dir():
     assert os.path.isfile('tests/custom_output_dir/target/simple.txt')
     assert not os.path.isfile('tests/custom_output_dir/inputpizzä/simple.txt')
 
+
 @pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
-def test_generate_files_target_dir_overwrite():
+def test_generate_files_target_dir_no_overwrite():
     os.mkdir('tests/custom_output_dir')
     os.mkdir('tests/custom_output_dir/target')
 
-    with open('tests/custom_output_dir/target/bystander.txt' , 'w'):
-       pass
+    with open('tests/custom_output_dir/target/bystander.txt', 'w'):
+        pass
 
-    with open('tests/custom_output_dir/target/simple.txt' , 'w'):
+    with open('tests/custom_output_dir/target/simple.txt', 'w'):
         pass
 
     with pytest.raises(exceptions.OutputFileExistsException):
@@ -188,10 +190,10 @@ def test_generate_files_target_dir_overwrite():
     os.mkdir('tests/custom_output_dir')
     os.mkdir('tests/custom_output_dir/target')
 
-    with open('tests/custom_output_dir/target/bystander.txt' , 'w'):
-       pass
+    with open('tests/custom_output_dir/target/bystander.txt', 'w'):
+        pass
 
-    with open('tests/custom_output_dir/target/simple.txt' , 'w'):
+    with open('tests/custom_output_dir/target/simple.txt', 'w'):
         pass
 
     generate.generate_files(
@@ -209,12 +211,13 @@ def test_generate_files_target_dir_overwrite():
     with open('tests/custom_output_dir/target/simple.txt') as stream:
         assert stream.read() != ''
 
+
 @pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
 def test_generate_files_target_preexisting():
     os.mkdir('tests/custom_output_dir')
     os.mkdir('tests/custom_output_dir/target')
 
-    with open('tests/custom_output_dir/target/bystander.txt' , 'w'):
+    with open('tests/custom_output_dir/target/bystander.txt', 'w'):
         pass
 
     generate.generate_files(
@@ -235,7 +238,7 @@ def test_generate_files_preexisting():
     os.mkdir('tests/custom_output_dir')
     os.mkdir('tests/custom_output_dir/target')
 
-    with open('tests/custom_output_dir/target/bystander.txt' , 'w') as pre_stream:
+    with open('tests/custom_output_dir/target/bystander.txt', 'w'):
         pass
 
     generate.generate_files(
@@ -248,7 +251,8 @@ def test_generate_files_preexisting():
     )
 
     assert os.path.isfile('tests/custom_output_dir/inputpizzä/simple.txt')
-    assert not os.path.isfile('tests/custom_output_dir/inputpizzä/bystander.txt')
+    assert not os.path.isfile(
+        'tests/custom_output_dir/inputpizzä/bystander.txt')
 
 
 @pytest.mark.usefixtures('clean_system', 'remove_additional_folders')

--- a/tests/test_generate_files.py
+++ b/tests/test_generate_files.py
@@ -147,6 +147,109 @@ def test_generate_files_output_dir():
     )
     assert os.path.isfile('tests/custom_output_dir/inputpizzä/simple.txt')
 
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_generate_files_target_dir():
+    os.mkdir('tests/custom_output_dir')
+    generate.generate_files(
+        context={
+            'cookiecutter': {'food': 'pizzä', '_target': 'target'}
+        },
+        repo_dir=os.path.abspath('tests/test-generate-files'),
+        output_dir='tests/custom_output_dir'
+    )
+    assert os.path.isfile('tests/custom_output_dir/target/simple.txt')
+    assert not os.path.isfile('tests/custom_output_dir/inputpizzä/simple.txt')
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_generate_files_target_dir_overwrite():
+    os.mkdir('tests/custom_output_dir')
+    os.mkdir('tests/custom_output_dir/target')
+
+    with open('tests/custom_output_dir/target/bystander.txt' , 'w'):
+       pass
+
+    with open('tests/custom_output_dir/target/simple.txt' , 'w'):
+        pass
+
+    with pytest.raises(exceptions.OutputFileExistsException):
+        generate.generate_files(
+            context={
+                'cookiecutter': {'food': 'pizzä', '_target': 'target'}
+            },
+            repo_dir=os.path.abspath('tests/test-generate-files'),
+            output_dir='tests/custom_output_dir'
+        )
+
+    assert os.path.isfile('tests/custom_output_dir/target/bystander.txt')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_generate_files_target_dir_overwrite():
+    os.mkdir('tests/custom_output_dir')
+    os.mkdir('tests/custom_output_dir/target')
+
+    with open('tests/custom_output_dir/target/bystander.txt' , 'w'):
+       pass
+
+    with open('tests/custom_output_dir/target/simple.txt' , 'w'):
+        pass
+
+    generate.generate_files(
+        context={
+            'cookiecutter': {'food': 'pizzä', '_target': 'target'}
+        },
+        repo_dir=os.path.abspath('tests/test-generate-files'),
+        output_dir='tests/custom_output_dir',
+        overwrite_if_exists=True
+    )
+
+    assert os.path.isfile('tests/custom_output_dir/target/simple.txt')
+    assert os.path.isfile('tests/custom_output_dir/target/bystander.txt')
+
+    with open('tests/custom_output_dir/target/simple.txt') as stream:
+        assert stream.read() != ''
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_generate_files_target_preexisting():
+    os.mkdir('tests/custom_output_dir')
+    os.mkdir('tests/custom_output_dir/target')
+
+    with open('tests/custom_output_dir/target/bystander.txt' , 'w'):
+        pass
+
+    generate.generate_files(
+        context={
+            'cookiecutter': {'food': 'pizzä', '_target': 'target'}
+        },
+        repo_dir=os.path.abspath('tests/test-generate-files'),
+        output_dir='tests/custom_output_dir'
+    )
+
+    assert os.path.isfile('tests/custom_output_dir/target/simple.txt')
+    assert os.path.isfile('tests/custom_output_dir/target/bystander.txt')
+    assert not os.path.isfile('tests/custom_output_dir/inputpizzä/simple.txt')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_generate_files_preexisting():
+    os.mkdir('tests/custom_output_dir')
+    os.mkdir('tests/custom_output_dir/target')
+
+    with open('tests/custom_output_dir/target/bystander.txt' , 'w') as pre_stream:
+        pass
+
+    generate.generate_files(
+        context={
+            'cookiecutter': {'food': 'pizzä'}
+        },
+        repo_dir=os.path.abspath('tests/test-generate-files'),
+        output_dir='tests/custom_output_dir',
+        overwrite_if_exists=True,
+    )
+
+    assert os.path.isfile('tests/custom_output_dir/inputpizzä/simple.txt')
+    assert not os.path.isfile('tests/custom_output_dir/inputpizzä/bystander.txt')
+
 
 @pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
 def test_return_rendered_project_dir():

--- a/tests/test_generate_files.py
+++ b/tests/test_generate_files.py
@@ -186,6 +186,35 @@ def test_generate_files_target_dir_no_overwrite():
 
 
 @pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_generate_files_target_dir_no_overwrite_no_render():
+    os.mkdir('tests/custom_output_dir')
+    os.mkdir('tests/custom_output_dir/target')
+
+    with open('tests/custom_output_dir/target/bystander.txt', 'w'):
+        pass
+
+    with open('tests/custom_output_dir/target/simple.txt', 'w'):
+        pass
+
+    with pytest.raises(exceptions.OutputFileExistsException):
+        generate.generate_files(
+            context={
+                'cookiecutter': {
+                    'food': 'pizzä',
+                    '_target': 'target',
+                    '_copy_without_render': [
+                        "*"
+                    ]
+                }
+            },
+            repo_dir=os.path.abspath('tests/test-generate-files'),
+            output_dir='tests/custom_output_dir'
+        )
+
+    assert os.path.isfile('tests/custom_output_dir/target/bystander.txt')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
 def test_generate_files_target_dir_overwrite():
     os.mkdir('tests/custom_output_dir')
     os.mkdir('tests/custom_output_dir/target')


### PR DESCRIPTION
Pull request for issue #35 

I imagine people might have quite a lot of opinions about how this should be implemented. But I really want this feature, so I'll throw up a strawman for people to have opinions on.

The approach here is to add a `_target` setting to `cookiecutter.json` which gets rendered to a directory into which files get copied.

Demonstrating I've read the contributing file: 

* Can someone add a please-help tag to this request I don't have the permissions?
* It is definitely possible to implement this outside of cookiecutter... but it's slightly perverse to have a separate utility for expanding a specific type of template.
* I've written tests and run them with tox they pass for py27 and py35. If someone can tell me how to easily install 7 versions of python that would be useful.

Some thorny issues that people might have opinions on:

* How file overwriting should work. I overwrite nothign unless the `-f` flag is given
* Are we actually happy with relative paths
* It's a bit perverse that you have to use a directory name like '{{cookiecutter.source}}' in the template which then gets ignored.

I've written some documentation but was unable to get make the documentation run, `make servedocs` hangs with

```
python -c "$BROWSER_PYSCRIPT" docs/_build/html/index.html
watchmedo shell-command -p '*.rst' -c 'make -C docs html' -R -D .
``` 
and no ports are listened on.

