### PR TITLE
D100: Add missing docstring headers

### DIFF
--- a/cookiecutter/zipfile.py
+++ b/cookiecutter/zipfile.py
@@ -1,9 +1,12 @@
+"""Utility functions for handling and fetching repo archives in zip format."""
+
 from __future__ import absolute_import
 
 import os
-import requests
 import tempfile
 from zipfile import ZipFile
+
+import requests
 
 try:
     # BadZipfile was renamed to BadZipFile in Python 3.2.

--- a/docs/ccext.py
+++ b/docs/ccext.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-from cookiecutter import cli
+
+"""Custom Sphinx extension to build a list of all of cookiecutter's cli."""
 
 import click
-
 from docutils import nodes
 from docutils.parsers import rst
 from docutils.statemachine import ViewList
+
+from cookiecutter import cli
 
 
 class CcCommandLineOptions(rst.Directive):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+"""Documentation build configuration file."""
+
 #
 # cookiecutter documentation build configuration file, created by
 # sphinx-quickstart on Thu Jul 11 11:31:49 2013.

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ tag_name = {new_version}
 [bumpversion:file:cookiecutter/__init__.py]
 
 [flake8]
-ignore = E231,E731,W503,D100,D101,D102,D103,D400
+ignore = E231,E731,W503,D101,D102,D103,D400
 # D400 First line should end with a period
 
 # Excludes due to known issues or incompatibilities:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""cookiecutter distutils configuration"""
+
 import os
 import io
 import sys

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Cookiecutter Test Suites"""
+"""Cookiecutter integration tests"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""
-conftest.
-
---------
-Contains pytest fixtures which are globally available throughout the suite.
-"""
+"""pytest fixtures which are globally available throughout the suite."""
 
 import logging
 import os

--- a/tests/hooks-abort-render/hooks/post_gen_project.py
+++ b/tests/hooks-abort-render/hooks/post_gen_project.py
@@ -3,6 +3,8 @@
 
 # flake8: noqa
 
+"""Simple post-gen hook for testing the handling of different exit codes."""
+
 import sys
 
 {% if cookiecutter.abort_post_gen == "yes" %}

--- a/tests/hooks-abort-render/hooks/pre_gen_project.py
+++ b/tests/hooks-abort-render/hooks/pre_gen_project.py
@@ -3,6 +3,8 @@
 
 # flake8: noqa
 
+"""Simple pre-gen hook for testing the handling of different exit codes."""
+
 import sys
 
 {% if cookiecutter.abort_pre_gen == "yes" %}

--- a/tests/replay/conftest.py
+++ b/tests/replay/conftest.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""
-conftest.
-
---------
-"""
+"""pytest fixtures for testing cookiecutter's replay feature."""
 
 import pytest
 
@@ -24,11 +20,9 @@ def context():
 
 @pytest.fixture
 def replay_test_dir():
-    """Fixture to test directory."""
     return "tests/test-replay/"
 
 
 @pytest.fixture
 def mock_user_config(mocker):
-    """Fixture to mock user config."""
     return mocker.patch("cookiecutter.main.get_user_config")

--- a/tests/repository/test_abbreviation_expansion.py
+++ b/tests/repository/test_abbreviation_expansion.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Collection of tests around common path and url shorthands."""
+
 from __future__ import unicode_literals
 import pytest
 

--- a/tests/repository/test_determine_repo_dir_clones_repo.py
+++ b/tests/repository/test_determine_repo_dir_clones_repo.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+"""Collection of tests around cloning cookiecutter template repositories."""
+
 import os
 
 import pytest

--- a/tests/repository/test_determine_repo_dir_finds_existing_cookiecutter.py
+++ b/tests/repository/test_determine_repo_dir_finds_existing_cookiecutter.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
+
+"""Tests around detection whether cookiecutter templates are cached locally."""
+
 import io
 import os
+
 import pytest
 
 from cookiecutter import repository

--- a/tests/repository/test_determine_repo_dir_finds_subdirectories.py
+++ b/tests/repository/test_determine_repo_dir_finds_subdirectories.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
+
+"""Tests around locally cached cookiecutter template repositories."""
+
 import io
 import os
+
 import pytest
 
 from cookiecutter import repository, exceptions
@@ -30,7 +34,6 @@ def cloned_cookiecutter_path(user_config_data, template):
 def test_should_find_existing_cookiecutter(
     template, user_config_data, cloned_cookiecutter_path
 ):
-
     project_dir, cleanup = repository.determine_repo_dir(
         template,
         abbreviations={},
@@ -45,8 +48,7 @@ def test_should_find_existing_cookiecutter(
 
 
 def test_local_repo_typo(template, user_config_data, cloned_cookiecutter_path):
-    """An unknown local repository should raise a `RepositoryNotFound` \
-    exception."""
+    """An unknown local repo should raise a `RepositoryNotFound` exception."""
     with pytest.raises(exceptions.RepositoryNotFound) as err:
         repository.determine_repo_dir(
             template,

--- a/tests/repository/test_determine_repository_should_use_local_repo.py
+++ b/tests/repository/test_determine_repository_should_use_local_repo.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
+
+"""Tests around using locally cached cookiecutter template repositories."""
+
 import os
-from cookiecutter import repository, exceptions
 
 import pytest
+
+from cookiecutter import repository, exceptions
 
 
 def test_finds_local_repo(tmpdir):

--- a/tests/repository/test_is_repo_url.py
+++ b/tests/repository/test_is_repo_url.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+"""Tests for all supported cookiecutter template repository locations."""
+
 import pytest
 
 from cookiecutter.config import BUILTIN_ABBREVIATIONS

--- a/tests/repository/test_repository_has_cookiecutter_json.py
+++ b/tests/repository/test_repository_has_cookiecutter_json.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
-from cookiecutter.repository import repository_has_cookiecutter_json
+
+"""Tests around validation if a given repository contains a (valid) config."""
 
 import pytest
+
+from cookiecutter.repository import repository_has_cookiecutter_json
 
 
 def test_valid_repository():

--- a/tests/test-extensions/custom-extension-post/hooks/post_gen_project.py
+++ b/tests/test-extensions/custom-extension-post/hooks/post_gen_project.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
 # flake8: noqa
+
+"""Sample post-gen hook for testing that custom extensions are available and exposed methods are callable."""
 
 print("{% hello cookiecutter.name %}")

--- a/tests/test-extensions/custom-extension-pre/hooks/pre_gen_project.py
+++ b/tests/test-extensions/custom-extension-pre/hooks/pre_gen_project.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
 # flake8: noqa
+
+"""Sample pre-gen hook for testing that custom extensions are available and exposed methods are callable."""
 
 print("{% hello cookiecutter.name %}")

--- a/tests/test-extensions/hello_extension/hello_extension.py
+++ b/tests/test-extensions/hello_extension/hello_extension.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
+"""Provides custom extension, exposing a ``hello`` command."""
+
 from jinja2 import nodes
 from jinja2.ext import Extension
 
 
 class HelloExtension(Extension):
-    tags = set(["hello"])
+    tags = {"hello"}
 
     def __init__(self, environment):
         """Hello Extension Constructor"""

--- a/tests/test-output-folder/{{cookiecutter.test_name}}/{{cookiecutter.folder_name}}/{{cookiecutter.filename}}.py
+++ b/tests/test-output-folder/{{cookiecutter.test_name}}/{{cookiecutter.folder_name}}/{{cookiecutter.filename}}.py
@@ -1,1 +1,3 @@
-print("This is the contents of {{ cookiecutter.filename }}.py.")
+"""Sample file to be created through a cookiecutter run."""
+
+print("These are the contents of {{ cookiecutter.filename }}.py.")

--- a/tests/test-pyhooks/hooks/post_gen_project.py
+++ b/tests/test-pyhooks/hooks/post_gen_project.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+"""Simple post-gen hook for testing project folder and custom file creation."""
+
 from __future__ import print_function
 
 print("pre generation hook")

--- a/tests/test-pyhooks/hooks/pre_gen_project.py
+++ b/tests/test-pyhooks/hooks/pre_gen_project.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+"""Simple pre-gen hook for testing project folder and custom file creation."""
+
 from __future__ import print_function
 
 print("pre generation hook")

--- a/tests/test-pyshellhooks/hooks/post_gen_project.py
+++ b/tests/test-pyshellhooks/hooks/post_gen_project.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+"""Simple post-gen hook for testing project folder and custom file creation."""
+
 from __future__ import print_function
 
 print("pre generation hook")

--- a/tests/test-pyshellhooks/hooks/pre_gen_project.py
+++ b/tests/test-pyshellhooks/hooks/pre_gen_project.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+"""Simple pre-gen hook for testing project folder and custom file creation."""
+
 from __future__ import print_function
 
 print("pre generation hook")

--- a/tests/test_abort_generate_on_hook_error.py
+++ b/tests/test_abort_generate_on_hook_error.py
@@ -1,9 +1,16 @@
 # -*- coding: utf-8 -*-
 
+"""
+test_abort_generate_on_hook_error
+
+Tests to ensure cookiecutter properly exits with a non-zero exit code whenever
+errors occur in (optional) pre- or pos-gen hooks.
+"""
+
 import pytest
 
-from cookiecutter import generate
 from cookiecutter import exceptions
+from cookiecutter import generate
 
 
 @pytest.mark.usefixtures("clean_system")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 
-import os
+"""Collection of tests around cookiecutter's command-line interface."""
+
 import json
+import os
 
-from click.testing import CliRunner
 import pytest
+from click.testing import CliRunner
 
+from cookiecutter import utils
 from cookiecutter.__main__ import main
 from cookiecutter.main import cookiecutter
-from cookiecutter import utils
 
 
 @pytest.fixture(scope="session")
@@ -178,7 +180,6 @@ def test_cli_overwrite_if_exists_when_output_dir_does_not_exist(
 
 @pytest.mark.usefixtures("make_fake_project_dir", "remove_fake_project_dir")
 def test_cli_overwrite_if_exists_when_output_dir_exists(cli_runner, overwrite_cli_flag):
-
     result = cli_runner("tests/fake-repo-pre/", "--no-input", overwrite_cli_flag,)
     assert result.exit_code == 0
     assert os.path.isdir("fake-project")

--- a/tests/test_cookiecutter_invocation.py
+++ b/tests/test_cookiecutter_invocation.py
@@ -8,9 +8,10 @@ using the entry point set up for the package.
 """
 
 import os
-import pytest
 import subprocess
 import sys
+
+import pytest
 
 from cookiecutter import utils
 

--- a/tests/test_cookiecutter_local_with_input.py
+++ b/tests/test_cookiecutter_local_with_input.py
@@ -7,7 +7,9 @@ Tests formerly known from a unittest residing in test_main.py named
 TestCookiecutterLocalWithInput.test_cookiecutter_local_with_input
 TestCookiecutterLocalWithInput.test_cookiecutter_input_extra_context
 """
+
 import os
+
 import pytest
 
 from cookiecutter import main, utils

--- a/tests/test_custom_extensions_in_hooks.py
+++ b/tests/test_custom_extensions_in_hooks.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import os
+"""
+test_custom_extension_in_hooks
+
+Tests to ensure custom cookiecutter extensions are properly made available to
+pre- and post-gen hooks.
+"""
+
 import codecs
+import os
 
 import pytest
 

--- a/tests/test_default_extensions.py
+++ b/tests/test_default_extensions.py
@@ -1,10 +1,17 @@
 # -*- coding: utf-8 -*-
 
-import os
-import io
+"""
+test_default_extensions
 
-import pytest
+Tests to ensure Jinja2 filters/extensions are available from within pre- and
+post-gen hooks.
+"""
+
+import io
+import os
+
 import freezegun
+import pytest
 
 from cookiecutter.main import cookiecutter
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Collection of tests around loading extensions."""
+
 import pytest
 
 from cookiecutter.environment import StrictEnvironment

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Collection of tests around general exception handling."""
+
 from jinja2.exceptions import UndefinedError
 
 from cookiecutter import exceptions

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 
-"""
-test_find
-
-Tests for `cookiecutter.find` module.
-"""
+"""Tests for `cookiecutter.find` module."""
 
 import os
+
 import pytest
 
 from cookiecutter import find

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -11,10 +11,12 @@ TestGenerateContext.test_generate_context_with_default_and_extra
 """
 
 from __future__ import unicode_literals
-import pytest
+
 import os
 import re
 from collections import OrderedDict
+
+import pytest
 
 from cookiecutter import generate
 from cookiecutter.exceptions import ContextDecodingException

--- a/tests/test_generate_file.py
+++ b/tests/test_generate_file.py
@@ -9,12 +9,13 @@ TestGenerateFile.test_generate_file_verbose_template_syntax_error
 """
 
 from __future__ import unicode_literals
+
 import json
 import os
 
+import pytest
 from jinja2 import FileSystemLoader
 from jinja2.exceptions import TemplateSyntaxError
-import pytest
 
 from cookiecutter import generate
 from cookiecutter.environment import StrictEnvironment

--- a/tests/test_generate_files.py
+++ b/tests/test_generate_files.py
@@ -23,12 +23,14 @@ clean_system teardown code
 """
 
 from __future__ import unicode_literals
-import os
+
 import io
+import os
+
 import pytest
 
-from cookiecutter import generate
 from cookiecutter import exceptions
+from cookiecutter import generate
 from cookiecutter import utils
 
 

--- a/tests/test_generate_hooks.py
+++ b/tests/test_generate_hooks.py
@@ -11,10 +11,12 @@ TestHooks.test_run_shell_hooks
 """
 
 from __future__ import unicode_literals
+
 import errno
 import os
-import sys
 import stat
+import sys
+
 import pytest
 
 from cookiecutter import generate
@@ -90,7 +92,6 @@ def test_empty_hooks():
 
 @pytest.mark.usefixtures("clean_system", "remove_additional_folders")
 def test_oserror_hooks(mocker):
-
     message = "Out of memory"
 
     err = OSError(message)

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
+
+"""Collection of tests around loading cookiecutter config if present."""
+
 import os
+
 import pytest
 
 from cookiecutter import config

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""
-test_hooks
-
-Tests for `cookiecutter.hooks` module.
-"""
+"""Tests for `cookiecutter.hooks` module."""
 
 import os
 import pytest

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Collection of tests around log handling."""
+
 import logging
 
 import pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+"""Collection of tests around cookiecutter's replay feature."""
+
 from cookiecutter.main import cookiecutter
 
 

--- a/tests/test_output_folder.py
+++ b/tests/test_output_folder.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
 
 """
-test_output_folder
+tests_output_folder
 
 Test formerly known from a unittest residing in test_generate.py named
 TestOutputFolder.test_output_folder
 """
 
 from __future__ import unicode_literals
+
 import os
+
 import pytest
 
+from cookiecutter import exceptions
 from cookiecutter import generate
 from cookiecutter import utils
-from cookiecutter import exceptions
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_preferred_encoding.py
+++ b/tests/test_preferred_encoding.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import locale
+"""Collection of tests around character encodings."""
+
 import codecs
-import pytest
+import locale
 import sys
+
+import pytest
 
 PY3 = sys.version_info[0] == 3
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 
-"""
-test_prompt
+"""Tests for `cookiecutter.prompt` module."""
 
-Tests for `cookiecutter.prompt` module.
-"""
-
-from collections import OrderedDict
 import platform
+from collections import OrderedDict
 
 import pytest
 import six

--- a/tests/test_read_repo_password.py
+++ b/tests/test_read_repo_password.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+"""Tests around handling repositories which require authentication."""
+
 from cookiecutter.prompt import read_repo_password
 
 

--- a/tests/test_read_user_choice.py
+++ b/tests/test_read_user_choice.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
+"""Tests around prompting for and handling of choice variables."""
+
 import click
 import pytest
 
 from cookiecutter.prompt import read_user_choice
 
 OPTIONS = ["hello", "world", "foo", "bar"]
-
 
 EXPECTED_PROMPT = """Select varname:
 1 - hello

--- a/tests/test_repo_not_found.py
+++ b/tests/test_repo_not_found.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Testing invalid cookiecutter template repositories."""
+
 import pytest
 
 from cookiecutter import main, exceptions

--- a/tests/test_specify_output_dir.py
+++ b/tests/test_specify_output_dir.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Tests for cookiecutter's output directory customization feature."""
+
 import pytest
 
 from cookiecutter import main

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 
-"""
-test_utils
-
-Tests for `cookiecutter.utils` module.
-"""
+"""Tests for `cookiecutter.utils` module."""
 
 import os
-import pytest
 import stat
 import sys
+
+import pytest
 
 from cookiecutter import utils
 

--- a/tests/undefined-variable/dir-name/{{cookiecutter.project_slug}}/{{cookiecutter.foobar}}/helloworld.py
+++ b/tests/undefined-variable/dir-name/{{cookiecutter.project_slug}}/{{cookiecutter.foobar}}/helloworld.py
@@ -1,0 +1,6 @@
+"""
+Sample Python file.
+
+Expected not to be created in a test due to the undefined variable
+``cookiecutter.foobar``.
+"""

--- a/tests/vcs/test_clone.py
+++ b/tests/vcs/test_clone.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+"""Tests around cloning repositories and detection of errors at it."""
+
 import os
 import subprocess
 

--- a/tests/vcs/test_identify_repo.py
+++ b/tests/vcs/test_identify_repo.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+"""Collection of tests around repository type identification."""
+
 import pytest
 
 from cookiecutter import exceptions, vcs

--- a/tests/vcs/test_is_vcs_installed.py
+++ b/tests/vcs/test_is_vcs_installed.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+"""Collection of tests around VCS detection."""
+
 import pytest
 
 from cookiecutter import vcs


### PR DESCRIPTION
Took the list generated by `pycodestyle --select=D100` and added docstrings for each entry. Also took the liberty to reorder imports in files touched to follow the usual order (builtin-external-internal, `import` before `from .. import ..`, lexicographical).

Solves GH-1269