### PR TITLE
Add slugify in the default extensions list

### DIFF
--- a/docs/advanced/template_extensions.rst
+++ b/docs/advanced/template_extensions.rst
@@ -31,6 +31,7 @@ By default Cookiecutter includes the following extensions:
 
 - ``cookiecutter.extensions.JsonifyExtension``
 - ``cookiecutter.extensions.RandomStringExtension``
+- ``cookiecutter.extensions.SlugifyExtension``
 - ``jinja2_time.TimeExtension``
 
 Jsonify extension


### PR DESCRIPTION
To avoid new users to think they have to add it manually.
