### PR TITLE
ci: disable coverage comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+# comment spam as user can always click the failed coverage check
+comment: false


### PR DESCRIPTION
This disables the comment from codecov.io about the code coverage.

The report is still produced and the check will report red if it fails.
User can always click the link to see what failed.

This should declutter the reviewing process.