### PR TITLE
Remove support for python2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,19 +19,16 @@ jobs:
         name:
           - "linting"
 
-          - "ubuntu-py35"
           - "ubuntu-py36"
           - "ubuntu-py37"
           - "ubuntu-py38"
           - "ubuntu-pypy3"
 
-          - "macos-py35"
           - "macos-py36"
           - "macos-py37"
           - "macos-py38"
           - "macos-pypy3"
 
-          - "windows-py35"
           - "windows-py36"
           - "windows-py37"
           - "windows-py38"
@@ -42,10 +39,6 @@ jobs:
             os: ubuntu-latest
             tox_env: "lint"
 
-          - name: "ubuntu-py35"
-            python: "3.5"
-            os: ubuntu-latest
-            tox_env: "py35"
           - name: "ubuntu-py36"
             python: "3.6"
             os: ubuntu-latest
@@ -63,10 +56,6 @@ jobs:
             os: ubuntu-latest
             tox_env: "pypy3"
 
-          - name: "macos-py35"
-            python: "3.5"
-            os: macos-latest
-            tox_env: "py35"
           - name: "macos-py36"
             python: "3.6"
             os: macos-latest
@@ -84,10 +73,6 @@ jobs:
             os: macos-latest
             tox_env: "pypy3"
 
-          - name: "windows-py35"
-            python: "3.5"
-            os: windows-latest
-            tox_env: "py35"
           - name: "windows-py36"
             python: "3.6"
             os: windows-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,23 +19,18 @@ jobs:
         name:
           - "linting"
 
-          - "ubuntu-py27"
           - "ubuntu-py35"
           - "ubuntu-py36"
           - "ubuntu-py37"
           - "ubuntu-py38"
-          - "ubuntu-pypy"
           - "ubuntu-pypy3"
 
-          - "macos-py27"
           - "macos-py35"
           - "macos-py36"
           - "macos-py37"
           - "macos-py38"
-          - "macos-pypy"
           - "macos-pypy3"
 
-          - "windows-py27"
           - "windows-py35"
           - "windows-py36"
           - "windows-py37"
@@ -47,10 +42,6 @@ jobs:
             os: ubuntu-latest
             tox_env: "lint"
 
-          - name: "ubuntu-py27"
-            python: "2.7"
-            os: ubuntu-latest
-            tox_env: "py27"
           - name: "ubuntu-py35"
             python: "3.5"
             os: ubuntu-latest
@@ -67,19 +58,11 @@ jobs:
             python: "3.8"
             os: ubuntu-latest
             tox_env: "py38"
-          - name: "ubuntu-pypy"
-            python: "pypy2"
-            os: ubuntu-latest
-            tox_env: "pypy"
           - name: "ubuntu-pypy3"
             python: "pypy3"
             os: ubuntu-latest
             tox_env: "pypy3"
 
-          - name: "macos-py27"
-            python: "2.7"
-            os: macos-latest
-            tox_env: "py27"
           - name: "macos-py35"
             python: "3.5"
             os: macos-latest
@@ -96,19 +79,11 @@ jobs:
             python: "3.8"
             os: macos-latest
             tox_env: "py38"
-          - name: "macos-pypy"
-            python: "pypy2"
-            os: macos-latest
-            tox_env: "pypy"
           - name: "macos-pypy3"
             python: "pypy3"
             os: macos-latest
             tox_env: "pypy3"
 
-          - name: "windows-py27"
-            python: "2.7"
-            os: windows-latest
-            tox_env: "py27"
           - name: "windows-py35"
             python: "3.5"
             os: windows-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ jobs:
     include:
       - python: 3.7
         env: TOXENV=lint
-      - python: 2.7
-        env: TOXENV=py27
       - python: 3.5
         env: TOXENV=py35
       - python: 3.6
@@ -17,23 +15,8 @@ jobs:
         env: TOXENV=py37
       - python: 3.8
         env: TOXENV=py38
-      - python: pypy
-        env: TOXENV=pypy
       - python: pypy3
         env: TOXENV=pypy3
-      - name: "Python 2.7 on Windows"
-        os: windows
-        language: shell
-        before_install:
-          - choco install python2
-          - python --version
-          - python -m pip install --upgrade pip
-          - pip install --upgrade virtualenv wheel
-          - virtualenv $HOME/venv
-          - source $HOME/venv/Scripts/activate
-        env:
-          - TOXENV=py27
-          - PATH=/c/Python27:/c/Python27/Scripts:$PATH
       - name: "Python 3.5 on Windows"
         os: windows
         language: shell
@@ -41,8 +24,8 @@ jobs:
           - choco install python --version 3.5.4
           - python --version
           - python -m pip install --upgrade pip
-          - pip3 install --upgrade virtualenv wheel
-          - virtualenv $HOME/venv
+          - python -m pip install --upgrade virtualenv wheel
+          - python -m virtualenv $HOME/venv
           - source $HOME/venv/Scripts/activate
         env:
           - TOXENV=py35
@@ -54,8 +37,8 @@ jobs:
           - choco install python --version 3.6.7
           - python --version
           - python -m pip install --upgrade pip
-          - pip3 install --upgrade virtualenv wheel
-          - virtualenv $HOME/venv
+          - python -m pip install --upgrade virtualenv wheel
+          - python -m virtualenv $HOME/venv
           - source $HOME/venv/Scripts/activate
         env:
           - TOXENV=py36
@@ -67,8 +50,8 @@ jobs:
           - choco install python --version 3.7.2
           - python --version
           - python -m pip install --upgrade pip
-          - pip3 install --upgrade virtualenv wheel
-          - virtualenv $HOME/venv
+          - python -m pip install --upgrade virtualenv wheel
+          - python -m virtualenv $HOME/venv
           - source $HOME/venv/Scripts/activate
         env:
           - TOXENV=py37
@@ -80,8 +63,8 @@ jobs:
           - choco install python --version 3.8.0
           - python --version
           - python -m pip install --upgrade pip
-          - pip3 install --upgrade virtualenv wheel
-          - virtualenv $HOME/venv
+          - python -m pip install --upgrade virtualenv wheel
+          - python -m virtualenv $HOME/venv
           - source $HOME/venv/Scripts/activate
         env:
           - TOXENV=py38
@@ -90,11 +73,10 @@ jobs:
 script: tox
 
 install:
-    - pip install tox
-
+    - python -m pip install tox
 
 after_success:
     # Report coverage results to codecov.io
     # and export tox environment variables
-    - pip install codecov
+    - python -m pip install codecov
     - codecov -e TOXENV TRAVIS_OS_NAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,3 +59,9 @@ script: tox
 
 install:
     - python -m pip install tox
+
+after_success:
+    # Report coverage results to codecov.io
+    # and export tox environment variables
+    - pip install codecov
+    - codecov -e TOXENV TRAVIS_OS_NAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ jobs:
     include:
       - python: 3.7
         env: TOXENV=lint
-      - python: 3.5
-        env: TOXENV=py35
       - python: 3.6
         env: TOXENV=py36
       - python: 3.7
@@ -17,19 +15,6 @@ jobs:
         env: TOXENV=py38
       - python: pypy3
         env: TOXENV=pypy3
-      - name: "Python 3.5 on Windows"
-        os: windows
-        language: shell
-        before_install:
-          - choco install python --version 3.5.4
-          - python --version
-          - python -m pip install --upgrade pip
-          - python -m pip install --upgrade virtualenv wheel
-          - python -m virtualenv $HOME/venv
-          - source $HOME/venv/Scripts/activate
-        env:
-          - TOXENV=py35
-          - PATH=/c/Python35:/c/Python35/Scripts:$PATH
       - name: "Python 3.6 on Windows"
         os: windows
         language: shell
@@ -74,9 +59,3 @@ script: tox
 
 install:
     - python -m pip install tox
-
-after_success:
-    # Report coverage results to codecov.io
-    # and export tox environment variables
-    - python -m pip install codecov
-    - codecov -e TOXENV TRAVIS_OS_NAME

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,10 +198,10 @@ This configuration file setup the pytest-cov plugin and it is an additional depe
 It is possible to tests with some versions of python, to do this the command is:
 
 ```bash
-tox -e py27,py35,pypy
+tox -e py36,pypy3
 ```
 
-Will run py.test with the python2.7, python3.5 and pypy interpreters, for example.
+Will run py.test with the python3.6 and pypy3 interpreters, for example.
 
 ## Core Committer Guide
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Did someone say features?
 
 * Cross-platform: Windows, Mac, and Linux are officially supported.
 * You don't have to know/write Python code to use Cookiecutter
-* Works with Python 3.5, 3.6, 3.7, 3.8 and PyPy3.
+* Works with Python 3.6, 3.7, 3.8 and PyPy3.
 * Project templates can be in any programming language or markup format:
   Python, JavaScript, Ruby, CoffeeScript, RST, Markdown, CSS, HTML, you name it.
   You can use multiple languages in the same project template.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Did someone say features?
 
 * Cross-platform: Windows, Mac, and Linux are officially supported.
 * You don't have to know/write Python code to use Cookiecutter
-* Works with Python 2.7, 3.5, 3.6, 3.7, 3.8 ,PyPy and PyPy3.
-* Project templates can be in any programming language or markup format:  
-  Python, JavaScript, Ruby, CoffeeScript, RST, Markdown, CSS, HTML, you name it.  
+* Works with Python 3.5, 3.6, 3.7, 3.8 and PyPy3.
+* Project templates can be in any programming language or markup format:
+  Python, JavaScript, Ruby, CoffeeScript, RST, Markdown, CSS, HTML, you name it.
   You can use multiple languages in the same project template.
 * Simple command line usage:
 

--- a/cookiecutter/vcs.py
+++ b/cookiecutter/vcs.py
@@ -6,11 +6,8 @@ from __future__ import unicode_literals
 import logging
 import os
 import subprocess
+from shutil import which
 
-try:
-    from shutil import which
-except ImportError:
-    from whichcraft import which
 
 from cookiecutter.exceptions import (
     RepositoryNotFound,

--- a/cookiecutter/zipfile.py
+++ b/cookiecutter/zipfile.py
@@ -4,15 +4,10 @@ from __future__ import absolute_import
 
 import os
 import tempfile
+from zipfile import BadZipFile
 from zipfile import ZipFile
-
 import requests
 
-try:
-    # BadZipfile was renamed to BadZipFile in Python 3.2.
-    from zipfile import BadZipFile
-except ImportError:
-    from zipfile import BadZipfile as BadZipFile
 
 from cookiecutter.exceptions import InvalidZipRepository
 from cookiecutter.prompt import read_repo_password

--- a/cookiecutter/zipfile.py
+++ b/cookiecutter/zipfile.py
@@ -4,10 +4,9 @@ from __future__ import absolute_import
 
 import os
 import tempfile
-from zipfile import BadZipFile
-from zipfile import ZipFile
-import requests
+from zipfile import BadZipFile, ZipFile
 
+import requests
 
 from cookiecutter.exceptions import InvalidZipRepository
 from cookiecutter.prompt import read_repo_password

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -59,7 +59,7 @@ You may also install  `Windows Subsystem for Linux <https://msdn.microsoft.com/e
 Packaging tools
 ^^^^^^^^^^^^^^^
 
-``pip`` and ``setuptools`` now come with Python 3 >=3.5. See the Python Packaging Authority's (PyPA) documentation `Requirements for Installing Packages <https://packaging.python.org/en/latest/installing/#requirements-for-installing-packages>`_ for full details.
+``pip`` and ``setuptools`` now come with Python 3 >=3.6. See the Python Packaging Authority's (PyPA) documentation `Requirements for Installing Packages <https://packaging.python.org/en/latest/installing/#requirements-for-installing-packages>`_ for full details.
 
 
 Install cookiecutter

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -18,7 +18,6 @@ You can install the Python binaries from `python.org <https://www.python.org/dow
 
 .. code-block:: bash
 
-    # for python 3.x
     $ brew install python3
 
 
@@ -60,7 +59,7 @@ You may also install  `Windows Subsystem for Linux <https://msdn.microsoft.com/e
 Packaging tools
 ^^^^^^^^^^^^^^^
 
-``pip`` and ``setuptools`` now come with Python 2 >=2.7.9 or Python 3 >=3.5. See the Python Packaging Authority's (PyPA) documentation `Requirements for Installing Packages <https://packaging.python.org/en/latest/installing/#requirements-for-installing-packages>`_ for full details.
+``pip`` and ``setuptools`` now come with Python 3 >=3.5. See the Python Packaging Authority's (PyPA) documentation `Requirements for Installing Packages <https://packaging.python.org/en/latest/installing/#requirements-for-installing-packages>`_ for full details.
 
 
 Install cookiecutter
@@ -70,7 +69,7 @@ At the command line:
 
 .. code-block:: bash
 
-    $ pip install --user cookiecutter
+    $ python3 -m pip install --user cookiecutter
 
 Or, if you do not have pip:
 
@@ -133,6 +132,6 @@ Or with pip:
 
 .. code-block:: bash
 
-    $ pip install --upgrade cookiecutter
+    $ python3 -m pip install --upgrade cookiecutter
 
 Then you should be good to go.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 skip-string-normalization = true
 exclude = '/(tests/hooks-abort-render/hooks|docs\/HelloCookieCutter1)/'
 line-length = 88
-target-version = ['py27']
+target-version = ['py35']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 skip-string-normalization = true
 exclude = '/(tests/hooks-abort-render/hooks|docs\/HelloCookieCutter1)/'
 line-length = 88
-target-version = ['py35']
+target-version = ['py36']

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     package_dir={'cookiecutter': 'cookiecutter'},
     entry_points={'console_scripts': ['cookiecutter = cookiecutter.__main__:main']},
     include_package_data=True,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=requirements,
     license='BSD',
     zip_safe=False,
@@ -70,7 +70,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -79,9 +78,16 @@ setup(
         "Programming Language :: Python",
         "Topic :: Software Development",
     ],
-    keywords=(
-        'cookiecutter, Python, projects, project templates, Jinja2, '
-        'skeleton, scaffolding, project directory, setup.py, package, '
-        'packaging'
-    ),
+    keywords=[
+        "cookiecutter",
+        "Python",
+        "projects",
+        "project templates",
+        "Jinja2",
+        "skeleton",
+        "scaffolding",
+        "project directory",
+        "package",
+        "packaging",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 
 from setuptools import setup
 
-version = "1.7.2"
+version = "2.0.0"
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
@@ -58,9 +58,8 @@ setup(
     package_dir={'cookiecutter': 'cookiecutter'},
     entry_points={'console_scripts': ['cookiecutter = cookiecutter.__main__:main']},
     include_package_data=True,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5',
     install_requires=requirements,
-    extras_require={':python_version<"3.3"': ['whichcraft>=0.4.0']},
     license='BSD',
     zip_safe=False,
     classifiers=[
@@ -69,9 +68,7 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
@@ -79,6 +76,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
+        "Programming Language :: Python",
         "Topic :: Software Development",
     ],
     keywords=(

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
 envlist =
     lint
-    py27
     py35
     py36
     py37
     py38
-    pypy
     pypy3
 minversion = 3.14.2
 requires =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     lint
-    py35
     py36
     py37
     py38


### PR DESCRIPTION
Python 2.7 is officially dead and we are not going to make any new release that supports it.

This removes py27 code but a follow-up will address other changes like removing use of `six`.

Major version is bumped to 1.8.0 to mark this breaking change.