### PR TITLE
Allow non-json-serializable context

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def cookiecutter(
         template, checkout=None, no_input=False, extra_context=None,
         replay=False, overwrite_if_exists=False, output_dir='.',
-        config_file=None, default_config=False, password=None):
+        config_file=None, default_config=False, password=None, no_dump=False):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -84,7 +84,8 @@ def cookiecutter(
         # include template dir or url in the context dict
         context['cookiecutter']['_template'] = template
 
-        dump(config_dict['replay_dir'], template_name, context)
+        if not no_dump:
+            dump(config_dict['replay_dir'], template_name, context)
 
     # Create project from local context and project template.
     result = generate_files(

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -25,7 +25,8 @@ logger = logging.getLogger(__name__)
 def cookiecutter(
         template, checkout=None, no_input=False, extra_context=None,
         replay=False, overwrite_if_exists=False, output_dir='.',
-        config_file=None, default_config=False, password=None, dump_replay_data=True):
+        config_file=None, default_config=False, password=None,
+        dump_replay_data=True):
     """
     API equivalent to using Cookiecutter at the command line.
 

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def cookiecutter(
         template, checkout=None, no_input=False, extra_context=None,
         replay=False, overwrite_if_exists=False, output_dir='.',
-        config_file=None, default_config=False, password=None, no_dump=False):
+        config_file=None, default_config=False, password=None, dump_replay_data=True):
     """
     API equivalent to using Cookiecutter at the command line.
 
@@ -84,7 +84,7 @@ def cookiecutter(
         # include template dir or url in the context dict
         context['cookiecutter']['_template'] = template
 
-        if not no_dump:
+        if dump_replay_data:
             dump(config_dict['replay_dir'], template_name, context)
 
     # Create project from local context and project template.

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -165,7 +165,7 @@ def render_variable(env, raw, cookiecutter_dict):
             for v in raw
         ]
     elif not isinstance(raw, basestring):
-        raw = str(raw)
+        return raw
 
     template = env.from_string(raw)
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -17,8 +17,8 @@ from cookiecutter import prompt, exceptions, environment
 
 
 @pytest.mark.parametrize('raw_var, rendered_var', [
-    (1, '1'),
-    (True, 'True'),
+    (1, 1),
+    (True, True),
     ('foo', 'foo'),
     ('{{cookiecutter.project}}', 'foobar'),
     (None, None),
@@ -35,9 +35,7 @@ def test_convert_to_str(mocker, raw_var, rendered_var):
     assert result == rendered_var
 
     # Make sure that non None non str variables are converted beforehand
-    if raw_var is not None:
-        if not isinstance(raw_var, basestring):
-            raw_var = str(raw_var)
+    if isinstance(raw_var, basestring):
         from_string.assert_called_once_with(raw_var)
     else:
         assert not from_string.called
@@ -191,11 +189,11 @@ class TestPrompt(object):
             'project_name': "Slartibartfast",
             'details': {
                 "key": "value",
-                "integer_key": "37",
+                "integer_key": 37,
                 "other_name": "Slartibartfast",
                 "dict_key": {
                     "deep_key": "deep_value",
-                    "deep_integer": "42",
+                    "deep_integer": 42,
                     "deep_other_name": "Slartibartfast",
                     "deep_list": [
                         "deep value 1",


### PR DESCRIPTION
This fixes #1005 by no longer stringifying context. This, however also may break json serialization so it adds an option, `no_dump`, to disable json serialization of context (which is used for replays). You should set this if you are passing non-json-serializable context.

This would most likely be a breaking change for many if people are assuming that non-strings in context get stringified (some of my existing cookiecutter code did).

Let me know if there is a better way to handle this.