### PR TITLE
Add ExpressJS cookiecutter in the list.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -585,6 +585,7 @@ JS
 * `cookiecutter-es6-package`_: A template for writing node packages using ES6 via babel.
 * `cookiecutter-angular2`_: A template for modular angular2 with typescript apps.
 * `CICADA`_: A template + script that automatically creates list/detail controllers and partials for an AngularJS frontend to connect to a DRF backend. Works well with `cc-automated-drf-template <https://github.com/TAMU-CPT/cc-automated-drf-template>`__.
+* `cookiecutter-express`_: Cookiecutter for ExpressJS with mongoose, passportjs, ansible, circleci, sphinx, sentry setup.
 
 .. _`cookiecutter-es6-boilerplate`: https://github.com/agconti/cookiecutter-es6-boilerplate
 .. _`cookiecutter-webpack`: https://github.com/hzdg/cookiecutter-webpack
@@ -595,6 +596,7 @@ JS
 .. _`cookiecutter-es6-package`: https://github.com/ratson/cookiecutter-es6-package
 .. _`cookiecutter-angular2`: https://github.com/matheuspoleza/cookiecutter-angular2
 .. _`CICADA`: https://github.com/TAMU-CPT/CICADA
+.. _`cookiecutter-express`: https://github.com/amritghimire/cookiecutter-express
 
 Kotlin
 ~~~~~~


### PR DESCRIPTION
I have added a cookiecutter for ExpressJS with mongoose, passportjs, ansible, circleci, sphinx, sentry setup in the list. 