### PR TITLE
feat: added `create-aio-app` to python's part

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -376,6 +376,7 @@ Python
 * `python-project-template`_: A template for Python projects with sophisticated release automation.
 * `cookiecutter-anyblok-project`_: A template for Anyblok based projects.
 * `cookiecutter-python-cli`_: A cookiecutter template for creating a Python CLI application using click
+* `create-aio-app`_: The boilerplate for aiohttp. Quick setup for your asynchronous web service.
 
 .. _`cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
 .. _`cookiecutter-pipproject`: https://github.com/wdm0006/cookiecutter-pipproject
@@ -429,6 +430,7 @@ Python
 .. _`python-project-template`: https://github.com/Kwpolska/python-project-template
 .. _`cookiecutter-anyblok-project`: https://github.com/AnyBlok/cookiecutter-anyblok-project
 .. _`cookiecutter-python-cli`: https://github.com/xuanluong/cookiecutter-python-cli
+.. _`create-aio-app`: https://github.com/aio-libs/create-aio-app
 
 Python-Django
 ^^^^^^^^^^^^^


### PR DESCRIPTION
Hi 👋

This is template for `aiohttp`

## Features

- [aiohttp](https://aiohttp.readthedocs.io/en/stable/) - the best python framework :)
- [mypy](https://mypy.readthedocs.io/en/latest/) - for optional static typing
- [pytest](https://pytest.readthedocs.io/en/latest/) - for run unit tests
- [black](https://black.readthedocs.io/en/latest/) - for code formatter
- [flake8](https://flake8.readthedocs.io/en/latest/) - for linting
- [trafaret](https://trafaret.readthedocs.io/en/latest/) - for validation input data
- [aio devtools](https://github.com/aio-libs/aiohttp-devtools) - helpful tool for develop
- [aiohttp debug toolbar](https://github.com/aio-libs/aiohttp-debugtoolbar) - helpful tool for debugging
- [postgres](https://www.postgresql.org/) - storage
- [alembic](https://alembic.sqlalchemy.org/en/latest/tutorial.html) - tool for create migration
- [sqlAlchemy](https://www.sqlalchemy.org/) - orm
- [sphinx](http://www.sphinx-doc.org/en/master/) - for generate docs
- [docker-compose](https://docs.docker.com/compose/) - for running develop environment and deploy