### PR TITLE
Added: --strip cli option, ???

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -90,10 +90,14 @@ def validate_extra_context(ctx, param, value):
     u'--debug-file', type=click.Path(), default=None,
     help=u'File to be used as a stream for DEBUG logging',
 )
+@click.option(
+    u'--strip', is_flag=True,
+    help=u'Strip template directory',
+)
 def main(
         template, extra_context, no_input, checkout, verbose,
         replay, overwrite_if_exists, output_dir, config_file,
-        default_config, debug_file):
+        default_config, debug_file, strip):
     """Create a project from a Cookiecutter project template (TEMPLATE).
 
     Cookiecutter is free and open source software, developed and managed by
@@ -121,6 +125,7 @@ def main(
             output_dir=output_dir,
             config_file=config_file,
             default_config=default_config,
+            strip=strip
         )
     except (OutputDirExistsException,
             InvalidModeException,

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -241,7 +241,7 @@ def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context):
 
 
 def generate_files(repo_dir, context=None, output_dir='.',
-                   overwrite_if_exists=False):
+                   overwrite_if_exists=False, strip=False):
     """Render the templates and saves them to files.
 
     :param repo_dir: Project template input directory.
@@ -249,6 +249,7 @@ def generate_files(repo_dir, context=None, output_dir='.',
     :param output_dir: Where to output the generated project dir into.
     :param overwrite_if_exists: Overwrite the contents of the output directory
         if it exists.
+    :param strip: Strip project template directory.
     """
     template_dir = find_template(repo_dir)
     logger.debug('Generating project from {}...'.format(template_dir))
@@ -262,7 +263,7 @@ def generate_files(repo_dir, context=None, output_dir='.',
     )
     try:
         project_dir = render_and_create_dir(
-            unrendered_dir,
+            unrendered_dir if not strip else '',
             context,
             output_dir,
             env,

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def cookiecutter(
         template, checkout=None, no_input=False, extra_context=None,
         replay=False, overwrite_if_exists=False, output_dir='.',
-        config_file=None, default_config=False):
+        config_file=None, default_config=False, strip=False):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -42,6 +42,7 @@ def cookiecutter(
     :param output_dir: Where to output the generated project dir into.
     :param config_file: User configuration file path.
     :param default_config: Use default values rather than a config file.
+    :param strip: Strip template directory.
     """
     if replay and ((no_input is not False) or (extra_context is not None)):
         err_msg = (
@@ -88,5 +89,6 @@ def cookiecutter(
         repo_dir=repo_dir,
         context=context,
         overwrite_if_exists=overwrite_if_exists,
-        output_dir=output_dir
+        output_dir=output_dir,
+        strip=strip
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,7 @@ def test_cli_replay(mocker, cli_runner):
         config_file=None,
         default_config=False,
         extra_context=None,
+        strip=False,
     )
 
 
@@ -129,6 +130,7 @@ def test_cli_exit_on_noinput_and_replay(mocker, cli_runner):
         config_file=None,
         default_config=False,
         extra_context=None,
+        strip=False,
     )
 
 
@@ -160,6 +162,7 @@ def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
         config_file=None,
         default_config=False,
         extra_context=None,
+        strip=False,
     )
 
 
@@ -219,6 +222,7 @@ def test_cli_output_dir(mocker, cli_runner, output_dir_flag, output_dir):
         config_file=None,
         default_config=False,
         extra_context=None,
+        strip=False,
     )
 
 
@@ -257,6 +261,7 @@ def test_user_config(mocker, cli_runner, user_config_path):
         config_file=user_config_path,
         default_config=False,
         extra_context=None,
+        strip=False
     )
 
 
@@ -283,7 +288,8 @@ def test_default_user_config_overwrite(mocker, cli_runner, user_config_path):
         output_dir='.',
         config_file=user_config_path,
         default_config=True,
-        extra_context=None
+        extra_context=None,
+        strip=False
     )
 
 
@@ -306,6 +312,7 @@ def test_default_user_config(mocker, cli_runner):
         config_file=None,
         default_config=True,
         extra_context=None,
+        strip=False
     )
 
 

--- a/tests/test_specify_output_dir.py
+++ b/tests/test_specify_output_dir.py
@@ -54,7 +54,8 @@ def test_api_invocation(mocker, template, output_dir, context):
         repo_dir=template,
         context=context,
         overwrite_if_exists=False,
-        output_dir=output_dir
+        output_dir=output_dir,
+        strip=False
     )
 
 
@@ -67,5 +68,6 @@ def test_default_output_dir(mocker, template, context):
         repo_dir=template,
         context=context,
         overwrite_if_exists=False,
-        output_dir='.'
+        output_dir='.',
+        strip=False
     )


### PR DESCRIPTION
The following commit implements a new feature: stripping the template directory.
When you create your project based on cookiecutter template, it's using the first "jinja formatted" directory as template directory and render it.
Even if you specify an output directory it will always create a sub-rendered-directory.

The strip option skip this first template directory and render the boilerplate in output directory.

Basically this allows to specify the output rendered directory:
```
cookiecutter --strip -o my-output-directory my-cookiecutter-template
```
or to render in working directory:
```
cookiecutter --strip -f -o . my-cookiecutter-template
```

The "strip" name is inspired from `tar` tool where `--strip-components` option _strip NUMBER leading components from file_.