### PR TITLE
Implement cloning before deleting existing template

### DIFF
--- a/cookiecutter/utils.py
+++ b/cookiecutter/utils.py
@@ -5,7 +5,6 @@ import logging
 import os
 import shutil
 import stat
-import sys
 
 from cookiecutter.prompt import read_user_yes_no
 
@@ -69,16 +68,13 @@ def make_executable(script_path):
     os.chmod(script_path, status.st_mode | stat.S_IEXEC)
 
 
-def prompt_and_delete(path, no_input=False):
+def prompt_ok_to_delete(path, no_input=False):
     """
     Ask user if it's okay to delete the previously-downloaded file/directory.
 
-    If yes, delete it. If no, checks to see if the old version should be
-    reused. If yes, it's reused; otherwise, Cookiecutter exits.
-
     :param path: Previously downloaded zipfile.
-    :param no_input: Suppress prompt to delete repo and just delete it.
-    :return: True if the content was deleted
+    :param no_input: Suppress prompt.
+    :return: True if the content will be deleted.
     """
     # Suppress prompt if called via API
     if no_input:
@@ -89,19 +85,21 @@ def prompt_and_delete(path, no_input=False):
         ).format(path)
 
         ok_to_delete = read_user_yes_no(question, 'yes')
+    return ok_to_delete
 
-    if ok_to_delete:
-        if os.path.isdir(path):
-            rmtree(path)
-        else:
-            os.remove(path)
-        return True
+
+def prompt_ok_to_reuse(path, no_input=False):
+    """
+    Ask user if it's okay to reuse the previously-downloaded file/directory.
+
+    :param path: Previously downloaded zipfile.
+    :param no_input: Suppress prompt.
+    :return: True if the content will be re-used.
+    """
+    if no_input:
+        ok_to_reuse = False
     else:
         ok_to_reuse = read_user_yes_no(
             "Do you want to re-use the existing version?", 'yes'
         )
-
-        if ok_to_reuse:
-            return False
-
-        sys.exit()
+    return ok_to_reuse

--- a/cookiecutter/vcs.py
+++ b/cookiecutter/vcs.py
@@ -2,7 +2,12 @@
 import logging
 import os
 import subprocess
-from shutil import which
+from shutil import (
+    which,
+    move,
+)
+import sys
+import tempfile
 
 from cookiecutter.exceptions import (
     RepositoryCloneFailed,
@@ -10,7 +15,12 @@ from cookiecutter.exceptions import (
     UnknownRepoType,
     VCSNotInstalled,
 )
-from cookiecutter.utils import make_sure_path_exists, prompt_and_delete
+from cookiecutter.utils import (
+    make_sure_path_exists,
+    prompt_ok_to_delete,
+    prompt_ok_to_reuse,
+    rmtree,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -85,36 +95,81 @@ def clone(repo_url, checkout=None, clone_to_dir='.', no_input=False):
         repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))
     logger.debug('repo_dir is {0}'.format(repo_dir))
 
-    if os.path.isdir(repo_dir):
-        clone = prompt_and_delete(repo_dir, no_input=no_input)
-    else:
-        clone = True
-
-    if clone:
-        try:
-            subprocess.check_output(
-                [repo_type, 'clone', repo_url],
-                cwd=clone_to_dir,
-                stderr=subprocess.STDOUT,
-            )
-            if checkout is not None:
-                subprocess.check_output(
-                    [repo_type, 'checkout', checkout],
-                    cwd=repo_dir,
-                    stderr=subprocess.STDOUT,
-                )
-        except subprocess.CalledProcessError as clone_error:
-            output = clone_error.output.decode('utf-8')
-            if 'not found' in output.lower():
-                raise RepositoryNotFound(
-                    'The repository {} could not be found, '
-                    'have you made a typo?'.format(repo_url)
-                )
-            if any(error in output for error in BRANCH_ERRORS):
-                raise RepositoryCloneFailed(
-                    'The {} branch of repository {} could not found, '
-                    'have you made a typo?'.format(checkout, repo_url)
-                )
-            raise
-
+    if _need_to_clone(repo_dir, no_input):
+        _delete_old_and_clone_new(
+            repo_dir, repo_url, repo_type, clone_to_dir, checkout,
+        )
     return repo_dir
+
+
+def _need_to_clone(repo_dir, no_input):
+    ok_to_delete = prompt_ok_to_delete(repo_dir, no_input=no_input)
+
+    if ok_to_delete:
+        ok_to_reuse = False
+    else:
+        ok_to_reuse = prompt_ok_to_reuse(repo_dir, no_input=no_input)
+
+    if not ok_to_delete and not ok_to_reuse:
+        sys.exit()
+
+    need_to_clone = ok_to_delete and not ok_to_reuse
+    return need_to_clone
+
+
+def _delete_old_and_clone_new(repo_dir, repo_url, repo_type, clone_to_dir, checkout):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        backup_performed = os.path.exists(repo_dir)
+        if backup_performed:
+            backup_dir = os.path.join(tmp_dir, os.path.basename(repo_dir))
+            _backup_and_delete_repo(repo_dir, backup_dir)
+
+        try:
+            _clone_repo(repo_dir, repo_url, repo_type, clone_to_dir, checkout)
+        except subprocess.CalledProcessError as clone_error:
+            if backup_performed:
+                _restore_old_repo(repo_dir, backup_dir)
+            _handle_clone_error(clone_error, repo_url, checkout)
+
+
+def _clone_repo(repo_dir, repo_url, repo_type, clone_to_dir, checkout):
+    subprocess.check_output(
+        [repo_type, 'clone', repo_url], cwd=clone_to_dir, stderr=subprocess.STDOUT,
+    )
+    if checkout is not None:
+        subprocess.check_output(
+            [repo_type, 'checkout', checkout], cwd=repo_dir, stderr=subprocess.STDOUT,
+        )
+
+
+def _handle_clone_error(clone_error, repo_url, checkout):
+    output = clone_error.output.decode('utf-8')
+    if 'not found' in output.lower():
+        raise RepositoryNotFound(
+            'The repository {} could not be found, '
+            'have you made a typo?'.format(repo_url)
+        )
+    if any(error in output for error in BRANCH_ERRORS):
+        raise RepositoryCloneFailed(
+            'The {} branch of repository {} could not found, '
+            'have you made a typo?'.format(checkout, repo_url)
+        )
+    raise
+
+
+def _backup_and_delete_repo(path, backup_path):
+    logger.info('Backing up repo {} to {}'.format(path, backup_path))
+    move(path, backup_path)
+    logger.info('Moving repo {} to {}'.format(path, backup_path))
+
+
+def _restore_old_repo(path, backup_path):
+    try:
+        rmtree(path)
+        logger.info('Cleaning {}'.format(path))
+    except FileNotFoundError:
+        pass
+
+    logger.info('Restoring backup repo {}'.format(backup_path))
+    move(backup_path, path)
+    logger.info('Restored {} successfully'.format(path))

--- a/cookiecutter/zipfile.py
+++ b/cookiecutter/zipfile.py
@@ -7,7 +7,7 @@ import requests
 
 from cookiecutter.exceptions import InvalidZipRepository
 from cookiecutter.prompt import read_repo_password
-from cookiecutter.utils import make_sure_path_exists, prompt_and_delete
+from cookiecutter.utils import make_sure_path_exists, prompt_ok_to_delete
 
 
 def unzip(zip_uri, is_url, clone_to_dir='.', no_input=False, password=None):
@@ -34,7 +34,7 @@ def unzip(zip_uri, is_url, clone_to_dir='.', no_input=False, password=None):
         zip_path = os.path.join(clone_to_dir, identifier)
 
         if os.path.exists(zip_path):
-            download = prompt_and_delete(zip_path, no_input=no_input)
+            download = prompt_ok_to_delete(zip_path, no_input=no_input)
         else:
             download = True
 

--- a/tests/test_cookiecutter_local_no_input.py
+++ b/tests/test_cookiecutter_local_no_input.py
@@ -128,7 +128,7 @@ def test_cookiecutter_template_cleanup(mocker):
     mocker.patch('tempfile.mkdtemp', return_value='fake-tmp', autospec=True)
 
     mocker.patch(
-        'cookiecutter.utils.prompt_and_delete', return_value=True, autospec=True
+        'cookiecutter.utils.prompt_ok_to_delete', return_value=True, autospec=True
     )
 
     main.cookiecutter('tests/files/fake-repo-tmpl.zip', no_input=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,130 +87,56 @@ def test_work_in(tmp_path):
     assert cwd == Path.cwd()
 
 
-def test_prompt_should_ask_and_rm_repo_dir(mocker, tmp_path):
-    """In `prompt_and_delete()`, if the user agrees to delete/reclone the \
-    repo, the repo should be deleted."""
+def test_prompt_ok_to_delete_reads_user_yes(mocker):
+    """In `prompt_ok_to_delete()` the user answers yes."""
     mock_read_user = mocker.patch(
         'cookiecutter.utils.read_user_yes_no', return_value=True
     )
-    repo_dir = Path(tmp_path, 'repo')
-    repo_dir.mkdir()
+    ok_to_delete = utils.prompt_ok_to_delete('path/to/repo')
 
-    deleted = utils.prompt_and_delete(str(repo_dir))
-
-    assert mock_read_user.called
-    assert not repo_dir.exists()
-    assert deleted
+    assert mock_read_user.called_once
+    assert ok_to_delete
 
 
-def test_prompt_should_ask_and_exit_on_user_no_answer(mocker, tmp_path):
-    """In `prompt_and_delete()`, if the user decline to delete/reclone the \
-    repo, cookiecutter should exit."""
+def test_prompt_ok_to_delete_reads_user_no(mocker):
+    """In `prompt_ok_to_delete()` the user answers no."""
+    mock_read_user = mocker.patch(
+        'cookiecutter.utils.read_user_yes_no', return_value=False
+    )
+    ok_to_delete = utils.prompt_ok_to_delete('path/to/repo')
+
+    assert mock_read_user.called_once
+    assert not ok_to_delete
+
+
+def test_prompt_ok_to_delete_no_user_input(mocker):
+    """In `prompt_ok_to_delete()` no user input means yes."""
+    mock_read_user = mocker.patch(
+        'cookiecutter.utils.read_user_yes_no', return_value=False
+    )
+    ok_to_delete = utils.prompt_ok_to_delete('path/to/repo', no_input=True)
+
+    assert not mock_read_user.called
+    assert ok_to_delete
+
+
+def test_prompt_ok_to_reuse(mocker):
+    """In `prompt_ok_to_reuse()` check that the user Yes is read."""
+    mock_read_user = mocker.patch(
+        'cookiecutter.utils.read_user_yes_no', return_value=True,
+    )
+    ok_to_reuse = utils.prompt_ok_to_reuse('any_path')
+
+    assert mock_read_user.called_once
+    assert ok_to_reuse
+
+
+def test_prompt_not_ok_to_reuse(mocker):
+    """In `prompt_ok_to_reuse()` check that the user No is read."""
     mock_read_user = mocker.patch(
         'cookiecutter.utils.read_user_yes_no', return_value=False,
     )
-    mock_sys_exit = mocker.patch('sys.exit', return_value=True)
-    repo_dir = Path(tmp_path, 'repo')
-    repo_dir.mkdir()
+    ok_to_reuse = utils.prompt_ok_to_reuse('any_path')
 
-    deleted = utils.prompt_and_delete(str(repo_dir))
-
-    assert mock_read_user.called
-    assert repo_dir.exists()
-    assert not deleted
-    assert mock_sys_exit.called
-
-
-def test_prompt_should_ask_and_rm_repo_file(mocker, tmp_path):
-    """In `prompt_and_delete()`, if the user agrees to delete/reclone a \
-    repo file, the repo should be deleted."""
-    mock_read_user = mocker.patch(
-        'cookiecutter.utils.read_user_yes_no', return_value=True, autospec=True
-    )
-
-    repo_file = tmp_path.joinpath('repo.zip')
-    repo_file.write_text('this is zipfile content')
-
-    deleted = utils.prompt_and_delete(str(repo_file))
-
-    assert mock_read_user.called
-    assert not repo_file.exists()
-    assert deleted
-
-
-def test_prompt_should_ask_and_keep_repo_on_no_reuse(mocker, tmp_path):
-    """In `prompt_and_delete()`, if the user wants to keep their old \
-    cloned template repo, it should not be deleted."""
-    mock_read_user = mocker.patch(
-        'cookiecutter.utils.read_user_yes_no', return_value=False, autospec=True
-    )
-    repo_dir = Path(tmp_path, 'repo')
-    repo_dir.mkdir()
-
-    with pytest.raises(SystemExit):
-        utils.prompt_and_delete(str(repo_dir))
-
-    assert mock_read_user.called
-    assert repo_dir.exists()
-
-
-def test_prompt_should_ask_and_keep_repo_on_reuse(mocker, tmp_path):
-    """In `prompt_and_delete()`, if the user wants to keep their old \
-    cloned template repo, it should not be deleted."""
-
-    def answer(question, default):
-        if 'okay to delete' in question:
-            return False
-        else:
-            return True
-
-    mock_read_user = mocker.patch(
-        'cookiecutter.utils.read_user_yes_no', side_effect=answer, autospec=True
-    )
-    repo_dir = Path(tmp_path, 'repo')
-    repo_dir.mkdir()
-
-    deleted = utils.prompt_and_delete(str(repo_dir))
-
-    assert mock_read_user.called
-    assert repo_dir.exists()
-    assert not deleted
-
-
-def test_prompt_should_not_ask_if_no_input_and_rm_repo_dir(mocker, tmp_path):
-    """Prompt should not ask if no input and rm dir.
-
-    In `prompt_and_delete()`, if `no_input` is True, the call to
-    `prompt.read_user_yes_no()` should be suppressed.
-    """
-    mock_read_user = mocker.patch(
-        'cookiecutter.prompt.read_user_yes_no', return_value=True, autospec=True
-    )
-    repo_dir = Path(tmp_path, 'repo')
-    repo_dir.mkdir()
-
-    deleted = utils.prompt_and_delete(str(repo_dir), no_input=True)
-
-    assert not mock_read_user.called
-    assert not repo_dir.exists()
-    assert deleted
-
-
-def test_prompt_should_not_ask_if_no_input_and_rm_repo_file(mocker, tmp_path):
-    """Prompt should not ask if no input and rm file.
-
-    In `prompt_and_delete()`, if `no_input` is True, the call to
-    `prompt.read_user_yes_no()` should be suppressed.
-    """
-    mock_read_user = mocker.patch(
-        'cookiecutter.prompt.read_user_yes_no', return_value=True, autospec=True
-    )
-
-    repo_file = tmp_path.joinpath('repo.zip')
-    repo_file.write_text('this is zipfile content')
-
-    deleted = utils.prompt_and_delete(str(repo_file), no_input=True)
-
-    assert not mock_read_user.called
-    assert not repo_file.exists()
-    assert deleted
+    assert mock_read_user.called_once
+    assert not ok_to_reuse

--- a/tests/vcs/test_clone.py
+++ b/tests/vcs/test_clone.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 
 import pytest
+from pathlib import Path
 
 from cookiecutter import exceptions, vcs
 
@@ -48,7 +49,7 @@ def test_clone_should_abort_if_user_does_not_want_to_reclone(mocker, tmpdir):
     without cloning anything."""
     mocker.patch('cookiecutter.vcs.is_vcs_installed', autospec=True, return_value=True)
     mocker.patch(
-        'cookiecutter.vcs.prompt_and_delete', side_effect=SystemExit, autospec=True
+        'cookiecutter.vcs.prompt_ok_to_delete', side_effect=SystemExit, autospec=True
     )
     mock_subprocess = mocker.patch(
         'cookiecutter.vcs.subprocess.check_output', autospec=True,
@@ -56,7 +57,7 @@ def test_clone_should_abort_if_user_does_not_want_to_reclone(mocker, tmpdir):
 
     clone_to_dir = tmpdir.mkdir('clone')
 
-    # Create repo_dir to trigger prompt_and_delete
+    # Create repo_dir to trigger prompt_ok_to_delete
     clone_to_dir.mkdir('cookiecutter-pytest-plugin')
 
     repo_url = 'https://github.com/pytest-dev/cookiecutter-pytest-plugin.git'
@@ -190,3 +191,137 @@ def test_clone_unknown_subprocess_error(mocker, clone_dir):
             clone_to_dir=clone_dir,
             no_input=True,
         )
+
+
+@pytest.mark.skip(reason='Unable to properly set up mocks')
+def test_not_ok_to_delete_not_ok_to_reuse_results_in_system_exit(mocker, clone_dir):
+    """In `clone()`, if the user does not download new version,\
+    and does not reuse old one, then sys.exit() must be called."""
+    mock_ok_to_delete = mocker.patch(
+        'cookiecutter.utils.prompt_ok_to_delete', return_value=False,
+    )
+
+    mock_ok_to_reuse = mocker.patch(
+        'cookiecutter.utils.prompt_ok_to_reuse', return_value=False,
+    )
+
+    with pytest.raises(SystemExit):
+        vcs.clone(
+            'https://github.com/pytest-dev/cookiecutter-pytest-plugin',
+            clone_to_dir=clone_dir,
+            no_input=True,
+        )
+    assert mock_ok_to_delete.called_once
+    assert mock_ok_to_reuse.called_once
+
+
+@pytest.mark.skip(reason='Unable to properly set up mocks and reasonable assertions',)
+def test_no_ok_to_delete_ok_to_reuse_asked(mocker, clone_dir):
+    """In `clone()` normal reuse workflow."""
+    mock_ok_to_delete = mocker.patch(
+        'cookiecutter.utils.prompt_ok_to_delete', return_value=False,
+    )
+
+    mock_ok_to_reuse = mocker.patch(
+        'cookiecutter.utils.prompt_ok_to_reuse', return_value=True,
+    )
+
+    vcs.clone(
+        'https://github.com/pytest-dev/cookiecutter-pytest-plugin',
+        clone_to_dir=clone_dir,
+        no_input=True,
+    )
+    assert mock_ok_to_delete.called_once
+    assert mock_ok_to_reuse.called_once
+
+
+def test_backup_and_delete_repo(mocker, tmpdir):
+    """Test that backup works correctly."""
+    mock_move = mocker.patch('shutil.move', return_value=True)
+
+    repo_dir = tmpdir.mkdir('repo')
+    backup_dir = tmpdir.mkdir('backup')
+
+    subdir = repo_dir.mkdir('subdir')
+    inner_dir = subdir.mkdir('inner_dir')
+
+    Path(repo_dir / 'cookiecutter.json').touch()
+    Path(subdir / 'README.md').touch()
+    Path(inner_dir / 'some_file.txt').touch()
+
+    original_files = [
+        x.relative_to(repo_dir)
+        for x in sorted(Path(repo_dir).glob('**/*'))
+        if x.is_file()
+    ]
+
+    vcs._backup_and_delete_repo(str(repo_dir), str(backup_dir))
+    backed_up_files = [
+        x.relative_to(backup_dir / 'repo')
+        for x in sorted(Path(backup_dir).glob('**/*'))
+        if x.is_file()
+    ]
+    assert mock_move.called_once
+    assert original_files == backed_up_files
+    assert not Path(repo_dir).exists()
+
+
+def test_restore_old_repo_to_existing_directory(mocker, tmpdir):
+    """Test that restore works correctly if repo directory exists."""
+    mock_rmtree = mocker.patch('cookiecutter.utils.rmtree', return_value=True)
+
+    repo_dir = tmpdir.mkdir('repo')
+    backup_dir = tmpdir.mkdir('backup').mkdir('repo')
+
+    subdir = backup_dir.mkdir('subdir')
+    inner_dir = subdir.mkdir('inner_dir')
+
+    Path(backup_dir / 'cookiecutter.json').touch()
+    Path(subdir / 'README.md').touch()
+    Path(inner_dir / 'some_file.txt').touch()
+
+    backed_up_files = [
+        x.relative_to(backup_dir)
+        for x in sorted(Path(backup_dir).glob('**/*'))
+        if x.is_file()
+    ]
+
+    vcs._restore_old_repo(str(repo_dir), str(backup_dir))
+    restored_files = [
+        x.relative_to(repo_dir)
+        for x in sorted(Path(repo_dir).glob('**/*'))
+        if x.is_file()
+    ]
+    assert backed_up_files == restored_files
+    assert not Path(backup_dir).exists()
+    assert mock_rmtree.called_once
+
+
+def test_restore_old_repo_to_non_existing_directory(mocker, tmpdir):
+    """Test that restore works correctly to non-existing directory."""
+    mock_rmtree = mocker.patch('cookiecutter.utils.rmtree', return_value=True)
+
+    backup_dir = tmpdir.mkdir('backup').mkdir('repo')
+
+    subdir = backup_dir.mkdir('subdir')
+    inner_dir = subdir.mkdir('inner_dir')
+
+    Path(backup_dir / 'cookiecutter.json').touch()
+    Path(subdir / 'README.md').touch()
+    Path(inner_dir / 'some_file.txt').touch()
+
+    backed_up_files = [
+        x.relative_to(backup_dir)
+        for x in sorted(Path(backup_dir).glob('**/*'))
+        if x.is_file()
+    ]
+
+    vcs._restore_old_repo(str(tmpdir / 'repo'), str(backup_dir))
+    restored_files = [
+        x.relative_to(tmpdir / 'repo')
+        for x in sorted(Path(tmpdir / 'repo').glob('**/*'))
+        if x.is_file()
+    ]
+    assert backed_up_files == restored_files
+    assert not Path(backup_dir).exists()
+    assert mock_rmtree.called_once

--- a/tests/zipfile/test_unzip.py
+++ b/tests/zipfile/test_unzip.py
@@ -18,8 +18,8 @@ def mock_download():
 
 def test_unzip_local_file(mocker, tmpdir):
     """Local file reference can be unzipped."""
-    mock_prompt_and_delete = mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', return_value=True, autospec=True
+    mock_prompt_ok_to_delete = mocker.patch(
+        'cookiecutter.zipfile.prompt_ok_to_delete', return_value=True, autospec=True
     )
 
     clone_to_dir = tmpdir.mkdir('clone')
@@ -29,13 +29,13 @@ def test_unzip_local_file(mocker, tmpdir):
     )
 
     assert output_dir.startswith(tempfile.gettempdir())
-    assert not mock_prompt_and_delete.called
+    assert not mock_prompt_ok_to_delete.called
 
 
 def test_unzip_protected_local_file_environment_password(mocker, tmpdir):
     """In `unzip()`, the environment can be used to provide a repo password."""
-    mock_prompt_and_delete = mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', return_value=True, autospec=True
+    mock_prompt_ok_to_delete = mocker.patch(
+        'cookiecutter.zipfile.prompt_ok_to_delete', return_value=True, autospec=True
     )
 
     clone_to_dir = tmpdir.mkdir('clone')
@@ -48,13 +48,13 @@ def test_unzip_protected_local_file_environment_password(mocker, tmpdir):
     )
 
     assert output_dir.startswith(tempfile.gettempdir())
-    assert not mock_prompt_and_delete.called
+    assert not mock_prompt_ok_to_delete.called
 
 
 def test_unzip_protected_local_file_bad_environment_password(mocker, tmpdir):
     """In `unzip()`, an error occurs if the environment has a bad password."""
     mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', return_value=True, autospec=True
+        'cookiecutter.zipfile.prompt_ok_to_delete', return_value=True, autospec=True
     )
 
     clone_to_dir = tmpdir.mkdir('clone')
@@ -71,7 +71,7 @@ def test_unzip_protected_local_file_bad_environment_password(mocker, tmpdir):
 def test_unzip_protected_local_file_user_password_with_noinput(mocker, tmpdir):
     """Can't unpack a password-protected repo in no_input mode."""
     mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', return_value=True, autospec=True
+        'cookiecutter.zipfile.prompt_ok_to_delete', return_value=True, autospec=True
     )
 
     clone_to_dir = tmpdir.mkdir('clone')
@@ -87,8 +87,8 @@ def test_unzip_protected_local_file_user_password_with_noinput(mocker, tmpdir):
 
 def test_unzip_protected_local_file_user_password(mocker, tmpdir):
     """A password-protected local file reference can be unzipped."""
-    mock_prompt_and_delete = mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', return_value=True, autospec=True
+    mock_prompt_ok_to_delete = mocker.patch(
+        'cookiecutter.zipfile.prompt_ok_to_delete', return_value=True, autospec=True
     )
     mocker.patch('cookiecutter.zipfile.read_repo_password', return_value='sekrit')
 
@@ -101,13 +101,13 @@ def test_unzip_protected_local_file_user_password(mocker, tmpdir):
     )
 
     assert output_dir.startswith(tempfile.gettempdir())
-    assert not mock_prompt_and_delete.called
+    assert not mock_prompt_ok_to_delete.called
 
 
 def test_unzip_protected_local_file_user_bad_password(mocker, tmpdir):
     """Error in `unzip()`, if user can't provide a valid password."""
     mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', return_value=True, autospec=True
+        'cookiecutter.zipfile.prompt_ok_to_delete', return_value=True, autospec=True
     )
     mocker.patch(
         'cookiecutter.zipfile.read_repo_password', return_value='not-the-right-password'
@@ -126,7 +126,7 @@ def test_unzip_protected_local_file_user_bad_password(mocker, tmpdir):
 def test_empty_zip_file(mocker, tmpdir):
     """In `unzip()`, an empty file raises an error."""
     mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', return_value=True, autospec=True
+        'cookiecutter.zipfile.prompt_ok_to_delete', return_value=True, autospec=True
     )
 
     clone_to_dir = tmpdir.mkdir('clone')
@@ -140,7 +140,7 @@ def test_empty_zip_file(mocker, tmpdir):
 def test_non_repo_zip_file(mocker, tmpdir):
     """In `unzip()`, a repository must have a top level directory."""
     mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', return_value=True, autospec=True
+        'cookiecutter.zipfile.prompt_ok_to_delete', return_value=True, autospec=True
     )
 
     clone_to_dir = tmpdir.mkdir('clone')
@@ -154,7 +154,7 @@ def test_non_repo_zip_file(mocker, tmpdir):
 def test_bad_zip_file(mocker, tmpdir):
     """In `unzip()`, a corrupted zip file raises an error."""
     mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', return_value=True, autospec=True
+        'cookiecutter.zipfile.prompt_ok_to_delete', return_value=True, autospec=True
     )
 
     clone_to_dir = tmpdir.mkdir('clone')
@@ -167,8 +167,8 @@ def test_bad_zip_file(mocker, tmpdir):
 
 def test_unzip_url(mocker, tmpdir):
     """In `unzip()`, a url will be downloaded and unzipped."""
-    mock_prompt_and_delete = mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', return_value=True, autospec=True
+    mock_prompt_ok_to_delete = mocker.patch(
+        'cookiecutter.zipfile.prompt_ok_to_delete', return_value=True, autospec=True
     )
 
     request = mocker.MagicMock()
@@ -187,13 +187,13 @@ def test_unzip_url(mocker, tmpdir):
     )
 
     assert output_dir.startswith(tempfile.gettempdir())
-    assert not mock_prompt_and_delete.called
+    assert not mock_prompt_ok_to_delete.called
 
 
 def test_unzip_url_existing_cache(mocker, tmpdir):
     """Url should be downloaded and unzipped, old zip file will be removed."""
-    mock_prompt_and_delete = mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', return_value=True, autospec=True
+    mock_prompt_ok_to_delete = mocker.patch(
+        'cookiecutter.zipfile.prompt_ok_to_delete', return_value=True, autospec=True
     )
 
     request = mocker.MagicMock()
@@ -216,7 +216,7 @@ def test_unzip_url_existing_cache(mocker, tmpdir):
     )
 
     assert output_dir.startswith(tempfile.gettempdir())
-    assert mock_prompt_and_delete.call_count == 1
+    assert mock_prompt_ok_to_delete.call_count == 1
 
 
 def test_unzip_url_existing_cache_no_input(mocker, tmpdir):
@@ -247,7 +247,9 @@ def test_unzip_url_existing_cache_no_input(mocker, tmpdir):
 def test_unzip_should_abort_if_no_redownload(mocker, tmpdir):
     """Should exit without cloning anything If no redownload."""
     mocker.patch(
-        'cookiecutter.zipfile.prompt_and_delete', side_effect=SystemExit, autospec=True
+        'cookiecutter.zipfile.prompt_ok_to_delete',
+        side_effect=SystemExit,
+        autospec=True,
     )
 
     mock_requests_get = mocker.patch(


### PR DESCRIPTION
This PR attempts to address https://github.com/cookiecutter/cookiecutter/issues/1444

When the template is downloaded and the user is asked whether the template should be re-downloaded, then the following steps are carried out.
1. The existing template is backed up in a temporary directory.
2. Try to download the new template
3. If failed to download the new template, then restore the backup.

Changes
---------

1. Function ``cookiecutter.utils.prompt_and_delete`` did both prompting the answer and deleting the existing template. I split function into ``prompt_ok_to_delete`` and ``prompt_ok_to_reuse``. Meanwhile the deletion of the existing template is carried out in ``cookiecutter.vcs``.
2. Refactor ``cookiecutter.vcs`` by extracting functions ``_need_to_clone``, ``_clone_repo``, ``_handle_clone_error``, ``_backup_and_delete_repo``, ``_restore_old_repo``.

Known issues
--------------

Code coverage dropped because I did not manage to implement proper tests with correct mocking of reading user input.
I appreciate if someone helps with that. The tests were created but marked to be skipped.