### PR TITLE
Fix indentation of .cookiecutterrc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ cookiecutter('https://github.com/audreyr/cookiecutter-pypackage.git')
 
 ```yaml
 default_context:
-full_name: "Audrey Roy"
-email: "audreyr@gmail.com"
-github_username: "audreyr"
+    full_name: "Audrey Roy"
+    email: "audreyr@gmail.com"
+    github_username: "audreyr"
 cookiecutters_dir: "~/.cookiecutters/"
 ```
 


### PR DESCRIPTION
Indent fields in `default_context` so that copy-pasting the snippet into `.cookiecutterrc` works.
Yaml is sensitive to indentation and it doesn't work as is now.