### PR TITLE
Fixed: Replaced no longer maintained pipsi by pipx

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -101,11 +101,11 @@ Alternate installations
 
     $ brew install cookiecutter
 
-**Pipsi (Linux/OSX only):**
+**Pipx (Linux, OSX and Windows):**
 
 .. code-block:: bash
 
-    $ pipsi install cookiecutter
+    $ pipx install cookiecutter
 
 **Debian/Ubuntu:**
 


### PR DESCRIPTION
Pipsi is no longer maintained (from the [pipsi github page](https://github.com/mitsuhiko/pipsi/)).