### PR TITLE
Parametrize namespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,7 @@ def is_pirate(message):
 ```
 
 * Write new code in Python 3.
+* If you are using VS Code with the Python extension, it's a good idea to set it up to use `flake8` for linting and `black` for formatting. Once your virtualenv is set up, run `pip install flake8 black`. Then in VS Code, go to Settings > Workspace, look for "python linting flake8" and check the "Python > Linting: Flake8 Enabled" checkbox. Look for "python black" and make sure the "Python > Formatting: Provider" setting is set to "black". In the "Python > Formatting: Black Args", add the following command-line arguments: `--skip-string-normalization` and `--line-length 79` to make it conform to the above standard for string quotes, and to flake8 settings.
 
 ## Testing with tox
 
@@ -296,7 +297,7 @@ Ensure that each pull request meets all requirements in [checklist](https://gist
 
 ### Process: Issues
 
-If an issue is a bug that needs an urgent fix, mark it for the next patch release.  
+If an issue is a bug that needs an urgent fix, mark it for the next patch release.
 Then either fix it or mark as please-help.
 
 For other issues: encourage friendly discussion, moderate debate, offer your thoughts.
@@ -353,7 +354,7 @@ note: Adding a template doesn't give authors credit.
 
 ### Process: Your own code changes
 
-All code changes, regardless of who does them, need to be reviewed and merged by someone else.  
+All code changes, regardless of who does them, need to be reviewed and merged by someone else.
 This rule applies to all the core committers.
 
 Exceptions:

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -118,7 +118,8 @@ def main(
             output_dir=output_dir,
             config_file=config_file,
             default_config=default_config,
-            password=os.environ.get('COOKIECUTTER_REPO_PASSWORD')
+            password=os.environ.get('COOKIECUTTER_REPO_PASSWORD'),
+            namespace='cookiecutter'
         )
     except (OutputDirExistsException,
             InvalidModeException,

--- a/cookiecutter/find.py
+++ b/cookiecutter/find.py
@@ -10,7 +10,7 @@ from .exceptions import NonTemplatedInputDirException
 logger = logging.getLogger(__name__)
 
 
-def find_template(repo_dir):
+def find_template(repo_dir, namespace='cookiecutter'):
     """Determine which child directory of `repo_dir` is the project template.
 
     :param repo_dir: Local directory of newly cloned repo.
@@ -22,7 +22,7 @@ def find_template(repo_dir):
 
     project_template = None
     for item in repo_dir_contents:
-        if 'cookiecutter' in item and '{{' in item and '}}' in item:
+        if namespace in item and '{{' in item and '}}' in item:
             project_template = item
             break
 

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -25,7 +25,8 @@ logger = logging.getLogger(__name__)
 def cookiecutter(
         template, checkout=None, no_input=False, extra_context=None,
         replay=False, overwrite_if_exists=False, output_dir='.',
-        config_file=None, default_config=False, password=None):
+        config_file=None, default_config=False, password=None,
+        namespace='cookiecutter'):
     """
     Run Cookiecutter just as if using it from the command line.
 
@@ -66,7 +67,7 @@ def cookiecutter(
     template_name = os.path.basename(os.path.abspath(repo_dir))
 
     if replay:
-        context = load(config_dict['replay_dir'], template_name)
+        context = load(config_dict['replay_dir'], template_name, namespace)
     else:
         context_file = os.path.join(repo_dir, 'cookiecutter.json')
         logger.debug('context_file is {}'.format(context_file))
@@ -75,23 +76,29 @@ def cookiecutter(
             context_file=context_file,
             default_context=config_dict['default_context'],
             extra_context=extra_context,
+            namespace=namespace,
         )
 
         # prompt the user to manually configure at the command line.
         # except when 'no-input' flag is set
-        context['cookiecutter'] = prompt_for_config(context, no_input)
+        context[namespace] = prompt_for_config(
+            context,
+            no_input=no_input,
+            namespace=namespace,
+        )
 
         # include template dir or url in the context dict
-        context['cookiecutter']['_template'] = template
+        context[namespace]['_template'] = template
 
-        dump(config_dict['replay_dir'], template_name, context)
+        dump(config_dict['replay_dir'], template_name, context, namespace)
 
     # Create project from local context and project template.
     result = generate_files(
         repo_dir=repo_dir,
         context=context,
         overwrite_if_exists=overwrite_if_exists,
-        output_dir=output_dir
+        output_dir=output_dir,
+        namespace=namespace,
     )
 
     # Cleanup (if required)

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -187,7 +187,7 @@ def prompt_choice_for_config(cookiecutter_dict, env, key, options, no_input):
     return read_user_choice(key, rendered_options)
 
 
-def prompt_for_config(context, no_input=False):
+def prompt_for_config(context, no_input=False, namespace='cookiecutter'):
     """Prompt user to enter a new config.
 
     :param dict context: Source for field names and sample values.
@@ -199,7 +199,7 @@ def prompt_for_config(context, no_input=False):
     # First pass: Handle simple and raw variables, plus choices.
     # These must be done first because the dictionaries keys and
     # values might refer to them.
-    for key, raw in iteritems(context[u'cookiecutter']):
+    for key, raw in iteritems(context[namespace]):
         if key.startswith(u'_'):
             cookiecutter_dict[key] = raw
             continue
@@ -224,7 +224,7 @@ def prompt_for_config(context, no_input=False):
             raise UndefinedVariableInTemplate(msg, err, context)
 
     # Second pass; handle the dictionaries.
-    for key, raw in iteritems(context[u'cookiecutter']):
+    for key, raw in iteritems(context[namespace]):
 
         try:
             if isinstance(raw, dict):

--- a/cookiecutter/replay.py
+++ b/cookiecutter/replay.py
@@ -19,7 +19,7 @@ def get_file_name(replay_dir, template_name):
     return os.path.join(replay_dir, file_name)
 
 
-def dump(replay_dir, template_name, context):
+def dump(replay_dir, template_name, context, namespace='cookiecutter'):
     if not make_sure_path_exists(replay_dir):
         raise IOError('Unable to create replay dir at {}'.format(replay_dir))
 
@@ -29,8 +29,8 @@ def dump(replay_dir, template_name, context):
     if not isinstance(context, dict):
         raise TypeError('Context is required to be of type dict')
 
-    if 'cookiecutter' not in context:
-        raise ValueError('Context is required to contain a cookiecutter key')
+    if namespace not in context:
+        raise ValueError('Context is required to contain a {} key'.format(namespace))  # noqa: E501
 
     replay_file = get_file_name(replay_dir, template_name)
 
@@ -38,7 +38,7 @@ def dump(replay_dir, template_name, context):
         json.dump(context, outfile)
 
 
-def load(replay_dir, template_name):
+def load(replay_dir, template_name, namespace='cookiecutter'):
     if not isinstance(template_name, basestring):
         raise TypeError('Template name is required to be of type str')
 
@@ -47,7 +47,7 @@ def load(replay_dir, template_name):
     with open(replay_file, 'r') as infile:
         context = json.load(infile)
 
-    if 'cookiecutter' not in context:
-        raise ValueError('Context is required to contain a cookiecutter key')
+    if namespace not in context:
+        raise ValueError('Context is required to contain a {} key'.format(namespace))  # noqa: E501
 
     return context

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,7 +97,8 @@ def test_cli_replay(mocker, cli_runner):
         config_file=None,
         default_config=False,
         extra_context=None,
-        password=None
+        password=None,
+        namespace='cookiecutter',
     )
 
 
@@ -131,6 +132,7 @@ def test_cli_exit_on_noinput_and_replay(mocker, cli_runner):
         default_config=False,
         extra_context=None,
         password=None,
+        namespace='cookiecutter',
     )
 
 
@@ -163,6 +165,7 @@ def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
         default_config=False,
         extra_context=None,
         password=None,
+        namespace='cookiecutter',
     )
 
 
@@ -223,6 +226,7 @@ def test_cli_output_dir(mocker, cli_runner, output_dir_flag, output_dir):
         default_config=False,
         extra_context=None,
         password=None,
+        namespace='cookiecutter',
     )
 
 
@@ -262,6 +266,7 @@ def test_user_config(mocker, cli_runner, user_config_path):
         default_config=False,
         extra_context=None,
         password=None,
+        namespace='cookiecutter',
     )
 
 
@@ -290,6 +295,7 @@ def test_default_user_config_overwrite(mocker, cli_runner, user_config_path):
         default_config=True,
         extra_context=None,
         password=None,
+        namespace='cookiecutter',
     )
 
 
@@ -313,6 +319,7 @@ def test_default_user_config(mocker, cli_runner):
         default_config=True,
         extra_context=None,
         password=None,
+        namespace='cookiecutter',
     )
 
 

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -24,7 +24,8 @@ from cookiecutter.exceptions import ContextDecodingException
 def context_data():
     context = (
         {
-            'context_file': 'tests/test-generate-context/test.json'
+            'context_file': 'tests/test-generate-context/test.json',
+            'namespace': 'test'
         },
         {
             'test': {'1': 2, 'some_key': 'some_val'}
@@ -34,7 +35,8 @@ def context_data():
     context_with_default = (
         {
             'context_file': 'tests/test-generate-context/test.json',
-            'default_context': {'1': 3}
+            'default_context': {'1': 3},
+            'namespace': 'test'
         },
         {
             'test': {'1': 3, 'some_key': 'some_val'}
@@ -45,6 +47,7 @@ def context_data():
         {
             'context_file': 'tests/test-generate-context/test.json',
             'extra_context': {'1': 4},
+            'namespace': 'test'
         },
         {
             'test': {'1': 4, 'some_key': 'some_val'}
@@ -56,6 +59,7 @@ def context_data():
             'context_file': 'tests/test-generate-context/test.json',
             'default_context': {'1': 3},
             'extra_context': {'1': 5},
+            'namespace': 'test'
         },
         {
             'test': {'1': 5, 'some_key': 'some_val'}
@@ -122,7 +126,12 @@ def context_file():
     return 'tests/test-generate-context/choices_template.json'
 
 
-def test_choices(context_file, default_context, extra_context):
+@pytest.fixture
+def namespace():
+    return 'choices_template'
+
+
+def test_choices(context_file, default_context, extra_context, namespace):
     """Make sure that the default for list variables is based on the user
     config and the list as such is not changed to a single value.
     """
@@ -137,7 +146,7 @@ def test_choices(context_file, default_context, extra_context):
     }
 
     generated_context = generate.generate_context(
-        context_file, default_context, extra_context
+        context_file, default_context, extra_context, namespace
     )
 
     assert generated_context == expected_context

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,6 +30,7 @@ def test_replay_dump_template_name(
         user_config_data['replay_dir'],
         'fake-repo-tmpl',
         mocker.ANY,
+        'cookiecutter',
     )
 
 
@@ -55,4 +56,5 @@ def test_replay_load_template_name(
     mock_replay_load.assert_called_once_with(
         user_config_data['replay_dir'],
         'fake-repo-tmpl',
+        'cookiecutter',
     )

--- a/tests/test_specify_output_dir.py
+++ b/tests/test_specify_output_dir.py
@@ -54,7 +54,8 @@ def test_api_invocation(mocker, template, output_dir, context):
         repo_dir=template,
         context=context,
         overwrite_if_exists=False,
-        output_dir=output_dir
+        output_dir=output_dir,
+        namespace='cookiecutter',
     )
 
 
@@ -67,5 +68,6 @@ def test_default_output_dir(mocker, template, context):
         repo_dir=template,
         context=context,
         overwrite_if_exists=False,
-        output_dir='.'
+        output_dir='.',
+        namespace='cookiecutter',
     )


### PR DESCRIPTION
This allows for specifying a different context namespace than the default `'cookiecutter'`, when using cookiecutter's methods from Python. The behaviour of the command-line tool is unchanged.

This should be a first step towards fixing issues #380 and #1166 .

Rationale:

- The code was already partially supporting custom namespaces, in the `generate_context` method of `generate.py`. The method takes a context file name as parameter, with default value `'cookiecutter.json'`, and then generates a context object, using the file stem as the namespace: https://github.com/cookiecutter/cookiecutter/blob/673f773bfaf591b056d977c4ab82b45d90dce11e/cookiecutter/generate.py#L104 So with a context file name "`foo.json`", we then end up with a namespace of "`foo`". This PR extends this idea by making other methods "symmetric" with that behaviour. Slight change: we decouple the namespace from the context file name stem, by also introducing a namespace parameter to the `generate_context` function.
- Changes are voluntarily kept minimal, to ensure backwards compatibility and to ease code review. The issue of aligning the CLI, to accept e.g. an extra `--namespace` flag would have to be addressed separately, after merging this.

The last commit (f6645be) is just some bonus documentation for VS Code users, and is unrelated to the main concern of this PR. I can remove it from the branch and make a new PR if preferred.