### PR TITLE
feat: don't call Popen for python hooks

### DIFF
--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -64,6 +64,16 @@ def find_hook(hook_name, hooks_dir='hooks'):
 
     return None
 
+def run_python_script(script_path, cwd='.'):
+    """Execute a python script from a working directory.
+
+    :param script_path: Absolute path to the script to run.
+    :param cwd: The directory to run the script from.
+    """
+    old_cwd = os.getcwd()
+    os.chdir(cwd)
+    exec(open(script_path).read())
+    os.chdir(old_cwd)
 
 def run_script(script_path, cwd='.'):
     """Execute a script from a working directory.
@@ -73,7 +83,8 @@ def run_script(script_path, cwd='.'):
     """
     run_thru_shell = sys.platform.startswith('win')
     if script_path.endswith('.py'):
-        script_command = [sys.executable, script_path]
+        run_python_script(script_path, cwd)
+        return
     else:
         script_command = [script_path]
 


### PR DESCRIPTION
I want to run cookiecutter with untrusted templates.

One way to do it is run cookiecutter in a sandbox environment such as the the ones in pypy, jython and ironpython.   In such sandbox, I can prevent the untrusted template from modifying files outside the generated project.

The challenge is that the hooks are invoked using subprocess.Popen.  Sandboxes cannot allow Popen, because the child process would escape the sandbox. 

This PR uses python's exec to run the hook code within the same process and remain sandboxed.

Note the tests don't pass because some of the tests invoke sys.exit(1),  which just exits cookiecutter itself.  Looking for feedback for ways to solve this.
 