### PR TITLE
Use yaml optionally

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -37,6 +37,7 @@ def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
     ordered_load(stream, yaml.SafeLoader)"""
     class OrderedLoader(Loader):
         pass
+
     def construct_mapping(loader, node):
         loader.flatten_mapping(node)
         return object_pairs_hook(loader.construct_pairs(node))
@@ -118,7 +119,7 @@ def generate_context(context_file='cookiecutter.json', default_context=None,
         # FIXME handle potential errors
         with open(context_file) as file_handle:
             obj = ordered_load(file_handle, yaml.SafeLoader)
-        
+
     # Add the Python object to the context dictionary
     file_name = os.path.split(context_file)[1]
     file_stem = file_name.split('.')[0]

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -68,7 +68,9 @@ def cookiecutter(
     if replay:
         context = load(config_dict['replay_dir'], template_name)
     else:
-        context_file = os.path.join(repo_dir, 'cookiecutter.json')
+        context_file = os.path.join(repo_dir, 'cookiecutter.yml')
+        if not os.path.isfile(context_file):
+            context_file = os.path.join(repo_dir, 'cookiecutter.json')
         logger.debug('context_file is {}'.format(context_file))
 
         context = generate_context(

--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -61,6 +61,20 @@ def repository_has_cookiecutter_json(repo_directory):
     return repo_directory_exists and repo_config_exists
 
 
+def repository_has_cookiecutter_yaml(repo_directory):
+    """Determine if `repo_directory` contains a `cookiecutter.yml` file.
+
+    :param repo_directory: The candidate repository directory.
+    :return: True if the `repo_directory` is valid, else False.
+    """
+    repo_directory_exists = os.path.isdir(repo_directory)
+
+    repo_config_exists = os.path.isfile(
+        os.path.join(repo_directory, 'cookiecutter.yml')
+    )
+    return repo_directory_exists and repo_config_exists
+
+
 def determine_repo_dir(template, abbreviations, clone_to_dir, checkout,
                        no_input, password=None):
     """
@@ -112,6 +126,9 @@ def determine_repo_dir(template, abbreviations, clone_to_dir, checkout,
         cleanup = False
 
     for repo_candidate in repository_candidates:
+        # prefer yaml to json
+        if repository_has_cookiecutter_yaml(repo_candidate):
+            return repo_candidate, cleanup
         if repository_has_cookiecutter_json(repo_candidate):
             return repo_candidate, cleanup
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ requirements = [
     'poyo>=0.1.0',
     'jinja2-time>=0.1.0',
     'requests>=2.18.0',
+    'PyYAML>=3.12',
 ]
 
 if sys.argv[-1] == 'readme':


### PR DESCRIPTION
This PR addresses #970.
If a ```cookiecutter.yml``` is present and a ```cookiecutter.json``` file is absent, it will read the config from the yaml file.  If the json file is present, it will be used for config even if the yaml file exists.  AFAICT, the only foreseeable problem with this PR is that pyyaml is inluded in the requirements in ```setup.py```.  If you can accept an "optional requirements" file, I can move the dependency to that and add instructions in the readme.  Except for the requirement being listed, I have tried to make this feature as optional as possible.  There is also an ```import yaml``` statement in ```generate.py`` ` that can be placed in a "try except" statement if desired.

I have been using this branch for the last year successfully and just rebased from current master before making this PR.  All of the templates that I have created are using yaml for config and they have been working just fine.

