### PR TITLE
Use sys.executable when invoking python interpreter from tests

### DIFF
--- a/tests/test_cookiecutter_invocation.py
+++ b/tests/test_cookiecutter_invocation.py
@@ -16,9 +16,11 @@ import sys
 from cookiecutter import utils
 
 
-def test_should_raise_error_without_template_arg(capfd):
+def test_should_raise_error_without_template_arg(monkeypatch, capfd):
+    monkeypatch.setenv('PYTHONPATH', '.')
+
     with pytest.raises(subprocess.CalledProcessError):
-        subprocess.check_call(['python', '-m', 'cookiecutter.cli'])
+        subprocess.check_call([sys.executable, '-m', 'cookiecutter.cli'])
 
     _, err = capfd.readouterr()
     exp_message = 'Error: Missing argument "TEMPLATE".'


### PR DESCRIPTION
When we only have python3 installed, the test for missing argument is
failing because there is no "python" executable. Use `sys.executable`
instead. Also set environment correctly, like done in 7024d3b36176.