### PR TITLE
alias "cc" to "cookiecutter" for templating and user's sanity

### DIFF
--- a/cookiecutter/find.py
+++ b/cookiecutter/find.py
@@ -22,7 +22,7 @@ def find_template(repo_dir):
 
     project_template = None
     for item in repo_dir_contents:
-        if 'cookiecutter' in item and '{{' in item and '}}' in item:
+        if ('cookiecutter' in item or 'cc' in item) and '{{' in item and '}}' in item:
             project_template = item
             break
 

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -83,6 +83,7 @@ def cookiecutter(
 
         # include template dir or url in the context dict
         context['cookiecutter']['_template'] = template
+        context['cc'] = context['cookiecutter']
 
         dump(config_dict['replay_dir'], template_name, context)
 

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -169,7 +169,7 @@ def render_variable(env, raw, cookiecutter_dict):
 
     template = env.from_string(raw)
 
-    rendered_template = template.render(cookiecutter=cookiecutter_dict)
+    rendered_template = template.render(cookiecutter=cookiecutter_dict, cc=cookiecutter_dict)
     return rendered_template
 
 


### PR DESCRIPTION
Simply add alias to `cookiecutter` prefix for templating as `cc` short version. 

As per https://github.com/cookiecutter/cookiecutter/issues/1166