### PR TITLE
Require pip 9.0.0 or newer for tox environments

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ init:
 
 install:
   - "%PYTHON%/Scripts/easy_install -U pip"
-  - "%PYTHON%/Scripts/pip install tox"
+  - "%PYTHON%/Scripts/pip install -U tox virtualenv"
   - "%PYTHON%/Scripts/pip install wheel"
 
 build: false  # Not a C# project, build stuff at the test step instead.

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ minversion = 3.2.0
 requires =
     # https://github.com/tox-dev/tox/issues/765
     virtualenv >= 16.4.0
+    pip >= 9.0.0
 
 [testenv]
 passenv =


### PR DESCRIPTION
Fix [Python 2.7 test environment](https://ci.appveyor.com/project/cookiecutter/cookiecutter/branch/master/job/ec787v2rawykero1). See https://github.com/tox-dev/tox/issues/1406