### PR TITLE
Drop appveyor referrences

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,8 +132,8 @@ Before you submit a pull request, check that it meets these guidelines:
 
 1. The pull request should include tests.
 2. If the pull request adds functionality, the docs should be updated. Put your new functionality into a function with a docstring, and add the feature to the list in README.md.
-3. The pull request should work for Python 2.7, 3.5, 3.6, 3.7 and PyPy on AppVeyor and Travis CI.
-4. Check [https://travis-ci.org/cookiecutter/cookiecutter/pull_requests](https://travis-ci.org/cookiecutter/cookiecutter/pull_requests) and [https://ci.appveyor.com/project/cookiecutter/cookiecutter/history](https://ci.appveyor.com/project/cookiecutter/cookiecutter/history) to ensure the tests pass for all supported Python versions and platforms.
+3. The pull request must pass all CI/CD jobs before being ready for review.
+4. If one CI/CD job is failing for unrelated reasons you may want to create another PR to fix that first.
 
 ### Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![pypi](https://img.shields.io/pypi/v/cookiecutter.svg)](https://pypi.python.org/pypi/cookiecutter)
 [![python](https://img.shields.io/pypi/pyversions/cookiecutter.svg)](https://pypi.python.org/pypi/cookiecutter)
 [![Build Status](https://travis-ci.org/cookiecutter/cookiecutter.svg?branch=master)](https://travis-ci.org/cookiecutter/cookiecutter)
-[![Appveyor](https://ci.appveyor.com/api/projects/status/github/cookiecutter/cookiecutter?branch=master&svg=true)](https://ci.appveyor.com/project/cookiecutter/cookiecutter/branch/master)
 [![codecov](https://codecov.io/gh/cookiecutter/cookiecutter/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/github/cookiecutter/cookiecutter?branch=master)
 [![slack](https://img.shields.io/badge/cookiecutter-Join%20on%20Slack-green?style=flat&logo=slack)](https://join.slack.com/t/cookie-cutter/shared_invite/enQtNzI0Mzg5NjE5Nzk5LTRlYWI2YTZhYmQ4YmU1Y2Q2NmE1ZjkwOGM0NDQyNTIwY2M4ZTgyNDVkNjMxMDdhZGI5ZGE5YmJjM2M3ODJlY2U)
 [![docs](https://readthedocs.org/projects/cookiecutter/badge/?version=latest)](https://readthedocs.org/projects/cookiecutter/?badge=latest)

--- a/tests/repository/test_is_repo_url.py
+++ b/tests/repository/test_is_repo_url.py
@@ -46,7 +46,7 @@ def test_is_repo_url_for_remote_urls(remote_repo_url):
     '/audreyr/cookiecutter.git',
     '/home/audreyr/cookiecutter',
     (
-        'c:\\users\\appveyor\\appdata\\local\\temp\\1\\pytest-0\\'
+        'c:\\users\\foo\\appdata\\local\\temp\\1\\pytest-0\\'
         'test_default_output_dir0\\template'
     ),
 ])


### PR DESCRIPTION
We no longer need to run AppVeyor because we already have same platforms covered by Travis, in a more reliable format.