### PR TITLE
New cookiecutter-aiohttp-uvloop template in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Please avoid creating PRs for listing additional templates. We outsourced their 
 * [python-project-template](https://github.com/Kwpolska/python-project-template): A template for Python projects with sophisticated release automation.
 * [cookiecutter-anyblok-project](https://github.com/AnyBlok/cookiecutter-anyblok-project): A template for Anyblok based projects.
 * [cookiecutter-python-cli](https://github.com/xuanluong/cookiecutter-python-cli): A cookiecutter template for creating a Python CLI application using click.
+* [cookiecutter-aiohttp-uvloop](https://github.com/osminogin/cookiecutter-aiohttp-uvloop): A template for aiohttp projects with [uvloop](https://github.com/MagicStack/uvloop) (ultra fast asyncio event loop).
 
 ### Python-Django
 


### PR DESCRIPTION
I'm glad to present to the community my template for python3 projects based on asyncio/aiohttp with uvloop (ultra fast event loop implementation). 

Read why [uvloop: Blazing fast Python networking](https://magic.io/blog/uvloop-blazing-fast-python-networking/), *TLDR* 
`In fact, it is at least 2x faster than nodejs, gevent, as well as any other Python asynchronous framework. The performance of uvloop-based asyncio is close to that of Go programs.`

Successfully used on several projects for high-load Public API, mobile app backends, but universally like aiohttp himself. I hope this will be useful to someone else.