### PR TITLE
Resolves #1029 generate.py::generate_files behavior when overwrite_if_exists=True and _copy_without_render specified

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -325,7 +325,12 @@ def generate_files(repo_dir, context=None, output_dir='.',
                     'Copying dir {} to {} without rendering'
                     ''.format(indir, outdir)
                 )
-                shutil.copytree(indir, outdir)
+
+                if overwrite_if_exists and os.path.exists(outdir):
+                    shutil.rmtree(outdir)
+                    shutil.copytree(indir, outdir)
+                else:
+                    shutil.copytree(indir, outdir)
 
             # We mutate ``dirs``, because we only want to go through these dirs
             # recursively

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -328,9 +328,7 @@ def generate_files(repo_dir, context=None, output_dir='.',
 
                 if overwrite_if_exists and os.path.exists(outdir):
                     shutil.rmtree(outdir)
-                    shutil.copytree(indir, outdir)
-                else:
-                    shutil.copytree(indir, outdir)
+                shutil.copytree(indir, outdir)
 
             # We mutate ``dirs``, because we only want to go through these dirs
             # recursively

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -11,7 +11,7 @@ import pytest
 
 from cookiecutter import generate
 from cookiecutter import utils
-
+from cookiecutter.cli import OutputDirExistsException
 
 @pytest.fixture(scope='function')
 def remove_test_dir(request):
@@ -23,11 +23,14 @@ def remove_test_dir(request):
             utils.rmtree('test_copy_without_render')
     request.addfinalizer(fin_remove_test_dir)
 
+@pytest.fixture(params=[True, False])
+def overwrite_if_exists(request):
+    return request.param
 
 @pytest.mark.usefixtures('clean_system', 'remove_test_dir')
-def test_generate_copy_without_render_extensions():
-    generate.generate_files(
-        context={
+def test_generate_copy_without_render_extensions(overwrite_if_exists):
+    
+    context={
             'cookiecutter': {
                 'repo_name': 'test_copy_without_render',
                 'render_test': 'I have been rendered!',
@@ -36,7 +39,10 @@ def test_generate_copy_without_render_extensions():
                     'rendered/not_rendered.yml',
                     '*.txt',
                 ]}
-        },
+        }
+    
+    generate.generate_files(
+        context=context,
         repo_dir='tests/test-generate-copy-without-render'
     )
 
@@ -68,3 +74,25 @@ def test_generate_copy_without_render_extensions():
 
     with open('test_copy_without_render/rendered/not_rendered.yml') as f:
         assert '{{cookiecutter.render_test}}' in f.read()
+
+    if overwrite_if_exists:
+        
+        # This should in all cases:
+        generate.generate_files(
+            context=context,
+            repo_dir='tests/test-generate-copy-without-render',
+            overwrite_if_exists=overwrite_if_exists
+        )
+
+    else:
+        
+        # This should fail, with OutputDirExistsException:
+        try:
+            generate.generate_files(
+                context=context,
+                repo_dir='tests/test-generate-copy-without-render',
+                overwrite_if_exists=overwrite_if_exists
+            )
+        except OutputDirExistsException as e:
+            pass
+        

--- a/tests/test_generate_copy_without_render.py
+++ b/tests/test_generate_copy_without_render.py
@@ -13,6 +13,7 @@ from cookiecutter import generate
 from cookiecutter import utils
 from cookiecutter.cli import OutputDirExistsException
 
+
 @pytest.fixture(scope='function')
 def remove_test_dir(request):
     """
@@ -23,24 +24,27 @@ def remove_test_dir(request):
             utils.rmtree('test_copy_without_render')
     request.addfinalizer(fin_remove_test_dir)
 
+
 @pytest.fixture(params=[True, False])
 def overwrite_if_exists(request):
     return request.param
 
+
 @pytest.mark.usefixtures('clean_system', 'remove_test_dir')
 def test_generate_copy_without_render_extensions(overwrite_if_exists):
-    
-    context={
-            'cookiecutter': {
-                'repo_name': 'test_copy_without_render',
-                'render_test': 'I have been rendered!',
-                '_copy_without_render': [
-                    '*not-rendered',
-                    'rendered/not_rendered.yml',
-                    '*.txt',
-                ]}
+
+    context = {
+        'cookiecutter': {
+            'repo_name': 'test_copy_without_render',
+            'render_test': 'I have been rendered!',
+            '_copy_without_render': [
+                '*not-rendered',
+                'rendered/not_rendered.yml',
+                '*.txt',
+            ]
         }
-    
+    }
+
     generate.generate_files(
         context=context,
         repo_dir='tests/test-generate-copy-without-render'
@@ -76,7 +80,7 @@ def test_generate_copy_without_render_extensions(overwrite_if_exists):
         assert '{{cookiecutter.render_test}}' in f.read()
 
     if overwrite_if_exists:
-        
+
         # This should in all cases:
         generate.generate_files(
             context=context,
@@ -85,7 +89,7 @@ def test_generate_copy_without_render_extensions(overwrite_if_exists):
         )
 
     else:
-        
+
         # This should fail, with OutputDirExistsException:
         try:
             generate.generate_files(
@@ -93,6 +97,5 @@ def test_generate_copy_without_render_extensions(overwrite_if_exists):
                 repo_dir='tests/test-generate-copy-without-render',
                 overwrite_if_exists=overwrite_if_exists
             )
-        except OutputDirExistsException as e:
+        except OutputDirExistsException:
             pass
-        


### PR DESCRIPTION
Resolves #1029

This highlights the issue, and provides a fix and updated test fixture to catch the issue going forward:

On base: 

```
tox  -- -v tests/test_generate_copy_without_render.py::test_generate_copy_without_render_extensions
```

yields:

```
tests/test_generate_copy_without_render.py::test_generate_copy_without_render_extensions[True] FAILED
tests/test_generate_copy_without_render.py::test_generate_copy_without_render_extensions[False] PASSED
```

On nicain/cookiecutter@1029:

```
tests/test_generate_copy_without_render.py::test_generate_copy_without_render_extensions[True] PASSED
tests/test_generate_copy_without_render.py::test_generate_copy_without_render_extensions[False] PASSED
```
  