### PR TITLE
Adds command "cookiecutter installed" to list installed (locally available) templates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ target/
 
 # PyCharm
 .idea/
+.env

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -15,7 +15,7 @@ import click
 
 from cookiecutter import __version__
 from cookiecutter.log import configure_logger
-from cookiecutter.config import get_user_config, get_config, DEFAULT_CONFIG
+from cookiecutter.config import get_user_config
 from cookiecutter.main import cookiecutter
 from cookiecutter.exceptions import (
     OutputDirExistsException,
@@ -58,7 +58,7 @@ def list_installed_templates(default_config, passed_config_file):
     cookiecutter_folder = config.get('cookiecutters_dir')
 
     if not os.path.exists(cookiecutter_folder):
-        click.echo('Error: Cannot list installed templates. ' + \
+        click.echo('Error: Cannot list installed templates. ' +
                    'Folder does not exist: {}'.format(cookiecutter_folder))
         sys.exit(-27)
 

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -50,19 +50,25 @@ def validate_extra_context(ctx, param, value):
 
 
 def list_installed_templates(default_config, passed_config_file):
-    """Lists installed (locally cloned) templates. Use cookiecutter installed"""
+    """
+    Lists installed (locally cloned) templates. Use cookiecutter installed
+    """
 
     config = get_user_config(passed_config_file, default_config)
     cookiecutter_folder = config.get('cookiecutters_dir')
 
     if not os.path.exists(cookiecutter_folder):
-        click.echo('Error: Cannot list installed templates. Folder does not exist: {}'.format(cookiecutter_folder))
+        click.echo('Error: Cannot list installed templates. ' + \
+                   'Folder does not exist: {}'.format(cookiecutter_folder))
         sys.exit(-27)
 
     template_names = [
         folder
         for folder in os.listdir(cookiecutter_folder)
-        if os.path.exists(os.path.join(cookiecutter_folder, folder, 'cookiecutter.json'))
+        if os.path.exists(os.path.join(
+            cookiecutter_folder,
+            folder,
+            'cookiecutter.json'))
     ]
 
     click.echo('{} installed templates: '.format(len(template_names)))


### PR DESCRIPTION
Adds new command: `cookiecutter installed`

This lists locally available templates, for example:

```
user$ cookiecutter installed
7 installed templates: 
 * cookiecutter-bottle
 * cookiecutter-pyramid-talk-python-starter
 * cookiecutter-sublime-text-3-plugin
 * cookiecutter-template
 * puppet-openstack-cookiecutter
 * pyramid-cookiecutter-starter
 * python-macon-template
```

I was not able to integrate it into click without breaking the existing functionality. Someone who knows click better than me please adjust this if possible.

I’d like to see just `cookiecutter —installed` as the command (so it would be listed in help output) but I only get a missing template error and all attempts to add the command as an option met with my lack of experience with click. 
