### PR TITLE
Added: CLI option to ignore hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lib64/
 parts/
 sdist/
 var/
+venv/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -102,6 +102,12 @@ def validate_extra_context(ctx, param, value):
     default=None,
     help='File to be used as a stream for DEBUG logging',
 )
+@click.option(
+    u"--accept-hooks",
+    type=click.Choice(["yes", "ask", "no"]),
+    default="yes",
+    help=u"Accept pre/post hooks",
+)
 def main(
     template,
     extra_context,
@@ -116,6 +122,7 @@ def main(
     debug_file,
     directory,
     skip_if_file_exists,
+    accept_hooks,
 ):
     """Create a project from a Cookiecutter project template (TEMPLATE).
 
@@ -131,6 +138,13 @@ def main(
 
     configure_logger(stream_level='DEBUG' if verbose else 'INFO', debug_file=debug_file)
 
+    # If needed, prompt the user to ask whether or not they want to execute
+    # the pre/post hooks.
+    if accept_hooks == "ask":
+        _accept_hooks = click.confirm("Do you want to execute hooks?")
+    else:
+        _accept_hooks = accept_hooks == "yes"
+
     try:
         cookiecutter(
             template,
@@ -145,6 +159,7 @@ def main(
             password=os.environ.get('COOKIECUTTER_REPO_PASSWORD'),
             directory=directory,
             skip_if_file_exists=skip_if_file_exists,
+            accept_hooks=_accept_hooks,
         )
     except (
         OutputDirExistsException,

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -258,6 +258,7 @@ def generate_files(
     output_dir='.',
     overwrite_if_exists=False,
     skip_if_file_exists=False,
+    accept_hooks=True,
 ):
     """Render the templates and saves them to files.
 
@@ -266,6 +267,7 @@ def generate_files(
     :param output_dir: Where to output the generated project dir into.
     :param overwrite_if_exists: Overwrite the contents of the output directory
         if it exists.
+    :param accept_hooks: Accept pre and post hooks if set to `True`.
     """
     template_dir = find_template(repo_dir)
     logger.debug('Generating project from %s...', template_dir)
@@ -296,9 +298,10 @@ def generate_files(
     # if rendering fails
     delete_project_on_failure = output_directory_created
 
-    _run_hook_from_repo_dir(
-        repo_dir, 'pre_gen_project', project_dir, context, delete_project_on_failure
-    )
+    if accept_hooks:
+        _run_hook_from_repo_dir(
+            repo_dir, 'pre_gen_project', project_dir, context, delete_project_on_failure
+        )
 
     with work_in(template_dir):
         env.loader = FileSystemLoader('.')
@@ -365,8 +368,9 @@ def generate_files(
                     msg = "Unable to create file '{}'".format(infile)
                     raise UndefinedVariableInTemplate(msg, err, context)
 
-    _run_hook_from_repo_dir(
-        repo_dir, 'post_gen_project', project_dir, context, delete_project_on_failure
-    )
+    if accept_hooks:
+        _run_hook_from_repo_dir(
+            repo_dir, 'post_gen_project', project_dir, context, delete_project_on_failure
+        )
 
     return project_dir

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -370,7 +370,11 @@ def generate_files(
 
     if accept_hooks:
         _run_hook_from_repo_dir(
-            repo_dir, 'post_gen_project', project_dir, context, delete_project_on_failure
+            repo_dir,
+            'post_gen_project',
+            project_dir,
+            context,
+            delete_project_on_failure,
         )
 
     return project_dir

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -31,6 +31,7 @@ def cookiecutter(
     password=None,
     directory=None,
     skip_if_file_exists=False,
+    accept_hooks=True,
 ):
     """
     Run Cookiecutter just as if using it from the command line.
@@ -48,6 +49,7 @@ def cookiecutter(
     :param default_config: Use default values rather than a config file.
     :param password: The password to use when extracting the repository.
     :param directory: Relative path to a cookiecutter template in a repository.
+    :param accept_hooks: Accept pre and post hooks if set to `True`.
     """
     if replay and ((no_input is not False) or (extra_context is not None)):
         err_msg = (
@@ -100,6 +102,7 @@ def cookiecutter(
         overwrite_if_exists=overwrite_if_exists,
         skip_if_file_exists=skip_if_file_exists,
         output_dir=output_dir,
+        accept_hooks=accept_hooks,
     )
 
     # Cleanup (if required)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,9 +17,9 @@ def cli_runner():
     """Fixture that returns a helper function to run the cookiecutter cli."""
     runner = CliRunner()
 
-    def cli_main(*cli_args):
+    def cli_main(*cli_args, **cli_kwargs):
         """Run cookiecutter cli main with the given args."""
-        return runner.invoke(main, cli_args)
+        return runner.invoke(main, cli_args, **cli_kwargs)
 
     return cli_main
 
@@ -105,6 +105,7 @@ def test_cli_replay(mocker, cli_runner):
         extra_context=None,
         password=None,
         directory=None,
+        accept_hooks=True,
     )
 
 
@@ -139,6 +140,7 @@ def test_cli_exit_on_noinput_and_replay(mocker, cli_runner):
         extra_context=None,
         password=None,
         directory=None,
+        accept_hooks=True,
     )
 
 
@@ -175,6 +177,7 @@ def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
         extra_context=None,
         password=None,
         directory=None,
+        accept_hooks=True,
     )
 
 
@@ -236,6 +239,7 @@ def test_cli_output_dir(mocker, cli_runner, output_dir_flag, output_dir):
         extra_context=None,
         password=None,
         directory=None,
+        accept_hooks=True,
     )
 
 
@@ -279,6 +283,7 @@ def test_user_config(mocker, cli_runner, user_config_path):
         extra_context=None,
         password=None,
         directory=None,
+        accept_hooks=True,
     )
 
 
@@ -305,6 +310,7 @@ def test_default_user_config_overwrite(mocker, cli_runner, user_config_path):
         extra_context=None,
         password=None,
         directory=None,
+        accept_hooks=True,
     )
 
 
@@ -329,6 +335,7 @@ def test_default_user_config(mocker, cli_runner):
         extra_context=None,
         password=None,
         directory=None,
+        accept_hooks=True,
     )
 
 
@@ -466,6 +473,50 @@ def test_directory_repo(cli_runner):
         'tests/fake-repo-dir/', '--no-input', '-v', '--directory=my-dir',
     )
     assert result.exit_code == 0
-    assert os.path.isdir('fake-project')
-    with open(os.path.join('fake-project', 'README.rst')) as f:
-        assert 'Project name: **Fake Project**' in f.read()
+    assert os.path.isdir("fake-project")
+    with open(os.path.join("fake-project", "README.rst")) as f:
+        assert "Project name: **Fake Project**" in f.read()
+
+
+cli_accept_hook_arg_testdata = [
+    ("--accept-hooks=yes", None, True),
+    ("--accept-hooks=no", None, False),
+    ("--accept-hooks=ask", "yes", True),
+    ("--accept-hooks=ask", "no", False),
+]
+
+
+@pytest.mark.parametrize(
+    "accept_hooks_arg,user_input,expected", cli_accept_hook_arg_testdata
+)
+def test_cli_accept_hooks(
+    mocker,
+    cli_runner,
+    output_dir_flag,
+    output_dir,
+    accept_hooks_arg,
+    user_input,
+    expected,
+):
+    mock_cookiecutter = mocker.patch("cookiecutter.cli.cookiecutter")
+
+    template_path = "tests/fake-repo-pre/"
+    result = cli_runner(
+        template_path, output_dir_flag, output_dir, accept_hooks_arg, input=user_input
+    )
+
+    assert result.exit_code == 0
+    mock_cookiecutter.assert_called_once_with(
+        template_path,
+        None,
+        False,
+        replay=False,
+        overwrite_if_exists=False,
+        output_dir=output_dir,
+        config_file=None,
+        default_config=False,
+        extra_context=None,
+        password=None,
+        directory=None,
+        accept_hooks=expected,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -518,5 +518,6 @@ def test_cli_accept_hooks(
         extra_context=None,
         password=None,
         directory=None,
+        skip_if_file_exists=False,
         accept_hooks=expected,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -498,6 +498,7 @@ def test_cli_accept_hooks(
     user_input,
     expected,
 ):
+    """Test cli invocation works with `accept-hooks` option."""
     mock_cookiecutter = mocker.patch("cookiecutter.cli.cookiecutter")
 
     template_path = "tests/fake-repo-pre/"

--- a/tests/test_generate_hooks.py
+++ b/tests/test_generate_hooks.py
@@ -2,7 +2,7 @@
 import errno
 import os
 import sys
-
+from pathlib import Path
 import pytest
 
 from cookiecutter import generate, utils
@@ -213,15 +213,14 @@ def test_run_shell_hooks_win(tmpdir):
 
 
 @pytest.mark.usefixtures("clean_system", "remove_additional_folders")
-def test_ignore_shell_hooks():
-    make_test_repo("tests/test-shellhooks")
+def test_ignore_shell_hooks(tmp_path):
     generate.generate_files(
         context={"cookiecutter": {"shellhooks": "shellhooks"}},
         repo_dir="tests/test-shellhooks/",
-        output_dir="tests/test-shellhooks/",
+        output_dir=tmp_path.joinpath('test-shellhooks'),
         accept_hooks=False,
     )
-    shell_pre_file = "tests/test-shellhooks/inputshellhooks/shell_pre.txt"
-    shell_post_file = "tests/test-shellhooks/inputshellhooks/shell_post.txt"
-    assert not os.path.exists(shell_pre_file)
-    assert not os.path.exists(shell_post_file)
+    shell_pre_file = tmp_path.joinpath("test-shellhooks/inputshellhooks/shell_pre.txt")
+    shell_post_file = tmp_path.joinpath("test-shellhooks/inputshellhooks/shell_post.txt")
+    assert not shell_pre_file.exists()
+    assert not shell_post_file.exists()

--- a/tests/test_generate_hooks.py
+++ b/tests/test_generate_hooks.py
@@ -2,7 +2,7 @@
 import errno
 import os
 import sys
-from pathlib import Path
+
 import pytest
 
 from cookiecutter import generate, utils
@@ -214,6 +214,7 @@ def test_run_shell_hooks_win(tmpdir):
 
 @pytest.mark.usefixtures("clean_system", "remove_additional_folders")
 def test_ignore_shell_hooks(tmp_path):
+    """Verify *.txt files not created, when accept_hooks=False."""
     generate.generate_files(
         context={"cookiecutter": {"shellhooks": "shellhooks"}},
         repo_dir="tests/test-shellhooks/",
@@ -221,6 +222,8 @@ def test_ignore_shell_hooks(tmp_path):
         accept_hooks=False,
     )
     shell_pre_file = tmp_path.joinpath("test-shellhooks/inputshellhooks/shell_pre.txt")
-    shell_post_file = tmp_path.joinpath("test-shellhooks/inputshellhooks/shell_post.txt")
+    shell_post_file = tmp_path.joinpath(
+        "test-shellhooks/inputshellhooks/shell_post.txt"
+    )
     assert not shell_pre_file.exists()
     assert not shell_post_file.exists()

--- a/tests/test_generate_hooks.py
+++ b/tests/test_generate_hooks.py
@@ -210,3 +210,18 @@ def test_run_shell_hooks_win(tmpdir):
     )
     assert os.path.exists(shell_pre_file)
     assert os.path.exists(shell_post_file)
+
+
+@pytest.mark.usefixtures("clean_system", "remove_additional_folders")
+def test_ignore_shell_hooks():
+    make_test_repo("tests/test-shellhooks")
+    generate.generate_files(
+        context={"cookiecutter": {"shellhooks": "shellhooks"}},
+        repo_dir="tests/test-shellhooks/",
+        output_dir="tests/test-shellhooks/",
+        accept_hooks=False,
+    )
+    shell_pre_file = "tests/test-shellhooks/inputshellhooks/shell_pre.txt"
+    shell_post_file = "tests/test-shellhooks/inputshellhooks/shell_post.txt"
+    assert not os.path.exists(shell_pre_file)
+    assert not os.path.exists(shell_post_file)

--- a/tests/test_specify_output_dir.py
+++ b/tests/test_specify_output_dir.py
@@ -61,6 +61,7 @@ def test_api_invocation(mocker, template, output_dir, context):
         overwrite_if_exists=False,
         skip_if_file_exists=False,
         output_dir=output_dir,
+        accept_hooks=True,
     )
 
 
@@ -76,4 +77,5 @@ def test_default_output_dir(mocker, template, context):
         overwrite_if_exists=False,
         skip_if_file_exists=False,
         output_dir='.',
+        accept_hooks=True,
     )

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ passenv =
     HOME
 commands =
     pip install -e .
-    pytest -x --cov=cookiecutter {posargs:tests}
+    pytest --cov=cookiecutter {posargs:tests}
 deps = -rtest_requirements.txt
 skip_install = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ passenv =
     HOME
 commands =
     pip install -e .
-    pytest --cov=cookiecutter {posargs:tests}
+    pytest -x --cov=cookiecutter {posargs:tests}
 deps = -rtest_requirements.txt
 skip_install = true
 


### PR DESCRIPTION
In some cases we want to generate the cookiecutters without running the
hooks. This patch adds a CLI switch which allows that behavior.

The documentation and the unit tests were updated to reflect this
change.

Drive-by:
* Update .gitgnore file