### PR TITLE
Fix for DeprecationWarning (about regular expression flags) on python 3.6

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,6 +35,8 @@ Other Changes:
   (#1057)
 * Make sure to preserve the order of items in the generated cookiecutter
   context, thanks to `@hackebrot`_ (#1074)
+* Fixed DeprecationWarning for a regular expression on python 3.6, thanks to
+  `@reinout`_ (#1124)
 * Add more cookiecutter templates to the mix:
 
   * `cookiecutter-python-cli`_ by `@xuanluong`_ (#1003)
@@ -69,6 +71,7 @@ Other Changes:
 .. _`@machinekoder`: https://github.com/machinekoder
 .. _`@JAStark`: https://github.com/JAStark
 .. _`@obestwalter`: https://github.com/obestwalter
+.. _`@reinout`: https://github.com/reinout
 
 
 1.6.0 (2017-10-15) Tim Tam

--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -11,12 +11,11 @@ from .vcs import clone
 from .zipfile import unzip
 
 REPO_REGEX = re.compile(r"""
-(?x)
 ((((git|hg)\+)?(git|ssh|https?):(//)?)  # something like git:// ssh:// etc.
  |                                      # or
  (\w+@[\w\.]+)                          # something like user@...
 )
-""")
+""", re.VERBOSE)
 
 
 def is_repo_url(value):


### PR DESCRIPTION
When running tests on travis with python 3.6, I got the following
deprecationwarning in cookiecutter/repository.py:19:

    DeprecationWarning: Flags not at the start of the expression '\n(?x)\n((((git|hg)\\+)' (truncated)
    """)

Python 3.6 prefers the flags right at the start, so it doesn't allow a newline
in front of it.
I fixed it by adding the flag at the end, which is more clear/verbose in any
case. Which is fitting as the flag is `re.VERBOSE` :-)