### PR TITLE
Make template-local extensions available to cookiecutter executions

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -8,12 +8,14 @@ library rather than a script.
 """
 
 from __future__ import unicode_literals
+
 import logging
 import os
+import sys
 
 from cookiecutter.config import get_user_config
-from cookiecutter.generate import generate_context, generate_files
 from cookiecutter.exceptions import InvalidModeException
+from cookiecutter.generate import generate_context, generate_files
 from cookiecutter.prompt import prompt_for_config
 from cookiecutter.replay import dump, load
 from cookiecutter.repository import determine_repo_dir
@@ -74,6 +76,10 @@ def cookiecutter(
     )
 
     template_name = os.path.basename(os.path.abspath(repo_dir))
+
+    # Prepend `repo_dir` to `sys.path` to make template-local extensions
+    # available and loadable to cookiecutter.
+    sys.path.insert(0, repo_dir)
 
     if replay:
         context = load(config_dict["replay_dir"], template_name)

--- a/tests/test_custom_extensions_in_hooks.py
+++ b/tests/test_custom_extensions_in_hooks.py
@@ -9,8 +9,8 @@ from cookiecutter import main
 
 
 @pytest.fixture(
-    params=["custom-extension-pre", "custom-extension-post", ],
-    ids=["pre_gen_hook", "post_gen_hook", ],
+    params=["custom-extension-pre", "custom-extension-post",],
+    ids=["pre_gen_hook", "post_gen_hook",],
 )
 def template(request):
     return "tests/test-extensions/" + request.param
@@ -32,7 +32,7 @@ def test_hook_with_extension(modify_syspath, template, output_dir):
         template,
         no_input=True,
         output_dir=output_dir,
-        extra_context={"project_slug": "foobar", "name": "Cookiemonster", },
+        extra_context={"project_slug": "foobar", "name": "Cookiemonster",},
     )
 
     readme_file = os.path.join(project_dir, "README.rst")
@@ -48,7 +48,7 @@ def test_hook_with_local_extension(template, output_dir):
         template,
         no_input=True,
         output_dir=output_dir,
-        extra_context={"project_slug": "foobar", "name": "Cookiemonster", },
+        extra_context={"project_slug": "foobar", "name": "Cookiemonster",},
     )
 
     readme_file = os.path.join(project_dir, "README.rst")

--- a/tests/test_custom_extensions_in_hooks.py
+++ b/tests/test_custom_extensions_in_hooks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import os
 import codecs
+import os
 
 import pytest
 
@@ -9,8 +9,8 @@ from cookiecutter import main
 
 
 @pytest.fixture(
-    params=["custom-extension-pre", "custom-extension-post",],
-    ids=["pre_gen_hook", "post_gen_hook",],
+    params=["custom-extension-pre", "custom-extension-post", ],
+    ids=["pre_gen_hook", "post_gen_hook", ],
 )
 def template(request):
     return "tests/test-extensions/" + request.param
@@ -21,18 +21,34 @@ def output_dir(tmpdir):
     return str(tmpdir.mkdir("hello"))
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def modify_syspath(monkeypatch):
     # Make sure that the custom extension can be loaded
     monkeypatch.syspath_prepend("tests/test-extensions/hello_extension")
 
 
-def test_hook_with_extension(template, output_dir):
+def test_hook_with_extension(modify_syspath, template, output_dir):
     project_dir = main.cookiecutter(
         template,
         no_input=True,
         output_dir=output_dir,
-        extra_context={"project_slug": "foobar", "name": "Cookiemonster",},
+        extra_context={"project_slug": "foobar", "name": "Cookiemonster", },
+    )
+
+    readme_file = os.path.join(project_dir, "README.rst")
+
+    with codecs.open(readme_file, encoding="utf8") as f:
+        readme = f.read().strip()
+
+    assert readme == "Hello Cookiemonster!"
+
+
+def test_hook_with_local_extension(template, output_dir):
+    project_dir = main.cookiecutter(
+        template,
+        no_input=True,
+        output_dir=output_dir,
+        extra_context={"project_slug": "foobar", "name": "Cookiemonster", },
     )
 
     readme_file = os.path.join(project_dir, "README.rst")


### PR DESCRIPTION
As I am currently writing and refactoring my first cookiecutter template, chances are quite good I am missing on some already existing functionality. 🙂 So please tell me if what I am trying to achieve is already possible.

### Situation

While refactoring my template, I tried extracting common functionality (like formatting and conversion functions) into custom extensions. An example of such a conversion would be to reformat a given project name into a valid Python module name (no leading non-word characters, no leading numbers, non-word characters replaced by underscores). I created an `extensions` below my template's root, made it a module (added `__init__.py`), and wrote said extensions. Finally, I added the extensions to my `cookiecutter.json`'s `_extensions` list; e.g., `"extensions": ["extensions.naming.ModuleNameExtension"]`.

### Issue

As `extensions` is not within my PYTHONPATH, cookiecutter fails to find my modules (custom extensions).

### Proposal

Auto-prepend `repo_dir` to `sys.path` in order to make custom Python modules (e.g., extensions) available to cookiecutter.

Downside: Custom modules might shadow other identically-named modules.