### PR TITLE
Added cookiecutter-mocha-template in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -611,6 +611,7 @@ JS
 * `cookiecutter-es6-package`_: A template for writing node packages using ES6 via babel.
 * `cookiecutter-angular2`_: A template for modular angular2 with typescript apps.
 * `CICADA`_: A template + script that automatically creates list/detail controllers and partials for an AngularJS frontend to connect to a DRF backend. Works well with `cc-automated-drf-template <https://github.com/TAMU-CPT/cc-automated-drf-template>`__.
+* `cookiecutter-mocha-template`_: A template for setting up mocha as testing framework for testing the node.js apps and apis.
 
 .. _`cookiecutter-es6-boilerplate`: https://github.com/agconti/cookiecutter-es6-boilerplate
 .. _`cookiecutter-webpack`: https://github.com/hzdg/cookiecutter-webpack
@@ -621,6 +622,7 @@ JS
 .. _`cookiecutter-es6-package`: https://github.com/ratson/cookiecutter-es6-package
 .. _`cookiecutter-angular2`: https://github.com/matheuspoleza/cookiecutter-angular2
 .. _`CICADA`: https://github.com/TAMU-CPT/CICADA
+.. _`cookiecutter-mocha-template`: https://github.com/shashikumarraja/cookiecutter-mocha-template
 
 Kotlin
 ~~~~~~


### PR DESCRIPTION
Added cookiecutter-mocha-template in JS section of readme. This template can be used for setting up mocha as test framework for testing node.js apps and apis.