### PR TITLE
Add a random_ascii_string() global function.

### DIFF
--- a/cookiecutter/environment.py
+++ b/cookiecutter/environment.py
@@ -27,6 +27,7 @@ class ExtensionLoaderMixin(object):
 
         default_extensions = [
             'cookiecutter.extensions.JsonifyExtension',
+            'cookiecutter.extensions.RandomStringExtension',
             'jinja2_time.TimeExtension',
         ]
         extensions = default_extensions + self._read_extensions(context)

--- a/cookiecutter/extensions.py
+++ b/cookiecutter/extensions.py
@@ -3,6 +3,13 @@
 """Jinja2 extensions."""
 
 import json
+import string
+
+try:
+    # Python 3.6 and above
+    from secrets import choice
+except ImportError:
+    from random import choice
 
 from jinja2.ext import Extension
 
@@ -18,3 +25,19 @@ class JsonifyExtension(Extension):
             return json.dumps(obj, sort_keys=True, indent=4)
 
         environment.filters['jsonify'] = jsonify
+
+
+class RandomStringExtension(Extension):
+    """Jinja2 extension to create a random string."""
+
+    def __init__(self, environment):
+        super(RandomStringExtension, self).__init__(environment)
+
+        def random_ascii_string(length, punctuation=False):
+            corpus = string.ascii_letters
+            if punctuation:
+                corpus = "".join((string.ascii_letters, string.punctuation))
+            else:
+                corpus = string.ascii_letters
+            return "".join(choice(corpus) for _ in range(length))
+        environment.globals.update(random_ascii_string=random_ascii_string)

--- a/docs/advanced/template_extensions.rst
+++ b/docs/advanced/template_extensions.rst
@@ -27,6 +27,59 @@ Please note that Cookiecutter will **not** install any dependencies on its own!
 As a user you need to make sure you have all the extensions installed, before
 running Cookiecutter on a template that requires custom Jinja2 extensions.
 
+By default Cookiecutter includes the folllowing extensions:
+
+- ``cookiecutter.extensions.JsonifyExtension``
+- ``cookiecutter.extensions.RandomStringExtension``
+- ``jinja2_time.TimeExtension``
+
+Jsonify extension
+~~~~~~~~~~~~~~~~~
+
+The ``cookiecutter.extensions.JsonifyExtension`` extension provides a ``jsonify`` filter in templates
+that converts a Python object to JSON:
+
+.. code-block:: jinja2
+
+    {% {'a': True} | jsonify %}
+
+Would output:
+
+.. code-block:: json
+
+    {"a": true}
+
+Random string extension
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``cookiecutter.extensions.RandomStringExtension`` extension provides a ``random_ascii_string``
+method in templates that generates a random fixed-length string, optionally with punctuation.
+
+To generate a random 12 character string:
+
+.. code-block:: jinja2
+
+    {{ random_ascii_string(12) }}
+
+Outputs:
+
+.. code-block:: text
+
+    bIIUczoNvswh
+
+The second argument controls if punctuation (``'!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'``) should be
+present in the result:
+
+.. code-block:: jinja2
+
+    {{ random_ascii_string(12, punctuation=True) }}
+
+Outputs:
+
+.. code-block:: text
+
+    fQupUkY}W!)!
+
 .. _`Jinja2 extensions`: http://jinja.pocoo.org/docs/latest/extensions/
 .. _`now`: https://github.com/hackebrot/jinja2-time#now-tag
 .. _`jinja2_time.TimeExtension`: https://github.com/hackebrot/jinja2-time

--- a/tests/files/{{cookiecutter.random_string_file}}.txt
+++ b/tests/files/{{cookiecutter.random_string_file}}.txt
@@ -1,0 +1,1 @@
+{{ random_ascii_string(length, punctuation) }}

--- a/tests/test_generate_file.py
+++ b/tests/test_generate_file.py
@@ -83,6 +83,29 @@ def test_generate_file_jsonify_filter(env):
 
 
 @pytest.mark.usefixtures('remove_cheese_file')
+@pytest.mark.parametrize("length", (10, 40))
+@pytest.mark.parametrize("punctuation", (True, False))
+def test_generate_file_random_ascii_string(env, length, punctuation):
+    infile = 'tests/files/{{cookiecutter.random_string_file}}.txt'
+    data = {'random_string_file': 'cheese'}
+    context = {
+        "cookiecutter": data,
+        "length": length,
+        "punctuation": punctuation
+    }
+    generate.generate_file(
+        project_dir=".",
+        infile=infile,
+        context=context,
+        env=env
+    )
+    assert os.path.isfile('tests/files/cheese.txt')
+    with open('tests/files/cheese.txt', 'rt') as f:
+        generated_text = f.read()
+        assert len(generated_text) == length
+
+
+@pytest.mark.usefixtures('remove_cheese_file')
 def test_generate_file_with_true_conditional(env):
     infile = 'tests/files/{% if generate_file == \'y\' %}cheese.txt{% endif %}'
     generate.generate_file(


### PR DESCRIPTION
Including a random string of some kind in a template is often a use case. Currently the workarounds are really quite annoying: You can use a post_hook to replace tokens in a file, but this is super hacky.

This feature has been requested a number of times, and I really think including a `random_ascii_string` global function would be really useful.