### PR TITLE
Retrieve project templates from S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ venv/
 *.egg-info/
 .installed.cfg
 *.egg
+pip-wheel-metadata/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -23,6 +23,11 @@ def is_repo_url(value):
     return bool(REPO_REGEX.match(value))
 
 
+def is_s3_url(value):
+    """Return True if the value is a URL to an S3 resource."""
+    return value.startswith('s3://')
+
+
 def is_zip_file(value):
     """Return True if value is a zip file."""
     return value.lower().endswith('.zip')
@@ -95,7 +100,7 @@ def determine_repo_dir(
     if is_zip_file(template):
         unzipped_dir = unzip(
             zip_uri=template,
-            is_url=is_repo_url(template),
+            is_url=is_repo_url(template) or is_s3_url(template),
             clone_to_dir=clone_to_dir,
             no_input=no_input,
             password=password,

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     include_package_data=True,
     python_requires='>=3.6',
     install_requires=requirements,
+    extras_require={'s3': ['boto3']},
     license='BSD',
     zip_safe=False,
     classifiers=[

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,6 @@
+boto3
 pytest
 pytest-cov
 pytest-mock
 freezegun
+moto

--- a/tests/repository/test_determine_repo_dir_clones_repo.py
+++ b/tests/repository/test_determine_repo_dir_clones_repo.py
@@ -12,6 +12,7 @@ from cookiecutter import exceptions, repository
         ('/path/to/zipfile.zip', False),
         ('https://example.com/path/to/zipfile.zip', True),
         ('http://example.com/path/to/zipfile.zip', True),
+        ('s3://example-bucket/path/to/zipfile.zip', True),
     ],
 )
 def test_zipfile_unzip(mocker, template, is_url, user_config_data):

--- a/tests/repository/test_is_repo_url.py
+++ b/tests/repository/test_is_repo_url.py
@@ -2,7 +2,12 @@
 import pytest
 
 from cookiecutter.config import BUILTIN_ABBREVIATIONS
-from cookiecutter.repository import expand_abbreviations, is_repo_url, is_zip_file
+from cookiecutter.repository import (
+    expand_abbreviations,
+    is_repo_url,
+    is_s3_url,
+    is_zip_file,
+)
 
 
 @pytest.fixture(
@@ -10,6 +15,7 @@ from cookiecutter.repository import expand_abbreviations, is_repo_url, is_zip_fi
         '/path/to/zipfile.zip',
         'https://example.com/path/to/zipfile.zip',
         'http://example.com/path/to/zipfile.zip',
+        's3://example-bucket/path/to/object.zip',
     ]
 )
 def zipfile(request):
@@ -20,6 +26,19 @@ def zipfile(request):
 def test_is_zip_file(zipfile):
     """Verify is_repo_url works."""
     assert is_zip_file(zipfile) is True
+
+
+@pytest.mark.parametrize(
+    'url,expected',
+    [
+        ('s3://example-bucket/path/to/object.zip', True),
+        ('https://example.com/path/to/zipfile.zip', False),
+        ('http://example.com/path/to/zipfile.zip', False),
+    ],
+)
+def test_is_s3_url(url, expected):
+    """Verify that S3 URLs are properly identified."""
+    assert is_s3_url(url) is expected
 
 
 @pytest.fixture(


### PR DESCRIPTION
This commit adds optional support for allowing .zip files containing Cookiecutter project templates to be stored and accessed via S3. In short, project templates can be stored in a private S3 bucket instead of having to be publically available at an HTTP(S) endpoint. This support is achieved by using pre-signed S3 URLs, so that the mechanism for retrieving files from S3 is not dramatically different from downloading a file via HTTP(S), as is currently done.

Support for this feature is optional, since it requires the boto3 library, so this commit also adds an "s3" extra as an installation option. Support can be enabled by installing Cookiecutter using

    $ pip install cookiecutter[s3]