### PR TITLE
Allow specifying a different hooks directory

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -141,6 +141,12 @@ def list_installed_templates(default_config, passed_config_file):
 @click.option(
     '-l', '--list-installed', is_flag=True, help='List currently installed templates.'
 )
+@click.option(
+    '--hooks-dir',
+    default='hooks',
+    type=click.Path(),
+    help='Path where hooks are located',
+)
 def main(
     template,
     extra_context,
@@ -158,6 +164,7 @@ def main(
     accept_hooks,
     replay_file,
     list_installed,
+    hooks_dir,
 ):
     """Create a project from a Cookiecutter project template (TEMPLATE).
 
@@ -202,6 +209,7 @@ def main(
             directory=directory,
             skip_if_file_exists=skip_if_file_exists,
             accept_hooks=_accept_hooks,
+            hooks_dir=hooks_dir,
         )
     except (
         OutputDirExistsException,

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -227,12 +227,13 @@ def ensure_dir_is_templated(dirname):
 
 
 def _run_hook_from_repo_dir(
-    repo_dir, hook_name, project_dir, context, delete_project_on_failure
+    repo_dir, hook_name, hooks_dir, project_dir, context, delete_project_on_failure
 ):
     """Run hook from repo directory, clean project directory if hook fails.
 
     :param repo_dir: Project template input directory.
     :param hook_name: The hook to execute.
+    :param hooks_dir: Path where hooks are located.
     :param project_dir: The directory to execute the script from.
     :param context: Cookiecutter project context.
     :param delete_project_on_failure: Delete the project directory on hook
@@ -240,7 +241,7 @@ def _run_hook_from_repo_dir(
     """
     with work_in(repo_dir):
         try:
-            run_hook(hook_name, project_dir, context)
+            run_hook(hook_name, os.path.abspath(hooks_dir), project_dir, context)
         except FailedHookException:
             if delete_project_on_failure:
                 rmtree(project_dir)
@@ -259,6 +260,7 @@ def generate_files(
     overwrite_if_exists=False,
     skip_if_file_exists=False,
     accept_hooks=True,
+    hooks_dir='hooks',
 ):
     """Render the templates and saves them to files.
 
@@ -268,6 +270,7 @@ def generate_files(
     :param overwrite_if_exists: Overwrite the contents of the output directory
         if it exists.
     :param accept_hooks: Accept pre and post hooks if set to `True`.
+    :param hooks_dir: Path where hooks are located.
     """
     template_dir = find_template(repo_dir)
     logger.debug('Generating project from %s...', template_dir)
@@ -302,7 +305,12 @@ def generate_files(
 
     if accept_hooks:
         _run_hook_from_repo_dir(
-            repo_dir, 'pre_gen_project', project_dir, context, delete_project_on_failure
+            repo_dir,
+            'pre_gen_project',
+            hooks_dir,
+            project_dir,
+            context,
+            delete_project_on_failure,
         )
 
     with work_in(template_dir):
@@ -374,6 +382,7 @@ def generate_files(
         _run_hook_from_repo_dir(
             repo_dir,
             'post_gen_project',
+            hooks_dir,
             project_dir,
             context,
             delete_project_on_failure,

--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -114,15 +114,16 @@ def run_script_with_context(script_path, cwd, context):
     run_script(temp.name, cwd)
 
 
-def run_hook(hook_name, project_dir, context):
+def run_hook(hook_name, hooks_dir, project_dir, context):
     """
     Try to find and execute a hook from the specified project directory.
 
     :param hook_name: The hook to execute.
+    :param hooks_dir: Absolute path where hooks are located.
     :param project_dir: The directory to execute the script from.
     :param context: Cookiecutter project context.
     """
-    scripts = find_hook(hook_name)
+    scripts = find_hook(hook_name, hooks_dir=hooks_dir)
     if not scripts:
         logger.debug('No %s hook found', hook_name)
         return

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -32,6 +32,7 @@ def cookiecutter(
     directory=None,
     skip_if_file_exists=False,
     accept_hooks=True,
+    hooks_dir='hooks',
 ):
     """
     Run Cookiecutter just as if using it from the command line.
@@ -51,6 +52,7 @@ def cookiecutter(
     :param password: The password to use when extracting the repository.
     :param directory: Relative path to a cookiecutter template in a repository.
     :param accept_hooks: Accept pre and post hooks if set to `True`.
+    :param hooks_dir: Path where hooks are located.
     """
     if replay and ((no_input is not False) or (extra_context is not None)):
         err_msg = (
@@ -111,6 +113,7 @@ def cookiecutter(
         skip_if_file_exists=skip_if_file_exists,
         output_dir=output_dir,
         accept_hooks=accept_hooks,
+        hooks_dir=hooks_dir,
     )
 
     # Cleanup (if required)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,7 @@ def test_cli_replay(mocker, cli_runner):
         password=None,
         directory=None,
         accept_hooks=True,
+        hooks_dir='hooks',
     )
 
 
@@ -132,6 +133,7 @@ def test_cli_replay_file(mocker, cli_runner):
         password=None,
         directory=None,
         accept_hooks=True,
+        hooks_dir='hooks',
     )
 
 
@@ -167,6 +169,7 @@ def test_cli_exit_on_noinput_and_replay(mocker, cli_runner):
         password=None,
         directory=None,
         accept_hooks=True,
+        hooks_dir='hooks',
     )
 
 
@@ -204,6 +207,7 @@ def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
         password=None,
         directory=None,
         accept_hooks=True,
+        hooks_dir='hooks',
     )
 
 
@@ -266,6 +270,7 @@ def test_cli_output_dir(mocker, cli_runner, output_dir_flag, output_dir):
         password=None,
         directory=None,
         accept_hooks=True,
+        hooks_dir='hooks',
     )
 
 
@@ -310,6 +315,39 @@ def test_user_config(mocker, cli_runner, user_config_path):
         password=None,
         directory=None,
         accept_hooks=True,
+        hooks_dir='hooks',
+    )
+
+
+@pytest.fixture
+def hooks_dir_path(tmpdir):
+    """Pytest fixture return `hooks-dir` argument as string."""
+    return str(tmpdir.join('myhooks'))
+
+
+def test_hooks_dir(mocker, cli_runner, hooks_dir_path):
+    """Test cli invocation works with `hooks-dir` option."""
+    mock_cookiecutter = mocker.patch('cookiecutter.cli.cookiecutter')
+
+    template_path = 'tests/fake-repo-pre/'
+    result = cli_runner(template_path, '--hooks-dir', hooks_dir_path)
+
+    assert result.exit_code == 0
+    mock_cookiecutter.assert_called_once_with(
+        template_path,
+        None,
+        False,
+        replay=False,
+        overwrite_if_exists=False,
+        skip_if_file_exists=False,
+        output_dir='.',
+        config_file=None,
+        default_config=False,
+        extra_context=None,
+        password=None,
+        directory=None,
+        accept_hooks=True,
+        hooks_dir=hooks_dir_path,
     )
 
 
@@ -337,6 +375,7 @@ def test_default_user_config_overwrite(mocker, cli_runner, user_config_path):
         password=None,
         directory=None,
         accept_hooks=True,
+        hooks_dir='hooks',
     )
 
 
@@ -362,6 +401,7 @@ def test_default_user_config(mocker, cli_runner):
         password=None,
         directory=None,
         accept_hooks=True,
+        hooks_dir='hooks',
     )
 
 
@@ -581,4 +621,5 @@ def test_cli_accept_hooks(
         directory=None,
         skip_if_file_exists=False,
         accept_hooks=expected,
+        hooks_dir='hooks',
     )

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -201,7 +201,9 @@ class TestExternalHooks(object):
 
         with utils.work_in(self.repo_path):
             with pytest.raises(exceptions.FailedHookException) as excinfo:
-                hooks.run_hook('pre_gen_project', tests_dir, {})
+                hooks.run_hook(
+                    'pre_gen_project', os.path.abspath('hooks'), tests_dir, {}
+                )
             assert 'Hook script failed' in str(excinfo.value)
 
 

--- a/tests/test_specify_output_dir.py
+++ b/tests/test_specify_output_dir.py
@@ -24,6 +24,12 @@ def output_dir(tmpdir):
 
 
 @pytest.fixture
+def hooks_dir(tmpdir):
+    """Fixture to prepare test hooks directory."""
+    return str(tmpdir.mkdir('hooks'))
+
+
+@pytest.fixture
 def template(tmpdir):
     """Fixture to prepare test template directory."""
     template_dir = tmpdir.mkdir('template')
@@ -62,6 +68,7 @@ def test_api_invocation(mocker, template, output_dir, context):
         skip_if_file_exists=False,
         output_dir=output_dir,
         accept_hooks=True,
+        hooks_dir='hooks',
     )
 
 
@@ -78,4 +85,22 @@ def test_default_output_dir(mocker, template, context):
         skip_if_file_exists=False,
         output_dir='.',
         accept_hooks=True,
+        hooks_dir='hooks',
+    )
+
+
+def test_passing_hooks_dir(mocker, template, hooks_dir, context):
+    """Verify hooks dir location is correctly passed."""
+    mock_gen_files = mocker.patch('cookiecutter.main.generate_files')
+
+    main.cookiecutter(template, hooks_dir=hooks_dir)
+
+    mock_gen_files.assert_called_once_with(
+        repo_dir=template,
+        context=context,
+        overwrite_if_exists=False,
+        skip_if_file_exists=False,
+        output_dir='.',
+        accept_hooks=True,
+        hooks_dir=hooks_dir,
     )


### PR DESCRIPTION
Currently, existing hooks are only sourced from within the root cookiecutter location under the hooks/ folder.
This commit adds a new CLI option to allow overriding that folder, if needed.
The rationale behind it is that one might want to have a generic or common set of pre/post hooks usable by all cookiecutters and sitting outside each cookiecutter template.