### PR TITLE
Add missing {% endif %} to Choice Variables example

### DIFF
--- a/docs/advanced/choice_variables.rst
+++ b/docs/advanced/choice_variables.rst
@@ -36,7 +36,7 @@ can be used like this::
 
   {%- elif cookiecutter.license == "BSD-3" -%}
   # More possible license content here
-  
+
   {% endif %}
 
 Cookiecutter is using `Jinja2's if conditional expression <http://jinja.pocoo.org/docs/dev/templates/#if>`_ to determine the correct license.

--- a/docs/advanced/choice_variables.rst
+++ b/docs/advanced/choice_variables.rst
@@ -36,6 +36,8 @@ can be used like this::
 
   {%- elif cookiecutter.license == "BSD-3" -%}
   # More possible license content here
+  
+  {% endif %}
 
 Cookiecutter is using `Jinja2's if conditional expression <http://jinja.pocoo.org/docs/dev/templates/#if>`_ to determine the correct license.
 


### PR DESCRIPTION
I think this example should have an endif Jinja2 template statement at the end of it, for it to be a working example