### PR TITLE
Feature: Add option 'inplace' to use current folder as project folder

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -88,10 +88,15 @@ def validate_extra_context(ctx, param, value):
     u'--debug-file', type=click.Path(), default=None,
     help=u'File to be used as a stream for DEBUG logging',
 )
+@click.option(
+    u'-i', u'--inplace', is_flag=True, default=False,
+    help=u'Use the current directory as project directory. This option sets '
+         u'overwrite-if-exists.'
+)
 def main(
         template, extra_context, no_input, checkout, verbose,
         replay, overwrite_if_exists, output_dir, config_file,
-        default_config, debug_file):
+        default_config, debug_file, inplace):
     """Create a project from a Cookiecutter project template (TEMPLATE).
 
     Cookiecutter is free and open source software, developed and managed by
@@ -118,7 +123,8 @@ def main(
             output_dir=output_dir,
             config_file=config_file,
             default_config=default_config,
-            password=os.environ.get('COOKIECUTTER_REPO_PASSWORD')
+            password=os.environ.get('COOKIECUTTER_REPO_PASSWORD'),
+            inplace=inplace
         )
     except (OutputDirExistsException,
             InvalidModeException,

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -181,10 +181,16 @@ def generate_file(project_dir, infile, context, env):
 
 
 def render_and_create_dir(dirname, context, output_dir, environment,
-                          overwrite_if_exists=False):
+                          overwrite_if_exists=False, inplace=False):
     """Render name of a directory, create the directory, return its path."""
-    name_tmpl = environment.from_string(dirname)
-    rendered_dirname = name_tmpl.render(**context)
+
+    # we need to overwrite when running inplace
+    overwrite_if_exists = inplace or overwrite_if_exists
+    if inplace:
+        rendered_dirname = u''
+    else:
+        name_tmpl = environment.from_string(dirname)
+        rendered_dirname = name_tmpl.render(**context)
 
     dir_to_create = os.path.normpath(
         os.path.join(output_dir, rendered_dirname)
@@ -245,7 +251,7 @@ def _run_hook_from_repo_dir(repo_dir, hook_name, project_dir, context,
 
 
 def generate_files(repo_dir, context=None, output_dir='.',
-                   overwrite_if_exists=False):
+                   overwrite_if_exists=False, inplace=False):
     """Render the templates and saves them to files.
 
     :param repo_dir: Project template input directory.
@@ -270,7 +276,8 @@ def generate_files(repo_dir, context=None, output_dir='.',
             context,
             output_dir,
             env,
-            overwrite_if_exists
+            overwrite_if_exists,
+            inplace
         )
     except UndefinedError as err:
         msg = "Unable to create project directory '{}'".format(unrendered_dir)

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def cookiecutter(
         template, checkout=None, no_input=False, extra_context=None,
         replay=False, overwrite_if_exists=False, output_dir='.',
-        config_file=None, default_config=False, password=None):
+        config_file=None, default_config=False, password=None, inplace=False):
     """
     Run Cookiecutter just as if using it from the command line.
 
@@ -91,7 +91,8 @@ def cookiecutter(
         repo_dir=repo_dir,
         context=context,
         overwrite_if_exists=overwrite_if_exists,
-        output_dir=output_dir
+        output_dir=output_dir,
+        inplace=inplace
     )
 
     # Cleanup (if required)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,7 +97,8 @@ def test_cli_replay(mocker, cli_runner):
         config_file=None,
         default_config=False,
         extra_context=None,
-        password=None
+        password=None,
+        inplace=False,
     )
 
 
@@ -131,6 +132,7 @@ def test_cli_exit_on_noinput_and_replay(mocker, cli_runner):
         default_config=False,
         extra_context=None,
         password=None,
+        inplace=False,
     )
 
 
@@ -163,6 +165,7 @@ def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
         default_config=False,
         extra_context=None,
         password=None,
+        inplace=False,
     )
 
 
@@ -223,6 +226,7 @@ def test_cli_output_dir(mocker, cli_runner, output_dir_flag, output_dir):
         default_config=False,
         extra_context=None,
         password=None,
+        inplace=False,
     )
 
 
@@ -262,6 +266,7 @@ def test_user_config(mocker, cli_runner, user_config_path):
         default_config=False,
         extra_context=None,
         password=None,
+        inplace=False,
     )
 
 
@@ -290,6 +295,7 @@ def test_default_user_config_overwrite(mocker, cli_runner, user_config_path):
         default_config=True,
         extra_context=None,
         password=None,
+        inplace=False,
     )
 
 
@@ -313,6 +319,7 @@ def test_default_user_config(mocker, cli_runner):
         default_config=True,
         extra_context=None,
         password=None,
+        inplace=False,
     )
 
 

--- a/tests/test_generate_files.py
+++ b/tests/test_generate_files.py
@@ -149,6 +149,20 @@ def test_generate_files_output_dir():
 
 
 @pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
+def test_generate_files_inplace():
+    os.mkdir('tests/custom_output_dir')
+    generate.generate_files(
+        context={
+            'cookiecutter': {'food': 'pizzä'}
+        },
+        repo_dir=os.path.abspath('tests/test-generate-files'),
+        output_dir='tests/custom_output_dir',
+        inplace=True
+    )
+    assert os.path.isfile('tests/custom_output_dir/simple.txt')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_additional_folders')
 def test_return_rendered_project_dir():
     os.mkdir('tests/custom_output_dir')
     project_dir = generate.generate_files(

--- a/tests/test_specify_output_dir.py
+++ b/tests/test_specify_output_dir.py
@@ -54,7 +54,8 @@ def test_api_invocation(mocker, template, output_dir, context):
         repo_dir=template,
         context=context,
         overwrite_if_exists=False,
-        output_dir=output_dir
+        output_dir=output_dir,
+        inplace=False,
     )
 
 
@@ -67,5 +68,6 @@ def test_default_output_dir(mocker, template, context):
         repo_dir=template,
         context=context,
         overwrite_if_exists=False,
-        output_dir='.'
+        output_dir='.',
+        inplace=False,
     )


### PR DESCRIPTION
The idea is being able to use Cookiecutter for completing parts of a projects, or for adding content to an existing project (as optional feature)