### PR TITLE
Convert JsonifyExtension class to a function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ target/
 # PyCharm
 .idea/
 .env
+
+# vscode
+.vscode/
+

--- a/cookiecutter/extensions.py
+++ b/cookiecutter/extensions.py
@@ -2,19 +2,13 @@
 
 """Jinja2 extensions."""
 
-import json
-
 from jinja2.ext import Extension
 
+from cookiecutter.utils import jsonify
 
-class JsonifyExtension(Extension):
+
+def jsonify_extension(environment):
     """Jinja2 extension to convert a Python object to JSON."""
-
-    def __init__(self, environment):
-        """Initialize the extension with the given environment."""
-        super(JsonifyExtension, self).__init__(environment)
-
-        def jsonify(obj):
-            return json.dumps(obj, sort_keys=True, indent=4)
-
-        environment.filters['jsonify'] = jsonify
+    environment.filters['jsonify'] = jsonify
+    extension = Extension(environment)
+    return extension

--- a/cookiecutter/utils.py
+++ b/cookiecutter/utils.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 import contextlib
 import errno
+import json
 import logging
 import os
 import stat
@@ -110,3 +111,12 @@ def prompt_and_delete(path, no_input=False):
             return False
 
         sys.exit()
+
+
+def jsonify(obj):
+    """Create formatted json string from a json object.
+
+    :param obj: The json object to convert
+    :return: The json string equivalent
+    """
+    return json.dumps(obj, sort_keys=True, indent=4)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -185,3 +185,9 @@ def test_prompt_should_not_ask_if_no_input_and_rm_repo_file(mocker, tmpdir):
     assert not mock_read_user.called
     assert not repo_file.exists()
     assert deleted
+
+
+def test_jsonify():
+    obj = {'key': 'value'}
+    expected_result = '{\n    "key": "value"\n}'
+    assert utils.jsonify(obj) == expected_result


### PR DESCRIPTION
This PR converts the custom jinja2 extension called JsonifyExtension to a function to conform with the standard stated here: https://github.com/cookiecutter/cookiecutter/blob/master/CONTRIBUTING.rst#L165 which states that this project should prefer functions to classes.