### PR TITLE
Convert RST files in docs/advanced to Markdown

### DIFF
--- a/docs_md/advanced/calling_from_python.md
+++ b/docs_md/advanced/calling_from_python.md
@@ -15,3 +15,4 @@ You can use Cookiecutter from Python:
 This is useful if, for example, you\'re writing a web framework and need
 to provide developers with a tool similar to [django-admin.py
 startproject]{.title-ref} or [npm init]{.title-ref}.
+

--- a/docs_md/advanced/calling_from_python.md
+++ b/docs_md/advanced/calling_from_python.md
@@ -1,0 +1,17 @@
+---
+title: Calling Cookiecutter Functions From Python
+---
+
+You can use Cookiecutter from Python:
+
+    from cookiecutter.main import cookiecutter
+
+    # Create project from the cookiecutter-pypackage/ template
+    cookiecutter('cookiecutter-pypackage/')
+
+    # Create project from the cookiecutter-pypackage.git repo template
+    cookiecutter('https://github.com/audreyr/cookiecutter-pypackage.git')
+
+This is useful if, for example, you\'re writing a web framework and need
+to provide developers with a tool similar to [django-admin.py
+startproject]{.title-ref} or [npm init]{.title-ref}.

--- a/docs_md/advanced/choice_variables.md
+++ b/docs_md/advanced/choice_variables.md
@@ -95,3 +95,4 @@ As you can see the order of the options changed from `1 - MIT` to
 `1 - Apache Software License 2.0`. **Cookiecutter** takes the first
 value in the list as the default.
 :::
+

--- a/docs_md/advanced/choice_variables.md
+++ b/docs_md/advanced/choice_variables.md
@@ -1,0 +1,97 @@
+---
+title: 'Choice Variables (1.1+)'
+---
+
+Choice variables provide different choices when creating a project.
+Depending on a user\'s choice the template renders things differently.
+
+Basic Usage
+===========
+
+Choice variables are regular key / value pairs, but with the value being
+a list of strings.
+
+For example, if you provide the following choice variable in your
+`cookiecutter.json`:
+
+    {
+        "license": ["MIT", "BSD-3", "GNU GPL v3.0", "Apache Software License 2.0"]
+    }
+
+you\'d get the following choices when running Cookiecutter:
+
+    Select license:
+    1 - MIT
+    2 - BSD-3
+    3 - GNU GPL v3.0
+    4 - Apache Software License 2.0
+    Choose from 1, 2, 3, 4 [1]:
+
+Depending on an user\'s choice, a different license is rendered by
+Cookiecutter.
+
+The above `license` choice variable creates `cookiecutter.license`,
+which can be used like this:
+
+    {%- if cookiecutter.license == "MIT" -%}
+    # Possible license content here
+
+    {%- elif cookiecutter.license == "BSD-3" -%}
+    # More possible license content here
+
+Cookiecutter is using [Jinja2\'s if conditional
+expression](http://jinja.pocoo.org/docs/dev/templates/#if) to determine
+the correct license.
+
+The created choice variable is still a regular Cookiecutter variable and
+can be used like this:
+
+    License
+    -------
+
+    Distributed under the terms of the `{{cookiecutter.license}}`_ license,
+
+Overwriting Default Choice Values
+=================================
+
+Choice Variables are overwritable using a
+`user-config`{.interpreted-text role="ref"} file.
+
+For example, a choice variable can be created in `cookiecutter.json` by
+using a list as value:
+
+    {
+        "license": ["MIT", "BSD-3", "GNU GPL v3.0", "Apache Software License 2.0"]
+    }
+
+By default, the first entry in the values list serves as default value
+in the prompt.
+
+Setting the default `license` agreement to *Apache Software License 2.0*
+can be done using:
+
+``` {.yaml}
+default_context:
+    license: "Apache Software License 2.0"
+```
+
+in the `user-config`{.interpreted-text role="ref"} file.
+
+The resulting prompt changes and looks like:
+
+    Select license:
+    1 - Apache Software License 2.0
+    2 - MIT
+    3 - BSD-3
+    4 - GNU GPL v3.0
+    Choose from 1, 2, 3, 4 [1]:
+
+::: {.note}
+::: {.admonition-title}
+Note
+:::
+
+As you can see the order of the options changed from `1 - MIT` to
+`1 - Apache Software License 2.0`. **Cookiecutter** takes the first
+value in the list as the default.
+:::

--- a/docs_md/advanced/cli_options.md
+++ b/docs_md/advanced/cli_options.md
@@ -1,0 +1,6 @@
+---
+title: Command Line Options
+---
+
+::: {.cc-command-line-options}
+:::

--- a/docs_md/advanced/cli_options.md
+++ b/docs_md/advanced/cli_options.md
@@ -4,3 +4,4 @@ title: Command Line Options
 
 ::: {.cc-command-line-options}
 :::
+

--- a/docs_md/advanced/copy_without_render.md
+++ b/docs_md/advanced/copy_without_render.md
@@ -17,3 +17,4 @@ Unix shell-style wildcards:
             "rendered_dir/not_rendered_file.ini"
         ]
     }
+

--- a/docs_md/advanced/copy_without_render.md
+++ b/docs_md/advanced/copy_without_render.md
@@ -1,0 +1,19 @@
+---
+title: Copy without Render
+---
+
+*New in Cookiecutter 1.1*
+
+To avoid rendering directories and files of a cookiecutter, the
+[\_copy\_without\_render]{.title-ref} key can be used in the
+[cookiecutter.json]{.title-ref}. The value of this key accepts a list of
+Unix shell-style wildcards:
+
+    {
+        "project_slug": "sample",
+        "_copy_without_render": [
+            "*.html",
+            "*not_rendered_dir",
+            "rendered_dir/not_rendered_file.ini"
+        ]
+    }

--- a/docs_md/advanced/dict_variables.md
+++ b/docs_md/advanced/dict_variables.md
@@ -1,0 +1,63 @@
+---
+title: 'Dictionary Variables (1.5+)'
+---
+
+Dictionary variables provide a way to define deep structured information
+when rendering a template.
+
+Basic Usage
+===========
+
+Dictionary variables are, as the name suggests, dictionaries of
+key-value pairs. The dictionary values can, themselves, be other
+dictionaries and lists - the data structure can be as deep as you need.
+
+For example, you could provide the following dictionary variable in your
+`cookiecutter.json`:
+
+    {
+        "project_slug": "new_project",
+        "file_types": {
+            "png": {
+                "name": "Portable Network Graphic",
+                "library": "libpng",
+                "apps": [
+                    "GIMP"
+                ]
+            },
+            "bmp": {
+                "name": "Bitmap",
+                "library": "libbmp",
+                "apps": [
+                    "Paint",
+                    "GIMP"
+                ]
+            }
+        }
+    }
+
+The above `file_type` dictionary variable creates
+`cookiecutter.file_types`, which can be used like this:
+
+    {% for extension, details in cookiecutter.file_types|dictsort %}
+    <dl>
+      <dt>Format name:</dt>
+      <dd>{{ details.name }}</dd>
+
+      <dt>Extension:</dt>
+      <dd>{{ extension }}</dd>
+
+      <dt>Applications:</dt>
+      <dd>
+          <ul>
+          {% for app in details.apps -%}
+              <li>{{ app }}</li>
+          {% endfor -%}
+          </ul>
+      </dd>
+    </dl>
+    {% endfor %}
+
+Cookiecutter is using [Jinja2\'s for
+expression](http://jinja.pocoo.org/docs/dev/templates/#for) to iterate
+over the items in the dictionary.

--- a/docs_md/advanced/dict_variables.md
+++ b/docs_md/advanced/dict_variables.md
@@ -61,3 +61,4 @@ The above `file_type` dictionary variable creates
 Cookiecutter is using [Jinja2\'s for
 expression](http://jinja.pocoo.org/docs/dev/templates/#for) to iterate
 over the items in the dictionary.
+

--- a/docs_md/advanced/hooks.md
+++ b/docs_md/advanced/hooks.md
@@ -1,0 +1,89 @@
+---
+title: 'Using Pre/Post-Generate Hooks (0.7.0+)'
+---
+
+You can have Python or Shell scripts that run before and/or after your
+project is generated.
+
+Put them in [hooks/]{.title-ref} like this:
+
+    cookiecutter-something/
+    ├── {{cookiecutter.project_slug}}/
+    ├── hooks
+    │   ├── pre_gen_project.py
+    │   └── post_gen_project.py
+    └── cookiecutter.json
+
+Shell scripts work similarly:
+
+    cookiecutter-something/
+    ├── {{cookiecutter.project_slug}}/
+    ├── hooks
+    │   ├── pre_gen_project.sh
+    │   └── post_gen_project.sh
+    └── cookiecutter.json
+
+It shouldn\'t be too hard to extend Cookiecutter to work with other
+types of scripts too. Pull requests are welcome.
+
+For portability, you should use Python scripts (with extension
+[.py]{.title-ref}) for your hooks, as these can be run on any platform.
+However, if you intend for your template to only be run on a single
+platform, a shell script (or [.bat]{.title-ref} file on Windows) can be
+a quicker alternative.
+
+Writing hooks
+=============
+
+Here are some details on how to write pre/post-generate hook scripts.
+
+Exit with an appropriate status
+-------------------------------
+
+Make sure your hook scripts work in a robust manner. If a hook script
+fails (that is, [if it finishes with a nonzero exit
+status](https://docs.python.org/3/library/sys.html#sys.exit)), the
+project generation will stop and the generated directory will be cleaned
+up.
+
+Current working directory
+-------------------------
+
+When the hook scripts script are run, their current working directory is
+the root of the generated project. This makes it easy for a
+post-generate hook to find generated files using relative paths.
+
+Template variables are rendered in the script
+---------------------------------------------
+
+Just like your project template, Cookiecutter also renders Jinja
+template syntax in your scripts. This lets you incorporate Jinja
+template variables in your scripts. For example, this line of Python
+sets `module_name` to the value of the `cookiecutter.module_name`
+template variable:
+
+``` {.python}
+module_name = '{{ cookiecutter.module_name }}'
+```
+
+Example: Validating template variables
+======================================
+
+Here is an example of script that validates a template variable before
+generating the project, to be used as `hooks/pre_gen_project.py`:
+
+``` {.python}
+import re
+import sys
+
+
+MODULE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
+
+module_name = '{{ cookiecutter.module_name }}'
+
+if not re.match(MODULE_REGEX, module_name):
+    print('ERROR: %s is not a valid Python module name!' % module_name)
+
+    # exits with status 1 to indicate failure
+    sys.exit(1)
+```

--- a/docs_md/advanced/hooks.md
+++ b/docs_md/advanced/hooks.md
@@ -87,3 +87,4 @@ if not re.match(MODULE_REGEX, module_name):
     # exits with status 1 to indicate failure
     sys.exit(1)
 ```
+

--- a/docs_md/advanced/index.md
+++ b/docs_md/advanced/index.md
@@ -1,0 +1,11 @@
+---
+title: Advanced Usage
+---
+
+Various advanced topics regarding cookiecutter usage.
+
+::: {.toctree maxdepth="2"}
+hooks user\_config calling\_from\_python injecting\_content
+suppressing\_prompts templates\_in\_context copy\_without\_render replay
+cli\_options choice\_variables dict\_variables template\_extensions
+:::

--- a/docs_md/advanced/index.md
+++ b/docs_md/advanced/index.md
@@ -9,3 +9,4 @@ hooks user\_config calling\_from\_python injecting\_content
 suppressing\_prompts templates\_in\_context copy\_without\_render replay
 cli\_options choice\_variables dict\_variables template\_extensions
 :::
+

--- a/docs_md/advanced/injecting_context.md
+++ b/docs_md/advanced/injecting_context.md
@@ -40,3 +40,4 @@ How this works:
 2.  To generate the project, [cookiecutter()]{.title-ref} is called,
     passing the timestamp in as context via the
     [extra\_context]{.title-ref} dict.
+

--- a/docs_md/advanced/injecting_context.md
+++ b/docs_md/advanced/injecting_context.md
@@ -1,0 +1,42 @@
+---
+title: Injecting Extra Context
+---
+
+You can specify an [extra\_context]{.title-ref} dictionary that will
+override values from [cookiecutter.json]{.title-ref} or
+\`.cookiecutterrc\`:
+
+    cookiecutter('cookiecutter-pypackage/',
+                 extra_context={'project_name': 'TheGreatest'})
+
+You will also need to add these keys to the
+[cookiecutter.json]{.title-ref} or [.cookiecutterrc]{.title-ref}.
+
+Example: Injecting a Timestamp
+==============================
+
+If you have `cookiecutter.json` that has the following keys:
+
+    {
+        "timestamp": "{{ cookiecutter.timestamp }}"
+    }
+
+This Python script will dynamically inject a timestamp value as the
+project is generated:
+
+    from cookiecutter.main import cookiecutter
+
+    from datetime import datetime
+
+    cookiecutter(
+        'cookiecutter-django',
+        extra_context={'timestamp': datetime.utcnow().isoformat()}
+    )
+
+How this works:
+
+1.  The script uses [datetime]{.title-ref} to get the current UTC time
+    in ISO format.
+2.  To generate the project, [cookiecutter()]{.title-ref} is called,
+    passing the timestamp in as context via the
+    [extra\_context]{.title-ref} dict.

--- a/docs_md/advanced/replay.md
+++ b/docs_md/advanced/replay.md
@@ -1,0 +1,44 @@
+---
+title: Replay Project Generation
+---
+
+*New in Cookiecutter 1.1*
+
+On invocation **Cookiecutter** dumps a json file to
+`~/.cookiecutter_replay/` which enables you to *replay* later on.
+
+In other words, it persists your **input** for a template and fetches it
+when you run the same template again.
+
+Example for a replay file (which was created via
+`cookiecutter gh:hackebrot/cookiedozer`):
+
+    {
+        "cookiecutter": {
+            "app_class_name": "FooBarApp",
+            "app_title": "Foo Bar",
+            "email": "raphael@example.com",
+            "full_name": "Raphael Pierzina",
+            "github_username": "hackebrot",
+            "kivy_version": "1.8.0",
+            "project_slug": "foobar",
+            "short_description": "A sleek slideshow app that supports swipe gestures.",
+            "version": "0.1.0",
+            "year": "2015"
+        }
+    }
+
+To fetch this context data without being prompted on the command line
+you can use either of the following methods.
+
+Pass the according option on the CLI:
+
+    cookiecutter --replay gh:hackebrot/cookiedozer
+
+Or use the Python API:
+
+    from cookiecutter.main import cookiecutter
+    cookiecutter('gh:hackebrot/cookiedozer', replay=True)
+
+This feature is comes in handy if, for instance, you want to create a
+new project from an updated template.

--- a/docs_md/advanced/replay.md
+++ b/docs_md/advanced/replay.md
@@ -42,3 +42,4 @@ Or use the Python API:
 
 This feature is comes in handy if, for instance, you want to create a
 new project from an updated template.
+

--- a/docs_md/advanced/suppressing_prompts.md
+++ b/docs_md/advanced/suppressing_prompts.md
@@ -41,3 +41,4 @@ line prompts:
 
 See the `API Reference <apiref>`{.interpreted-text role="ref"} for more
 details.
+

--- a/docs_md/advanced/suppressing_prompts.md
+++ b/docs_md/advanced/suppressing_prompts.md
@@ -1,0 +1,43 @@
+---
+title: 'Suppressing Command-Line Prompts'
+---
+
+To suppress the prompts asking for input, use [no\_input]{.title-ref}.
+
+Basic Example: Using the Defaults
+=================================
+
+Cookiecutter will pick a default value if used with \`no\_input\`:
+
+    from cookiecutter.main import cookiecutter
+    cookiecutter(
+        'cookiecutter-django',
+        no_input=True,
+    )
+
+In this case it will be using the default defined in
+[cookiecutter.json]{.title-ref} or [.cookiecutterrc]{.title-ref}.
+
+::: {.note}
+::: {.admonition-title}
+Note
+:::
+
+values from [cookiecutter.json]{.title-ref} will be overridden by values
+from [.cookiecutterrc]{.title-ref}
+:::
+
+Advanced Example: Defaults + Extra Context
+==========================================
+
+If you combine an [extra\_context]{.title-ref} dict with the
+[no\_input]{.title-ref} argument, you can programmatically create the
+project with a set list of context parameters and without any command
+line prompts:
+
+    cookiecutter('cookiecutter-pypackage/',
+                 no_input=True,
+                 extra_context={'project_name': 'TheGreatest'})
+
+See the `API Reference <apiref>`{.interpreted-text role="ref"} for more
+details.

--- a/docs_md/advanced/template_extensions.md
+++ b/docs_md/advanced/template_extensions.md
@@ -1,0 +1,34 @@
+---
+title: Template Extensions
+---
+
+*New in Cookiecutter 1.4*
+
+A template may extend the Cookiecutter environment with custom [Jinja2
+extensions](http://jinja2.readthedocs.io/en/latest/extensions.html#extensions),
+that can add extra filters, tests, globals or even extend the parser.
+
+To do so, a template author must specify the required extensions in
+`cookiecutter.json` as follows:
+
+``` {.json}
+{
+    "project_slug": "Foobar",
+    "year": "{% now 'utc', '%Y' %}",
+    "_extensions": ["jinja2_time.TimeExtension"]
+}
+```
+
+On invocation Cookiecutter tries to import the extensions and add them
+to its environment respectively.
+
+In the above example, Cookiecutter provides the additional tag
+[now](https://github.com/hackebrot/jinja2-time#now-tag), after
+installing the
+[jinja2\_time.TimeExtension](https://github.com/hackebrot/jinja2-time)
+and enabling it in `cookiecutter.json`.
+
+Please note that Cookiecutter will **not** install any dependencies on
+its own! As a user you need to make sure you have all the extensions
+installed, before running Cookiecutter on a template that requires
+custom Jinja2 extensions.

--- a/docs_md/advanced/template_extensions.md
+++ b/docs_md/advanced/template_extensions.md
@@ -32,3 +32,4 @@ Please note that Cookiecutter will **not** install any dependencies on
 its own! As a user you need to make sure you have all the extensions
 installed, before running Cookiecutter on a template that requires
 custom Jinja2 extensions.
+

--- a/docs_md/advanced/templates_in_context.md
+++ b/docs_md/advanced/templates_in_context.md
@@ -1,0 +1,39 @@
+---
+title: Templates in Context Values
+---
+
+The values (but not the keys!) of [cookiecutter.json]{.title-ref} are
+also Jinja2 templates. Values from user prompts are added to the context
+immediately, such that one context value can be derived from previous
+values. This approach can potentially save your user a lot of keystrokes
+by providing more sensible defaults.
+
+Basic Example: Templates in Context
+===================================
+
+Python packages show some patterns for their naming conventions:
+
+-   a human-readable project name
+-   a lowercase, dashed repository name
+-   an importable, dash-less package name
+
+Here is a [cookiecutter.json]{.title-ref} with templated values for this
+pattern:
+
+    {
+      "project_name": "My New Project",
+      "project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '-') }}",
+      "pkg_name": "{{ cookiecutter.project_slug|replace('-', '') }}"
+    }
+
+If the user takes the defaults, or uses [no\_input]{.title-ref}, the
+templated values will be:
+
+-   [my-new-project]{.title-ref}
+-   [mynewproject]{.title-ref}
+
+Or, if the user gives [Yet Another New Project]{.title-ref}, the values
+will be:
+
+-   [yet-another-new-project]{.title-ref}
+-   [yetanothernewproject]{.title-ref}

--- a/docs_md/advanced/templates_in_context.md
+++ b/docs_md/advanced/templates_in_context.md
@@ -37,3 +37,4 @@ will be:
 
 -   [yet-another-new-project]{.title-ref}
 -   [yetanothernewproject]{.title-ref}
+

--- a/docs_md/advanced/user_config.md
+++ b/docs_md/advanced/user_config.md
@@ -1,0 +1,60 @@
+---
+title: 'User Config (0.7.0+)'
+---
+
+If you use Cookiecutter a lot, you\'ll find it useful to have a user
+config file. By default Cookiecutter tries to retrieve settings from a
+[.cookiecutterrc]{.title-ref} file in your home directory.
+
+From version 1.3.0 you can also specify a config file on the command
+line via `--config-file`:
+
+    $ cookiecutter --config-file /home/audreyr/my-custom-config.yaml cookiecutter-pypackage
+
+Or you can set the `COOKIECUTTER_CONFIG` environment variable:
+
+    $ export COOKIECUTTER_CONFIG=/home/audreyr/my-custom-config.yaml
+
+If you wish to stick to the built-in config and not load any user config
+file at all, use the cli option `--default-config` instead. Preventing
+Cookiecutter from loading user settings is crucial for writing
+integration tests in an isolated environment.
+
+Example user config:
+
+``` {.yaml}
+default_context:
+    full_name: "Audrey Roy"
+    email: "audreyr@example.com"
+    github_username: "audreyr"
+cookiecutters_dir: "/home/audreyr/my-custom-cookiecutters-dir/"
+replay_dir: "/home/audreyr/my-custom-replay-dir/"
+abbreviations:
+    pp: https://github.com/audreyr/cookiecutter-pypackage.git
+    gh: https://github.com/{0}.git
+    bb: https://bitbucket.org/{0}
+```
+
+Possible settings are:
+
+-   default\_context: A list of key/value pairs that you want injected
+    as context whenever you generate a project with Cookiecutter. These
+    values are treated like the defaults in
+    [cookiecutter.json]{.title-ref}, upon generation of any project.
+-   cookiecutters\_dir: Directory where your cookiecutters are cloned to
+    when you use Cookiecutter with a repo argument.
+-   replay\_dir: Directory where Cookiecutter dumps context data to,
+    which you can fetch later on when using the
+    `replay feature <replay-feature>`{.interpreted-text role="ref"}.
+-   abbreviations: A list of abbreviations for cookiecutters.
+    Abbreviations can be simple aliases for a repo name, or can be used
+    as a prefix, in the form [abbr:suffix]{.title-ref}. Any suffix will
+    be inserted into the expansion in place of the text
+    [{0}]{.title-ref}, using standard Python string formatting. With the
+    above aliases, you could use the
+    [cookiecutter-pypackage]{.title-ref} template simply by saying
+    [cookiecutter pp]{.title-ref}, or [cookiecutter
+    gh:audreyr/cookiecutter-pypackage]{.title-ref}. The [gh]{.title-ref}
+    (github), [bb]{.title-ref} (bitbucket), and [gl]{.title-ref}
+    (gitlab) abbreviations shown above are actually built in, and can be
+    used without defining them yourself.

--- a/docs_md/advanced/user_config.md
+++ b/docs_md/advanced/user_config.md
@@ -58,3 +58,4 @@ Possible settings are:
     (github), [bb]{.title-ref} (bitbucket), and [gl]{.title-ref}
     (gitlab) abbreviations shown above are actually built in, and can be
     used without defining them yourself.
+


### PR DESCRIPTION
Referencing issue [1179](https://github.com/cookiecutter/cookiecutter/issues/1179)

I converted all `rst` files in `docs/advanced`
