### PR TITLE
Using XDG_CACHE_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ default_context:
 full_name: "Audrey Roy"
 email: "audreyr@gmail.com"
 github_username: "audreyr"
-cookiecutters_dir: "~/.cookiecutters/"
+cookiecutters_dir: "~/$XDG_CACHE_HOME/cookiecutters/"
 ```
 
-* Cookiecutters (cloned Cookiecutter project templates) are put into ``~/.cookiecutters/`` by default, or cookiecutters_dir if specified.
+* Cookiecutters (cloned Cookiecutter project templates) are put into ``$XDG_CACHE_HOME`` by default, or cookiecutters_dir if specified.
 
-* If you have already cloned a cookiecutter into ``~/.cookiecutters/``, you can reference it by directory name:
+* If you have already cloned a cookiecutter into ``$XDG_CACHE_HOME``, you can reference it by directory name:
 
 ```bash
 # Clone cookiecutter-pypackage

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -26,8 +26,8 @@ BUILTIN_ABBREVIATIONS = {
 }
 
 DEFAULT_CONFIG = {
-    'cookiecutters_dir': os.path.expanduser('~/.cookiecutters/'),
-    'replay_dir': os.path.expanduser('~/.cookiecutter_replay/'),
+    'cookiecutters_dir': os.path.expanduser('$XDG_CACHE_HOME/cookiecutters/'),
+    'replay_dir': os.path.expanduser('$XDG_CACHE_HOME/cookiecutter_replay/'),
     'default_context': collections.OrderedDict([]),
     'abbreviations': BUILTIN_ABBREVIATIONS,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,8 +162,9 @@ def user_config_data(user_dir):
 
     :returns: Dict with name of both user config dirs
     """
-    cookiecutters_dir = user_dir.mkdir('cookiecutters')
-    replay_dir = user_dir.mkdir('cookiecutter_replay')
+    cache = os.getenv("XDG_CACHE_HOME", default='~/.cache/')
+    cookiecutters_dir = user_dir.mkdir(os.path.join(cache, 'cookiecutters'))
+    replay_dir = user_dir.mkdir(os.path.join(cache, 'cookiecutter_replay'))
 
     return {
         'cookiecutters_dir': str(cookiecutters_dir),


### PR DESCRIPTION
[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) defines is a single base directory relative to which user-specific non-essential (cached) data should be written. This directory is defined by the environment variable $XDG_CACHE_HOME.

This commit change directories `cookiecutter_replay` and `cookiecutters` where cookiecutter stores its own data.