### PR TITLE
Update .travis.yml to be compatible with latest travis cfg specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # Config file for automatic testing at travis-ci.org
 dist: xenial
-sudo: false
+os: linux
 language: python
 
-matrix:
+jobs:
     include:
       - python: 3.7
         env: TOXENV=lint


### PR DESCRIPTION

To make sure that our .travis.yml doesn't get errors when validating with https://config.travis-ci.com/explore  it was necessary to


- Removed "sudo: false" because is deprecated
- Renamed "matrix" to "jobs" because "matrix" is deprecated
- Added "os: linux" because now the "os" is required on the root section