### PR TITLE
test: enable flake8-docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,4 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-black
+          - flake8-docstrings

--- a/cookiecutter/extensions.py
+++ b/cookiecutter/extensions.py
@@ -30,6 +30,7 @@ class RandomStringExtension(Extension):
     """Jinja2 extension to create a random string."""
 
     def __init__(self, environment):
+        """Jinja2 Extension Constructor"""
         super(RandomStringExtension, self).__init__(environment)
 
         def random_ascii_string(length, punctuation=False):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,8 @@ import sys
 # see: https://docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules  # noqa
 
 
+# flake8: noqa D107,D105
+
 class Mock(object):
     def __init__(self, *args, **kwargs):
         pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,8 @@ tag_name = {new_version}
 
 [flake8]
 # BLK100 excluded temporary until we enable python black
-ignore = E731,BLK100
+# D* added temporary to ease enablement remove them while addressing them
+ignore = E731,BLK100,D100,D101,D102,D103,D200,D202,D205,D400,D401
 
 [bdist_wheel]
 universal = 1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Cookiecutter Test Suites"""

--- a/tests/test-extensions/hello_extension/__init__.py
+++ b/tests/test-extensions/hello_extension/__init__.py
@@ -1,1 +1,2 @@
 # -*- coding: utf-8 -*-
+"""Hello Extension"""

--- a/tests/test-extensions/hello_extension/hello_extension.py
+++ b/tests/test-extensions/hello_extension/hello_extension.py
@@ -8,6 +8,7 @@ class HelloExtension(Extension):
     tags = set(['hello'])
 
     def __init__(self, environment):
+        """Hello Extension Constructor"""
         super(HelloExtension, self).__init__(environment)
 
     def _hello(self, name):

--- a/tests/test_read_user_dict.py
+++ b/tests/test_read_user_dict.py
@@ -90,7 +90,8 @@ def test_should_raise_type_error(mocker):
 
 def test_should_call_prompt_with_process_json(mocker):
     """Test to make sure that process_jon is actually being used
-    to generate a processor for the user input."""
+    to generate a processor for the user input.
+    """
 
     mock_prompt = mocker.patch(
         'cookiecutter.prompt.click.prompt',


### PR DESCRIPTION
Initial enablement of docstrings checks which solves only few rules:
D105, D107, D209

All the others are put with skip and we welcome having them fixed
one by one in individual PR which also remove the skip.

That is the only way such change can be tested correctly on CI.