### PR TITLE
add cookiecutter-flask-devops link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -344,6 +344,7 @@ Python
 * `cookiecutter-flask-foundation`_ : Flask Template with caching, forms, sqlalchemy and unit-testing.
 * `cookiecutter-flask-minimal`_ : Minimal but production-ready Flask project template with no other dependencies except for Flask itself.
 * `cookiecutter-flask-skeleton`_ : Flask starter project.
+* `cookiecutter-flask-devops`_ : Flask template with peewee, pytest, per-commit, gitlab-ci for vps ci/cd.
 * `cookiecutter-bottle`_ : A cookiecutter template for creating reusable Bottle projects quickly.
 * `cookiecutter-openstack`_: A template for an OpenStack project.
 * `cookiecutter-docopt`_: A template for a Python command-line script that uses `docopt`_ for arguments parsing.
@@ -386,6 +387,7 @@ Python
 .. _`cookiecutter-flask-foundation`: https://github.com/JackStouffer/cookiecutter-Flask-Foundation
 .. _`cookiecutter-flask-minimal`: https://github.com/candidtim/cookiecutter-flask-minimal
 .. _`cookiecutter-flask-skeleton`: https://github.com/realpython/cookiecutter-flask-skeleton
+.. _`cookiecutter-flask-devops`: https://github.com/Colaplusice/cookiecutter-flask-devops
 .. _`cookiecutter-flask-ask`: https://github.com/chrisvoncsefalvay/cookiecutter-flask-ask
 .. _`cookiecutter-bottle`: https://github.com/avelino/cookiecutter-bottle
 .. _`cookiecutter-openstack`: https://github.com/openstack-dev/cookiecutter

--- a/README.rst
+++ b/README.rst
@@ -344,7 +344,7 @@ Python
 * `cookiecutter-flask-foundation`_ : Flask Template with caching, forms, sqlalchemy and unit-testing.
 * `cookiecutter-flask-minimal`_ : Minimal but production-ready Flask project template with no other dependencies except for Flask itself.
 * `cookiecutter-flask-skeleton`_ : Flask starter project.
-* `cookiecutter-flask-devops`_ : Flask template with peewee, pytest, per-commit, gitlab-ci for vps ci/cd.
+* `cookiecutter-flask-devops`_ : Flask template with html5-boilerplate, peewee, pytest, per-commit, docker-compose, gitlab-ci for vps ci/cd.
 * `cookiecutter-bottle`_ : A cookiecutter template for creating reusable Bottle projects quickly.
 * `cookiecutter-openstack`_: A template for an OpenStack project.
 * `cookiecutter-docopt`_: A template for a Python command-line script that uses `docopt`_ for arguments parsing.


### PR DESCRIPTION
i create a cookiecutter template for flask with below features:
- peewee orm and simple migration
- pytest for unit test and black flake8 for code format
- html5-boilerplate for jinjia template
- docker-compose to deploy 
- gitlab-ci for auto update code for vps (WIP)
- per-commit for source control
