### PR TITLE
replace 'bdist_wheel' with 'sdist' from 'make clean' because it breaks pypi releases.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ submodules: ## Pull and update git submodules recursively
 .PHONY: release
 release: clean ## Package and upload release
 	@echo "+ $@"
-	@python setup.py sdist bdist_wheel
+	@python setup.py sdist 
 	@twine upload -r $(PYPI_SERVER) dist/*
 
 .PHONY: sdist


### PR DESCRIPTION
The issue can be seen on early versions of [awscli-bastion](https://pypi.org/project/awscli-bastion/0.5.0/).

### Error
We can reproduce the issue with running ``make clean`` with ``python setup.py bdist_wheel``:

```
$ make clean
$ make release
```

then install will fail

```
$ pip install awscli-bastion==0.5.0                                                                                                                                         master
Collecting awscli-bastion==0.5.0
  ERROR: Could not find a version that satisfies the requirement awscli-bastion==0.5.0 (from versions: 0.1.0.macosx-10.14-x86_64, 0.2.0.macosx-10.14-x86_64, 0.3.0.macosx-10.14-x86_64, 0.4.0.macosx-10.14-x86_64, 0.5.0.macosx-10.14-x86_64)
ERROR: No matching distribution found for awscli-bastion==0.5.0
```

### Solution

Edit ``make clean`` with ``python setup.py sdist``:

```
$ make clean
$ make release
```

then install will succeed

```
$ pip install awscli-bastion==0.6.0   