### PR TITLE
Configure release-drafter

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,43 @@
+# Format and labels modeled after those used by Ansible project
+#
+# Labels names are important as they are used by Release Drafter to decide
+# regarding where to record them in changelog or if to skip them.
+#
+# https://github.com/marketplace/actions/github-labeler can auto-configure
+# them, but it will never remove already existing ones.
+- name: bug
+  color: "fbca04"
+  description: "This issue/PR relates to a bug."
+- name: deprecated
+  color: "fef2c0"
+  description: "This issue/PR relates to a deprecated module."
+- name: docs
+  color: "4071a5"
+  description: "This issue/PR relates to or includes documentation."
+- name: enhancement
+  color: "ededed"
+  description: "This issue/PR relates to a feature request."
+- name: feature
+  color: "006b75"
+  description: "This issue/PR relates to a feature request."
+- name: major
+  color: "c6476b"
+  description: "Marks an important and likely breaking change."
+- name: packaging
+  color: "4071a5"
+  description: "Packaging category"
+- name: performance
+  color: "555555"
+  description: "Relates to product or testing performance."
+- name: skip-changelog
+  color: "eeeeee"
+  description: "Can be missed from the changelog."
+- name: stale
+  color: "eeeeee"
+  description: "Not updated in long time, will be closed soon."
+- name: wontfix
+  color: "eeeeee"
+  description: "This will not be worked on"
+- name: test
+  color: "0e8a16"
+  description: "This PR relates to tests, QA, CI."

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,4 +1,4 @@
-# Format and labels modeled after those used by Ansible project
+# Format and labels modeled after those used by Cookiecutter project
 #
 # Labels names are important as they are used by Release Drafter to decide
 # regarding where to record them in changelog or if to skip them.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -37,7 +37,7 @@
   description: "Not updated in long time, will be closed soon."
 - name: wontfix
   color: "eeeeee"
-  description: "This will not be worked on"
+  description: "The problem described is a bug which will never be fixed"
 - name: test
   color: "0e8a16"
   description: "This PR relates to tests, QA, CI."

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,7 +19,7 @@
   description: "This issue/PR relates to a feature request."
 - name: feature
   color: "006b75"
-  description: "This issue/PR relates to a feature request."
+  description: "This issue/PR relates to major feature request."
 - name: major
   color: "c6476b"
   description: "Marks an important and likely breaking change."

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,27 @@
+# Format and labels used aim to match those used by Ansible project
+categories:
+  - title: 'Major Changes'
+    labels:
+      - 'major'  # c6476b
+  - title: 'Minor Changes'
+    labels:
+      - 'feature'  # 006b75
+      - 'enhancement'  # ededed
+      - 'performance'  # 555555
+  - title: 'Bugfixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'  # fbca04
+      - 'docs'  # 4071a5
+      - 'packaging'  # 4071a5
+      - 'test'  # #0e8a16
+  - title: 'Deprecations'
+    labels:
+      - 'deprecated'  # fef2c0
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
Release Drafter creates and updates draft release notes based on merged PRs and their labels. The bot is already enabled and does never make any releases, only updates the Draft on
https://github.com/cookiecutter/cookiecutter/releases