### PR TITLE
Return generated context from cookiecutter API

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -89,4 +89,4 @@ def cookiecutter(
         context=context,
         overwrite_if_exists=overwrite_if_exists,
         output_dir=output_dir
-    )
+    ), context['cookiecutter']

--- a/tests/test_cookiecutter_local_no_input.py
+++ b/tests/test_cookiecutter_local_no_input.py
@@ -81,13 +81,13 @@ def test_cookiecutter_templated_context():
 @pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
 def test_cookiecutter_no_input_return_project_dir():
     """Call `cookiecutter()` with `no_input=True`."""
-    project_dir = main.cookiecutter('tests/fake-repo-pre', no_input=True)
+    project_dir, _ = main.cookiecutter('tests/fake-repo-pre', no_input=True)
     assert project_dir == os.path.abspath('fake-project')
 
 
 @pytest.mark.usefixtures('clean_system', 'remove_additional_dirs')
 def test_cookiecutter_dict_values_in_context():
-    project_dir = main.cookiecutter('tests/fake-repo-dict', no_input=True)
+    project_dir, _ = main.cookiecutter('tests/fake-repo-dict', no_input=True)
     assert project_dir == os.path.abspath('fake-project-dict')
 
     with open(os.path.join(project_dir, 'README.md')) as fh:

--- a/tests/test_custom_extensions_in_hooks.py
+++ b/tests/test_custom_extensions_in_hooks.py
@@ -33,7 +33,7 @@ def modify_syspath(monkeypatch):
 
 
 def test_hook_with_extension(template, output_dir):
-    project_dir = main.cookiecutter(
+    project_dir, _ = main.cookiecutter(
         template,
         no_input=True,
         output_dir=output_dir,

--- a/tests/test_default_extensions.py
+++ b/tests/test_default_extensions.py
@@ -18,7 +18,7 @@ def freeze():
 
 
 def test_jinja2_time_extension(tmpdir):
-    project_dir = cookiecutter(
+    project_dir, _ = cookiecutter(
         'tests/test-extensions/default/',
         no_input=True,
         output_dir=str(tmpdir)


### PR DESCRIPTION
I patched cookiecutter main function to return both result of `generate_files` function and generated context. Indeed the generated context is really useful for my application which using cookiecutter as Python module.

An example of usage: https://github.com/rmedaer/milhoja/blob/b1207e79/milhoja/milhoja.py#L178