### PR TITLE
Python3: Changed io.open to build-in open (PEP3116)

### DIFF
--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -1,7 +1,6 @@
 """Global configuration handling."""
 import collections
 import copy
-import io
 import logging
 import os
 
@@ -61,7 +60,7 @@ def get_config(config_path):
         )
 
     logger.debug('config_path is %s', config_path)
-    with io.open(config_path, encoding='utf-8') as file_handle:
+    with open(config_path, encoding='utf-8') as file_handle:
         try:
             yaml_dict = poyo.parse_string(file_handle.read())
         except poyo.exceptions.PoyoException as e:

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -1,6 +1,5 @@
 """Functions for generating a project from a project template."""
 import fnmatch
-import io
 import json
 import logging
 import os
@@ -172,7 +171,7 @@ def generate_file(project_dir, infile, context, env, skip_if_file_exists=False):
 
         # Detect original file newline to output the rendered file
         # note: newline='' ensures newlines are not converted
-        with io.open(infile, 'r', encoding='utf-8', newline='') as rd:
+        with open(infile, 'r', encoding='utf-8', newline='') as rd:
             rd.readline()  # Read the first line to load 'newlines' value
 
             # Use `_new_lines` overwrite from context, if configured.
@@ -183,7 +182,7 @@ def generate_file(project_dir, infile, context, env, skip_if_file_exists=False):
 
         logger.debug('Writing contents to file %s', outfile)
 
-        with io.open(outfile, 'w', encoding='utf-8', newline=newline) as fh:
+        with open(outfile, 'w', encoding='utf-8', newline=newline) as fh:
             fh.write(rendered_file)
 
     # Apply file permissions to output file

--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -1,6 +1,5 @@
 """Functions for discovering and executing various cookiecutter hooks."""
 import errno
-import io
 import logging
 import os
 import subprocess
@@ -100,7 +99,7 @@ def run_script_with_context(script_path, cwd, context):
     """
     _, extension = os.path.splitext(script_path)
 
-    with io.open(script_path, 'r', encoding='utf-8') as file:
+    with open(script_path, 'r', encoding='utf-8') as file:
         contents = file.read()
 
     with tempfile.NamedTemporaryFile(delete=False, mode='wb', suffix=extension) as temp:

--- a/tests/repository/test_determine_repo_dir_finds_existing_cookiecutter.py
+++ b/tests/repository/test_determine_repo_dir_finds_existing_cookiecutter.py
@@ -1,5 +1,4 @@
 """Tests around detection whether cookiecutter templates are cached locally."""
-import io
 import os
 
 import pytest
@@ -21,7 +20,7 @@ def cloned_cookiecutter_path(user_config_data, template):
     cloned_template_path = os.path.join(cookiecutters_dir, template)
     os.mkdir(cloned_template_path)
 
-    io.open(os.path.join(cloned_template_path, 'cookiecutter.json'), 'w')
+    open(os.path.join(cloned_template_path, 'cookiecutter.json'), 'w')
 
     return cloned_template_path
 

--- a/tests/repository/test_determine_repo_dir_finds_subdirectories.py
+++ b/tests/repository/test_determine_repo_dir_finds_subdirectories.py
@@ -1,5 +1,4 @@
 """Tests around locally cached cookiecutter template repositories."""
-import io
 import os
 
 import pytest
@@ -25,7 +24,7 @@ def cloned_cookiecutter_path(user_config_data, template):
     subdir_template_path = os.path.join(cloned_template_path, 'my-dir')
     if not os.path.exists(subdir_template_path):
         os.mkdir(subdir_template_path)
-    io.open(os.path.join(subdir_template_path, 'cookiecutter.json'), 'w')
+    open(os.path.join(subdir_template_path, 'cookiecutter.json'), 'w')
 
     return subdir_template_path
 

--- a/tests/test_default_extensions.py
+++ b/tests/test_default_extensions.py
@@ -1,5 +1,4 @@
 """Verify Jinja2 filters/extensions are available from pre-gen/post-gen hooks."""
-import io
 import os
 
 import freezegun
@@ -25,7 +24,7 @@ def test_jinja2_time_extension(tmpdir):
     changelog_file = os.path.join(project_dir, 'HISTORY.rst')
     assert os.path.isfile(changelog_file)
 
-    with io.open(changelog_file, 'r', encoding='utf-8') as f:
+    with open(changelog_file, 'r', encoding='utf-8') as f:
         changelog_lines = f.readlines()
 
     expected_lines = [

--- a/tests/test_generate_files.py
+++ b/tests/test_generate_files.py
@@ -3,7 +3,6 @@
 Use the global clean_system fixture and run additional teardown code to remove
 some special folders.
 """
-import io
 import os
 from pathlib import Path
 
@@ -62,7 +61,7 @@ def test_generate_files_with_linux_newline(tmp_path):
     assert newline_file.is_file()
     assert newline_file.exists()
 
-    with io.open(newline_file, 'r', encoding='utf-8', newline='') as f:
+    with open(newline_file, 'r', encoding='utf-8', newline='') as f:
         simple_text = f.readline()
     assert simple_text == 'newline is LF\n'
     assert f.newlines == '\n'
@@ -81,7 +80,7 @@ def test_generate_files_with_trailing_newline_forced_to_linux_by_context(tmp_pat
     assert newline_file.is_file()
     assert newline_file.exists()
 
-    with io.open(newline_file, 'r', encoding='utf-8', newline='') as f:
+    with open(newline_file, 'r', encoding='utf-8', newline='') as f:
         simple_text = f.readline()
     assert simple_text == 'newline is LF\r\n'
     assert f.newlines == '\r\n'
@@ -99,7 +98,7 @@ def test_generate_files_with_windows_newline(tmp_path):
     assert newline_file.is_file()
     assert newline_file.exists()
 
-    with io.open(newline_file, 'r', encoding='utf-8', newline='') as f:
+    with open(newline_file, 'r', encoding='utf-8', newline='') as f:
         simple_text = f.readline()
     assert simple_text == 'newline is CRLF\r\n'
     assert f.newlines == '\r\n'
@@ -117,7 +116,7 @@ def test_generate_files_with_windows_newline_forced_to_linux_by_context(tmp_path
     assert newline_file.is_file()
     assert newline_file.exists()
 
-    with io.open(newline_file, 'r', encoding='utf-8', newline='') as f:
+    with open(newline_file, 'r', encoding='utf-8', newline='') as f:
         simple_text = f.readline()
 
     assert simple_text == 'newline is CRLF\n'
@@ -238,7 +237,7 @@ def test_generate_files_with_overwrite_if_exists_with_skip_if_file_exists(tmp_pa
     assert Path(simple_with_new_line_file).is_file()
     assert Path(simple_with_new_line_file).exists()
 
-    simple_text = io.open(simple_file, 'rt', encoding='utf-8').read()
+    simple_text = open(simple_file, 'rt', encoding='utf-8').read()
     assert simple_text == 'temp'
 
 
@@ -264,7 +263,7 @@ def test_generate_files_with_skip_if_file_exists(tmp_path):
     assert not Path(simple_with_new_line_file).is_file()
     assert not Path(simple_with_new_line_file).exists()
 
-    simple_text = io.open(simple_file, 'rt', encoding='utf-8').read()
+    simple_text = open(simple_file, 'rt', encoding='utf-8').read()
     assert simple_text == 'temp'
 
 
@@ -289,7 +288,7 @@ def test_generate_files_with_overwrite_if_exists(tmp_path):
     assert Path(simple_with_new_line_file).is_file()
     assert Path(simple_with_new_line_file).exists()
 
-    simple_text = io.open(simple_file, 'rt', encoding='utf-8').read()
+    simple_text = open(simple_file, 'rt', encoding='utf-8').read()
     assert simple_text == 'I eat pizzä'
 
 


### PR DESCRIPTION
Import of `io` module was required in python <3. 
Since python 3 `open` is alias for `io.open` and direct import of `io` module not required.