### PR TITLE
Allow specifying custom j2 delimiters in environment variables

### DIFF
--- a/cookiecutter/environment.py
+++ b/cookiecutter/environment.py
@@ -54,7 +54,8 @@ class ExtensionLoaderMixin(object):
         else:
             return [str(ext) for ext in extensions]
 
-class CustomDelimiterConfigurerMixin(object):
+
+class DelimiterMixin(object):
     """Mixin to initialize the Jinja2 Environment with custom delimiters
     """
     def __init__(self, **kwargs):
@@ -64,7 +65,7 @@ class CustomDelimiterConfigurerMixin(object):
 
         kwargs.update(self._read_delimiters(context))
 
-        super(CustomDelimiterConfigurerMixin, self).__init__(
+        super(DelimiterMixin, self).__init__(
             **kwargs
         )
 
@@ -87,7 +88,8 @@ class CustomDelimiterConfigurerMixin(object):
 
         return delimiters
 
-class StrictEnvironment(ExtensionLoaderMixin, CustomDelimiterConfigurerMixin, Environment):
+
+class StrictEnvironment(ExtensionLoaderMixin, DelimiterMixin, Environment):
     """Create strict Jinja2 environment.
 
     Jinja2 environment will raise error on undefined variable in template-

--- a/cookiecutter/find.py
+++ b/cookiecutter/find.py
@@ -22,7 +22,9 @@ def find_template(repo_dir):
 
     project_template = None
     for item in repo_dir_contents:
-        if 'cookiecutter' in item and '{{' in item and '}}' in item:
+        variable_start = os.environ.get('J2_VARIABLE_START_STRING', '{{')
+        variable_end = os.environ.get('J2_VARIABLE_END_STRING', '}}')
+        if 'cookiecutter' in item and variable_start in item and variable_end in item:
             project_template = item
             break
 

--- a/cookiecutter/find.py
+++ b/cookiecutter/find.py
@@ -22,9 +22,9 @@ def find_template(repo_dir):
 
     project_template = None
     for item in repo_dir_contents:
-        variable_start = os.environ.get('J2_VARIABLE_START_STRING', '{{')
-        variable_end = os.environ.get('J2_VARIABLE_END_STRING', '}}')
-        if 'cookiecutter' in item and variable_start in item and variable_end in item:
+        var_start = os.environ.get('J2_VARIABLE_START_STRING', '{{')
+        var_end = os.environ.get('J2_VARIABLE_END_STRING', '}}')
+        if 'cookiecutter' in item and var_start in item and var_end in item:
             project_template = item
             break
 

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -214,7 +214,9 @@ def render_and_create_dir(dirname, context, output_dir, environment,
 
 def ensure_dir_is_templated(dirname):
     """Ensure that dirname is a templated directory name."""
-    if '{{' in dirname and '}}' in dirname:
+    variable_start = os.environ.get('J2_VARIABLE_START_STRING', '{{')
+    variable_end = os.environ.get('J2_VARIABLE_END_STRING', '}}')
+    if variable_start in dirname and variable_end in dirname:
         return True
     else:
         raise NonTemplatedInputDirException

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -214,9 +214,9 @@ def render_and_create_dir(dirname, context, output_dir, environment,
 
 def ensure_dir_is_templated(dirname):
     """Ensure that dirname is a templated directory name."""
-    variable_start = os.environ.get('J2_VARIABLE_START_STRING', '{{')
-    variable_end = os.environ.get('J2_VARIABLE_END_STRING', '}}')
-    if variable_start in dirname and variable_end in dirname:
+    var_start = os.environ.get('J2_VARIABLE_START_STRING', '{{')
+    var_end = os.environ.get('J2_VARIABLE_END_STRING', '}}')
+    if var_start in dirname and var_end in dirname:
         return True
     else:
         raise NonTemplatedInputDirException

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -22,3 +22,20 @@ def test_env_should_raise_for_unknown_extension():
 def test_env_should_come_with_jinja2_time_extension():
     env = StrictEnvironment(keep_trailing_newline=True)
     assert 'jinja2_time.jinja2_time.TimeExtension' in env.extensions
+
+@pytest.fixture(autouse=True)
+def test_env_should_contain_delimiter_overrides(monkeypatch):
+    monkeypatch.setenv('J2_VARIABLE_START_STRING', '<<')
+    monkeypatch.setenv('J2_VARIABLE_END_STRING', '>>')
+    monkeypatch.setenv('J2_BLOCK_START_STRING', '<%')
+    monkeypatch.setenv('J2_BLOCK_END_STRING', '%>')
+    monkeypatch.setenv('J2_COMMENT_START_STRING', '<#')
+    monkeypatch.setenv('J2_COMMENT_END_STRING', '#>')
+
+    env = StrictEnvironment(keep_trailing_newline=True)
+    assert '<<' == env.variable_start_string
+    assert '>>' == env.variable_end_string
+    assert '<%' == env.block_start_string
+    assert '%>' == env.block_end_string
+    assert '<#' == env.comment_start_string
+    assert '#>' == env.comment_end_string

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -23,6 +23,7 @@ def test_env_should_come_with_jinja2_time_extension():
     env = StrictEnvironment(keep_trailing_newline=True)
     assert 'jinja2_time.jinja2_time.TimeExtension' in env.extensions
 
+
 @pytest.fixture(autouse=True)
 def test_env_should_contain_delimiter_overrides(monkeypatch):
     monkeypatch.setenv('J2_VARIABLE_START_STRING', '<<')


### PR DESCRIPTION
First off, thank you for creating this excellent project!

We are templating a large number of pre-existing complex jinja2 templates and, to avoid having to use a workaround like the one described in https://github.com/cookiecutter/cookiecutter/issues/1068#issuecomment-406107802, we have added the ability to create the j2 [Environment](https://jinja.palletsprojects.com/en/2.10.x/api/#jinja2.Environment) with custom delimiters.

The approach in this PR is to source these overrides from the environment. For example, we run `cookiecutter` with:

```
J2_VARIABLE_START_STRING='<<'
J2_VARIABLE_END_STRING='>>'
J2_BLOCK_START_STRING='<%'
J2_BLOCK_END_STRING='%>'
J2_COMMENT_START_STRING='<#'
J2_COMMENT_END_STRING='#>'
```

We tried another approach using cookiecutter.json (similar to the way you already allow custom j2 modules to be loaded) but for various reasons (mainly that there are two places where the variable start and end delimiters are hard-coded from which config would not be easily accessible), we pursued this one.

We have not yet updated docs as we wanted to validate the general approach first.
