### PR TITLE
Remove EOL Python Versions 3.3 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Config file for automatic testing at travis-ci.org
-
+dist: xenial
 sudo: false
 language: python
 
@@ -7,12 +7,12 @@ matrix:
     include:
       - python: 2.7
         env: TOXENV=py27
-      - python: 3.4
-        env: TOXENV=py34
       - python: 3.5
         env: TOXENV=py35
       - python: 3.6
         env: TOXENV=py36
+      - python: 3.7
+        env: TOXENV=py37
       - python: pypy
         env: TOXENV=pypy
       - python: 3.5

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -153,7 +153,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5, 3.6, and PyPy on
+3. The pull request should work for Python 2.7, 3.5, 3.6, 3.7, and PyPy on
    AppVeyor and Travis CI.
 4. Check https://travis-ci.org/audreyr/cookiecutter/pull_requests and 
    https://ci.appveyor.com/project/audreyr/cookiecutter/history to ensure the tests pass for all supported Python versions and platforms.
@@ -221,9 +221,9 @@ dependency. It generate a coverage report after the tests.
 It is possible to tests with some versions of python, to do this the command
 is::
 
-    $ tox -e py27,py34,pypy
+    $ tox -e py27,py35,pypy
 
-Will run py.test with the python2.7, python3.4 and pypy interpreters, for
+Will run py.test with the python2.7, python3.5 and pypy interpreters, for
 example.
 
 

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Did someone say features?
 
 * Cross-platform: Windows, Mac, and Linux are officially supported.
 
-* Works with Python 2.7, 3.4, 3.5, 3.6, and PyPy. *(But you don't have to
+* Works with Python 2.7, 3.5, 3.6, 3.7, and PyPy. *(But you don't have to
   know/write Python code to use Cookiecutter.)*
 
 * Project templates can be in any programming language or markup format:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,6 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       TOXENV: "py27"
 
-    - PYTHON: "C:\\Python34"
-      TOXENV: "py34"
-
-    - PYTHON: "C:\\Python34-x64"
-      TOXENV: "py34"
-
     - PYTHON: "C:\\Python35"
       TOXENV: "py35"
 
@@ -26,6 +20,12 @@ environment:
 
     - PYTHON: "C:\\Python36-x64"
       TOXENV: "py36"
+
+    - PYTHON: "C:\\Python37"
+      TOXENV: "py37"
+
+    - PYTHON: "C:\\Python37-x64"
+      TOXENV: "py37"
 
 init:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%

--- a/docs/contributor_guidelines.rst
+++ b/docs/contributor_guidelines.rst
@@ -10,7 +10,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.3, 3.4, 3.5, 3.6, and PyPy on
+3. The pull request should work for Python 2.7, 3.5, 3.6, 3.7, and PyPy on
    Appveyor and Travis CI.
 4. Check https://travis-ci.org/audreyr/cookiecutter/pull_requests and 
    https://ci.appveyor.com/project/audreyr/cookiecutter/history to ensure the tests pass for all supported Python versions and platforms.

--- a/docs/contributor_testing.rst
+++ b/docs/contributor_testing.rst
@@ -30,7 +30,7 @@ dependency. It generate a coverage report after the tests.
 It is possible to tests with some versions of python, to do this the command
 is::
 
-    $ tox -e py27,py34,pypy
+    $ tox -e py27,py35,pypy
 
-Will run py.test with the python2.7, python3.4 and pypy interpreters, for
+Will run py.test with the python2.7, python3.5 and pypy interpreters, for
 example.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -60,7 +60,7 @@ You may also install  `Windows Subsystem for Linux <https://msdn.microsoft.com/e
 Packaging tools
 ^^^^^^^^^^^^^^^
 
-``pip`` and ``setuptools`` now come with Python 2 >=2.7.9 or Python 3 >=3.4. See the Python Packaging Authority's (PyPA) documentation `Requirements for Installing Packages <https://packaging.python.org/en/latest/installing/#requirements-for-installing-packages>`_ for full details.
+``pip`` and ``setuptools`` now come with Python 2 >=2.7.9 or Python 3 >=3.5. See the Python Packaging Authority's (PyPA) documentation `Requirements for Installing Packages <https://packaging.python.org/en/latest/installing/#requirements-for-installing-packages>`_ for full details.
 
 
 Install cookiecutter

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     long_description=readme,
     author='Audrey Roy',
     author_email='audreyr@gmail.com',
-    url='https://github.com/audreyr/cookiecutter',
+    url='https://github.com/cookiecutter/cookiecutter',
     packages=[
         'cookiecutter',
     ],
@@ -58,7 +58,7 @@ setup(
         ]
     },
     include_package_data=True,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=requirements,
     license='BSD',
     zip_safe=False,
@@ -72,9 +72,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy, flake8
+envlist = py27, py35, py36, py37, pypy, flake8
 
 [testenv]
 passenv = LC_ALL, LANG, HOME


### PR DESCRIPTION
Changes to original #1178 PR are: 

* Removed python 3.3 mentions in `docs/contributor_guidelines.rst`
* Added python 3.4 restriction to `setup.py`