### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ matrix:
         env: TOXENV=py35
       - python: 3.6
         env: TOXENV=py36
-      - python: 3.6
-        env: TOXENV=py36
+      - python: 3.7
+        env: TOXENV=py37
         sudo: true    # Required for Python 3.7
         dist: xenial  # Required for Python 3.7
       - python: pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Config file for automatic testing at travis-ci.org
 
-sudo: false
 language: python
 
 matrix:
@@ -15,13 +14,11 @@ matrix:
         env: TOXENV=py36
       - python: 3.7
         env: TOXENV=py37
-        sudo: true    # Required for Python 3.7
         dist: xenial  # Required for Python 3.7
       - python: pypy
         env: TOXENV=pypy
       - python: 3.7
         env: TOXENV=flake8
-        sudo: true    # Required for Python 3.7
         dist: xenial  # Required for Python 3.7
 
 install: pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,20 @@ matrix:
         env: TOXENV=py35
       - python: 3.6
         env: TOXENV=py36
+      - python: 3.6
+        env: TOXENV=py36
+        sudo: true    # Required for Python 3.7
+        dist: xenial  # Required for Python 3.7
       - python: pypy
         env: TOXENV=pypy
-      - python: 3.5
+      - python: 3.7
         env: TOXENV=flake8
+        sudo: true    # Required for Python 3.7
+        dist: xenial  # Required for Python 3.7
+
+install: pip install tox
 
 script: tox
-
-install:
-    - pip install tox
-
 
 after_success:
     # Report coverage results to codecov.io

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ templates), e.g. creating a Python package project from a Python package project
 
 .. image:: https://raw.github.com/audreyr/cookiecutter/3ac078356adf5a1a72042dfe72ebfa4a9cd5ef38/logo/cookiecutter_medium.png
 
-We are proud to be an open source sponsor of `PyCon 2016`_.
+We are proud to have been an open source sponsor of `PyCon 2016`_.
 
 Features
 --------
@@ -51,7 +51,7 @@ Did someone say features?
 
 * Cross-platform: Windows, Mac, and Linux are officially supported.
 
-* Works with Python 2.7, 3.4, 3.5, 3.6, and PyPy. *(But you don't have to
+* Works with Python 2.7, 3.4, 3.5, 3.6, 3.7, and PyPy. *(But you don't have to
   know/write Python code to use Cookiecutter.)*
 
 * Project templates can be in any programming language or markup format:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,12 @@ environment:
     - PYTHON: "C:\\Python36-x64"
       TOXENV: "py36"
 
+    - PYTHON: "C:\\Python37"
+      TOXENV: "py37"
+
+    - PYTHON: "C:\\Python37-x64"
+      TOXENV: "py37"
+
 init:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
   - "git config --system http.sslcainfo \"C:\\Program Files\\Git\\mingw64\\ssl\\certs\\ca-bundle.crt\""

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development',

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -86,8 +86,8 @@ def test_generate_context_with_json_decoding_error():
         )
     # original message from json module should be included
     pattern = (
-        'Expecting \'{0,1}:\'{0,1} delimiter: '
-        'line 1 column (19|20) \(char 19\)'
+        r'Expecting \'{0,1}:\'{0,1} delimiter: '
+        r'line 1 column (19|20) \(char 19\)'
     )
     assert re.search(pattern, str(excinfo.value))
     # File name should be included too...for testing purposes, just test the

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy, flake8
+envlist = py27, py34, py35, py36, py37, pypy, flake8
 
 [testenv]
 passenv = LC_ALL, LANG, HOME
@@ -8,7 +8,7 @@ deps = -rtest_requirements.txt
 
 [testenv:flake8]
 deps =
-    flake8==3.5.0
+    flake8
 commands =
     flake8 cookiecutter tests setup.py
 


### PR DESCRIPTION
Travis CI must run Python 3.7 with sudo on xenial as described at https://github.com/travis-ci/travis-ci/issues/9069

Tox: Removed the hardcoding of flake8 version because if the linter improves then we want our testing to benefit from those improvements.

