### PR TITLE
Use a more lightweight python porting library.

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -6,9 +6,7 @@ from collections import OrderedDict
 import json
 
 import click
-from past.builtins import basestring
-
-from future.utils import iteritems
+import six
 
 from jinja2.exceptions import UndefinedError
 
@@ -164,7 +162,7 @@ def render_variable(env, raw, cookiecutter_dict):
             render_variable(env, v, cookiecutter_dict)
             for v in raw
         ]
-    elif not isinstance(raw, basestring):
+    elif not isinstance(raw, six.string_types):
         raw = str(raw)
 
     template = env.from_string(raw)
@@ -199,7 +197,7 @@ def prompt_for_config(context, no_input=False):
     # First pass: Handle simple and raw variables, plus choices.
     # These must be done first because the dictionaries keys and
     # values might refer to them.
-    for key, raw in iteritems(context[u'cookiecutter']):
+    for key, raw in context[u'cookiecutter'].items():
         if key.startswith(u'_'):
             cookiecutter_dict[key] = raw
             continue
@@ -224,7 +222,7 @@ def prompt_for_config(context, no_input=False):
             raise UndefinedVariableInTemplate(msg, err, context)
 
     # Second pass; handle the dictionaries.
-    for key, raw in iteritems(context[u'cookiecutter']):
+    for key, raw in context[u'cookiecutter'].items():
 
         try:
             if isinstance(raw, dict):

--- a/cookiecutter/replay.py
+++ b/cookiecutter/replay.py
@@ -10,7 +10,8 @@ from __future__ import unicode_literals
 
 import json
 import os
-from past.builtins import basestring
+
+import six
 
 from .utils import make_sure_path_exists
 
@@ -26,7 +27,7 @@ def dump(replay_dir, template_name, context):
     if not make_sure_path_exists(replay_dir):
         raise IOError('Unable to create replay dir at {}'.format(replay_dir))
 
-    if not isinstance(template_name, basestring):
+    if not isinstance(template_name, six.string_types):
         raise TypeError('Template name is required to be of type str')
 
     if not isinstance(context, dict):
@@ -43,7 +44,7 @@ def dump(replay_dir, template_name, context):
 
 def load(replay_dir, template_name):
     """Read json data from file."""
-    if not isinstance(template_name, basestring):
+    if not isinstance(template_name, six.string_types):
         raise TypeError('Template name is required to be of type str')
 
     replay_file = get_file_name(replay_dir, template_name)

--- a/setup.py
+++ b/setup.py
@@ -23,13 +23,13 @@ with io.open('README.md', 'r', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    'future>=0.15.2',
     'binaryornot>=0.2.0',
     'jinja2>=2.7',
     'click>=7.0',
     'poyo>=0.1.0',
     'jinja2-time>=0.1.0',
     'requests>=2.18.0',
+    'six>=1.10',
 ]
 
 if sys.argv[-1] == 'readme':

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 import platform
 
 import pytest
-from past.builtins import basestring
+import six
 
 from cookiecutter import prompt, exceptions, environment
 
@@ -36,7 +36,7 @@ def test_convert_to_str(mocker, raw_var, rendered_var):
 
     # Make sure that non None non str variables are converted beforehand
     if raw_var is not None:
-        if not isinstance(raw_var, basestring):
+        if not isinstance(raw_var, six.string_types):
             raw_var = str(raw_var)
         from_string.assert_called_once_with(raw_var)
     else:


### PR DESCRIPTION
There's a few beefs I have with using `python-future`, notably:

- It installs the "new" module names in python2 (has some negative
  compatibility with libraries that poorly detect python2 / python3).
- Introduces `newbytes` and `newstr` whick leak out of modules into code which
  doesn't understand how to handle their types (often leads to errors in
  python 2 where `str(x)` causes `"b'...'"`).
- These are summarized in more detail
  [here][1]

Some other useful links from changes made in this PR:

- I dropped `iteritems(...)`, it's not going to make a performance difference
  here.  If you want an additional read on this, openstack has a nice
  [writeup][2] on this.

[1]: https://github.com/Yelp/yelp_clog/pull/18#issue-143837308
[2]: http://lists.openstack.org/pipermail/openstack-dev/2015-June/066391.html