### PR TITLE
Add link to python-module-cookiecutter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -336,6 +336,7 @@ Python
 * `cookiecutter-bottle`_ : A cookiecutter template for creating reusable Bottle projects quickly.
 * `cookiecutter-openstack`_: A template for an OpenStack project.
 * `cookiecutter-docopt`_: A template for a Python command-line script that uses `docopt`_ for arguments parsing.
+* `python-module-cookiecutter`_: A template bootstraping almost any Python module, with dependencies handled by pipenv (Pipfile), easy packaging with PBR, and of course pytest, Sphinx, yapft, flake8, pylint, mypy, optimized for both "library" and "Application" use cases, with auto-publish to travis on succesful tag build. "Sematic commit" also supported thanks to PBR in commit messages, allowing automatic tag.
 * `cookiecutter-quokka-module`_: A template to create a blueprint module for Quokka Flask CMS.
 * `cookiecutter-kivy`_: A template for NUI applications built upon the kivy python-framework.
 * `cookiedozer`_: A template for Python Kivy apps ready to be deployed to android devices with Buildozer.
@@ -378,6 +379,7 @@ Python
 .. _`cookiecutter-bottle`: https://github.com/avelino/cookiecutter-bottle
 .. _`cookiecutter-openstack`: https://github.com/openstack-dev/cookiecutter
 .. _`cookiecutter-docopt`: https://github.com/sloria/cookiecutter-docopt
+.. _`python-module-cookiecutter`: https://github.com/gsemet/python-module-cookiecutter
 .. _`docopt`: http://docopt.org/
 .. _`cookiecutter-quokka-module`: https://github.com/pythonhub/cookiecutter-quokka-module
 .. _`cookiecutter-kivy`: https://github.com/hackebrot/cookiecutter-kivy


### PR DESCRIPTION
Hi,

This is the cookiecutter I use everytime I need to create a python module. I started using pipenv a months ago, and combined with PBR and a proper tooling (doing here around a Makefile), it applies very well to library and application use cases. It is generic, that is does not bootstrap the code, only the tooling and build system.

PBR and pipenv handles pretty much all key things:
- dependencies declaration
- requirements.txt generation (for library) to support services such as readthedocs that does not support properly Pipfile yet
- library tracks only Pipfile, PBR handle the injection into setup.py properly
- application tracks both Pipfile and Pipfile.lock to maximize reproductibility
- PBR allows semantic commit ("sem-ver: feature" in the commit message means a jump of minor versioning, "sem-ver: api-break" means a jump of major version)
- of course "make tag-pbr" can automatically create the right tag according to the latest semantic commit.
- travis.yml secret automatically retrieved from travis
- travis pushes to pypi on successful tag build
- yapf/isort formatting (enforcing 1 import per line to simplify merges)
- test with pytest of course
- fancy classic stuff: coverage report, editorconfig, dockerfile, ...

To see its usages:
- library: https://github.com/gsemet/cfgtree
- application: https://github.com/Guake/guake

planned: backport the automatic release note generation using OpenStack's reno project.