### PR TITLE
Add cookiecutter-pipenv: Cookiecutter Python Package Template with Pipenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -327,6 +327,7 @@ Python
   template.
 * `cookiecutter-pipproject`_: Minimal package for pip-installable projects
 * `cookiecutter-pypackage-minimal`_: A minimal Python package template.
+* `cookiecutter-pipenv`_: Python Package Template with Pipenv.
 * `cookiecutter-lux-python`_: A boilerplate Python project that aims to create Python package with a convenient Makefile-facility and additional helpers.
 * `cookiecutter-flask`_ : A Flask template with Bootstrap 3, starter templates, and working user registration.
 * `cookiecutter-flask-2`_: A heavier weight fork of cookiecutter-flask, with more boilerplate including forgotten password and Heroku integration
@@ -368,6 +369,7 @@ Python
 .. _`cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
 .. _`cookiecutter-pipproject`: https://github.com/wdm0006/cookiecutter-pipproject
 .. _`cookiecutter-pypackage-minimal`: https://github.com/kragniz/cookiecutter-pypackage-minimal
+.. _`cookiecutter-pipenv`: https://github.com/elgertam/cookiecutter-pipenv
 .. _`cookiecutter-lux-python`: https://github.com/alexkey/cookiecutter-lux-python
 .. _`cookiecutter-flask`: https://github.com/sloria/cookiecutter-flask
 .. _`cookiecutter-flask-2`: https://github.com/wdm0006/cookiecutter-flask


### PR DESCRIPTION
I forked @audreyr's cookiecutter-pypackage so that it now uses Pipenv and Pipfile instead of pip and requirements.txt. In addition, I updated the docs to recommend using pipsi instead of manually installing Cookiecutter or Pipenv into virtualenvs. Other than a few further changes to the docs, this is substantially similar to the cookiecutter-pypackage.

I'd love it if you would add the link to my forked template. 😀