### PR TITLE
Add repo dir to context

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -72,18 +72,19 @@ def apply_overwrites_to_context(context, overwrite_context):
             context[variable] = overwrite
 
 
-def generate_context(context_file='cookiecutter.json', default_context=None,
-                     extra_context=None):
+def generate_context(repo_dir, context_file='cookiecutter.json',
+                     default_context=None, extra_context=None):
     """Generate the context for a Cookiecutter project template.
 
     Loads the JSON file as a Python object, with key being the JSON filename.
 
+    :param repo_dir: Project template input directory.
     :param context_file: JSON file containing key/value pairs for populating
         the cookiecutter's variables.
     :param default_context: Dictionary containing config to take into account.
     :param extra_context: Dictionary containing configuration overrides
     """
-    context = {}
+    context = {'_repo_dir': os.path.abspath(repo_dir)}
 
     try:
         with open(context_file) as file_handle:

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -72,6 +72,7 @@ def cookiecutter(
         logger.debug('context_file is {}'.format(context_file))
 
         context = generate_context(
+            repo_dir=repo_dir,
             context_file=context_file,
             default_context=config_dict['default_context'],
             extra_context=extra_context,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -330,6 +330,7 @@ def test_echo_undefined_variable_error(tmpdir, cli_runner):
     assert message in result.output
 
     context = {
+        '_repo_dir': os.path.abspath(template_path),
         'cookiecutter': {
             'github_username': 'hackebrot',
             'project_slug': 'testproject'

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -24,40 +24,48 @@ from cookiecutter.exceptions import ContextDecodingException
 def context_data():
     context = (
         {
+            'repo_dir': os.getcwd(),
             'context_file': 'tests/test-generate-context/test.json'
         },
         {
+            '_repo_dir': os.getcwd(),
             'test': {'1': 2, 'some_key': 'some_val'}
         }
     )
 
     context_with_default = (
         {
+            'repo_dir': os.getcwd(),
             'context_file': 'tests/test-generate-context/test.json',
             'default_context': {'1': 3}
         },
         {
+            '_repo_dir': os.getcwd(),
             'test': {'1': 3, 'some_key': 'some_val'}
         }
     )
 
     context_with_extra = (
         {
+            'repo_dir': os.getcwd(),
             'context_file': 'tests/test-generate-context/test.json',
             'extra_context': {'1': 4},
         },
         {
+            '_repo_dir': os.getcwd(),
             'test': {'1': 4, 'some_key': 'some_val'}
         }
     )
 
     context_with_default_and_extra = (
         {
+            'repo_dir': os.getcwd(),
             'context_file': 'tests/test-generate-context/test.json',
             'default_context': {'1': 3},
             'extra_context': {'1': 5},
         },
         {
+            '_repo_dir': os.getcwd(),
             'test': {'1': 5, 'some_key': 'some_val'}
         }
     )
@@ -82,6 +90,7 @@ def test_generate_context(input_params, expected_context):
 def test_generate_context_with_json_decoding_error():
     with pytest.raises(ContextDecodingException) as excinfo:
         generate.generate_context(
+            os.getcwd(),
             'tests/test-generate-context/invalid-syntax.json'
         )
     # original message from json module should be included
@@ -126,7 +135,9 @@ def test_choices(context_file, default_context, extra_context):
     """Make sure that the default for list variables is based on the user
     config and the list as such is not changed to a single value.
     """
+    repo_dir = os.getcwd()
     expected_context = {
+        '_repo_dir': repo_dir,
         'choices_template': OrderedDict([
             ('full_name', 'Raphael Pierzina'),
             ('github_username', 'hackebrot'),
@@ -137,7 +148,7 @@ def test_choices(context_file, default_context, extra_context):
     }
 
     generated_context = generate.generate_context(
-        context_file, default_context, extra_context
+        repo_dir, context_file, default_context, extra_context
     )
 
     assert generated_context == expected_context

--- a/tests/test_output_folder.py
+++ b/tests/test_output_folder.py
@@ -31,6 +31,7 @@ def remove_output_folder(request):
 @pytest.mark.usefixtures('clean_system', 'remove_output_folder')
 def test_output_folder():
     context = generate.generate_context(
+        repo_dir=os.getcwd(),
         context_file='tests/test-output-folder/cookiecutter.json'
     )
     generate.generate_files(
@@ -55,6 +56,7 @@ It is 2014."""
 @pytest.mark.usefixtures('clean_system', 'remove_output_folder')
 def test_exception_when_output_folder_exists():
     context = generate.generate_context(
+        repo_dir=os.getcwd(),
         context_file='tests/test-output-folder/cookiecutter.json'
     )
     output_folder = context['cookiecutter']['test_name']


### PR DESCRIPTION
Useful for e.g. getting a handle on the template being used in a pre_gen_project hook.

Fixes #706