### PR TITLE
Avoids tox/pip failures on old systems

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,15 @@
 [tox]
 envlist = py27, py35, py36, py37, pypy, flake8
+minversion = 3.2.0
+requires =
+    # https://github.com/tox-dev/tox/issues/765
+    virtualenv >= 16.4.0
 
 [testenv]
-passenv = LC_ALL, LANG, HOME
+passenv =
+    LC_ALL
+    LANG
+    HOME
 commands = pytest --cov=cookiecutter {posargs:tests}
 deps = -rtest_requirements.txt
 


### PR DESCRIPTION
Some systems may have older virtualenv versions which would install
an ancient version of pip (like 8.1.1) which is not able to parse
requirements correctly generating errors like:
```
RequirementParseError: Expected ',' or end-of-list in pathlib2>=2.2.0;python_version<"3.6" at ;python_version<"3.6"
You are using pip version 8.1.1, however version 19.1.1 is available.
```
We cannot really support such versions so we can assure that we
only run with relatively newer tools.

This should fixed observed AppVeyor errors.