### PR TITLE
Fix tox dependencies versions for tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ commands =
     pip install -e .
     pytest --cov=cookiecutter {posargs:tests}
 deps = -rtest_requirements.txt
-alwayscopy = true
 skip_install = true
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,8 @@ passenv =
     HOME
 commands = pytest --cov=cookiecutter {posargs:tests}
 deps = -rtest_requirements.txt
-alwayscopy = True
+alwayscopy = true
+skip_install = true
 
 [testenv:lint]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,11 @@ envlist =
     py37
     py38
     pypy
-minversion = 3.13.2
+minversion = 3.14.2
 requires =
     # https://github.com/tox-dev/tox/issues/765
-    virtualenv >= 16.7.4
-    pip >= 19.2.3
+    virtualenv >= 16.7.9
+    pip >= 19.3.1
 
 [testenv]
 passenv =
@@ -20,11 +20,12 @@ passenv =
     HOME
 commands = pytest --cov=cookiecutter {posargs:tests}
 deps = -rtest_requirements.txt
+alwayscopy = True
 
 [testenv:lint]
 commands =
     python -m pre_commit run {posargs:--all}
-deps = pre-commit>=1.17.0
+deps = pre-commit>=1.20.0
 skip_install = true
 usedevelop = false
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,9 @@ passenv =
     LC_ALL
     LANG
     HOME
-commands = pytest --cov=cookiecutter {posargs:tests}
+commands =
+    pip install -e .
+    pytest --cov=cookiecutter {posargs:tests}
 deps = -rtest_requirements.txt
 alwayscopy = true
 skip_install = true


### PR DESCRIPTION
Our appveyor is dependency dependent, so we need constantly update it.