### PR TITLE
Add file:// as a suitable protocol (#1)

### DIFF
--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -11,7 +11,8 @@ from .vcs import clone
 from .zipfile import unzip
 
 REPO_REGEX = re.compile(r"""
-((((git|hg)\+)?(git|ssh|https?):(//)?)  # something like git:// ssh:// etc.
+# something like git:// ssh:// file:// etc.
+((((git|hg)\+)?(git|ssh|file|https?):(//)?)
  |                                      # or
  (\w+@[\w\.]+)                          # something like user@...
 )

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -49,9 +49,7 @@ repository::
     $ cookiecutter https://github.com/audreyr/cookiecutter-pypackage.git
     $ cookiecutter git+ssh://git@github.com/audreyr/cookiecutter-pypackage.git
     $ cookiecutter hg+ssh://hg@bitbucket.org/audreyr/cookiecutter-pypackage
-    $ cookiecutter file://path/to/server/repo.git
-
-
+    
 You will be prompted to enter a bunch of project config values. (These are
 defined in the project's `cookiecutter.json`.)
 
@@ -69,6 +67,11 @@ If you want to work with repos that are not hosted in github or bitbucket you ca
 type of repo that you want to use prepending `hg+` or `git+` to repo url::
 
     $ cookiecutter hg+https://example.com/repo
+
+In addition, one can provide a path to the cookiecutter stored
+on a local server::
+
+    $ cookiecutter file://server/folder/project.git
 
 Works with Zip files
 --------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -49,6 +49,7 @@ repository::
     $ cookiecutter https://github.com/audreyr/cookiecutter-pypackage.git
     $ cookiecutter git+ssh://git@github.com/audreyr/cookiecutter-pypackage.git
     $ cookiecutter hg+ssh://hg@bitbucket.org/audreyr/cookiecutter-pypackage
+    $ cookiecutter file://path/to/server/repo.git
 
 
 You will be prompted to enter a bunch of project config values. (These are

--- a/tests/repository/test_is_repo_url.py
+++ b/tests/repository/test_is_repo_url.py
@@ -28,6 +28,7 @@ def test_is_zip_file(zipfile):
     'git+https://private.com/gitrepo',
     'hg+https://private.com/mercurialrepo',
     'https://bitbucket.org/pokoli/cookiecutter.hg',
+    'file://server/path/to/repo.git',
 ])
 def remote_repo_url(request):
     return request.param


### PR DESCRIPTION
Add file:// as a suitable protocol

Required if the repo is stored in Windows server, or other shared folder.

Enables the following:
$ cookiecutter "file://path/to/server/repo.git"
