### PR TITLE
Added output_dir to config

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -103,6 +103,10 @@ def cookiecutter(
 
         dump(config_dict['replay_dir'], template_name, context)
 
+    # Get output_dir from config
+    if config_dict['output_dir']:
+        output_dir = config_dict['output_dir']
+
     # Create project from local context and project template.
     result = generate_files(
         repo_dir=repo_dir,

--- a/docs/advanced/user_config.rst
+++ b/docs/advanced/user_config.rst
@@ -29,6 +29,7 @@ Example user config:
         github_username: "audreyr"
     cookiecutters_dir: "/home/audreyr/my-custom-cookiecutters-dir/"
     replay_dir: "/home/audreyr/my-custom-replay-dir/"
+    output_dir: "/home/audreyr/dev/"
     abbreviations:
         pp: https://github.com/audreyr/cookiecutter-pypackage.git
         gh: https://github.com/{0}.git
@@ -43,6 +44,7 @@ Possible settings are:
   use Cookiecutter with a repo argument.
 * replay_dir: Directory where Cookiecutter dumps context data to, which
   you can fetch later on when using the :ref:`replay feature <replay-feature>`.
+* output_dir:  Directory that Cookiecutter uses as the default output_dir.
 * abbreviations: A list of abbreviations for cookiecutters. Abbreviations can
   be simple aliases for a repo name, or can be used as a prefix, in the form
   `abbr:suffix`. Any suffix will be inserted into the expansion in place of

--- a/tests/test-config/valid-config.yaml
+++ b/tests/test-config/valid-config.yaml
@@ -4,5 +4,6 @@ default_context:
     github_username: "example"
 cookiecutters_dir: "/home/example/some-path-to-templates"
 replay_dir: "/home/example/some-path-to-replay-files"
+output_dir: "/home/example/some-path-for-dev-files"
 abbreviations:
     helloworld: "https://github.com/hackebrot/helloworld"

--- a/tests/test_get_user_config.py
+++ b/tests/test_get_user_config.py
@@ -49,7 +49,7 @@ def custom_config():
         },
         'cookiecutters_dir': '/home/example/some-path-to-templates',
         'replay_dir': '/home/example/some-path-to-replay-files',
-        'output_dir': '/home/example/some-path-for-dev-files'
+        'output_dir': '/home/example/some-path-for-dev-files',
         'abbreviations': {
             'gh': 'https://github.com/{0}.git',
             'gl': 'https://gitlab.com/{0}.git',

--- a/tests/test_get_user_config.py
+++ b/tests/test_get_user_config.py
@@ -49,6 +49,7 @@ def custom_config():
         },
         'cookiecutters_dir': '/home/example/some-path-to-templates',
         'replay_dir': '/home/example/some-path-to-replay-files',
+        'output_dir': '/home/example/some-path-for-dev-files'
         'abbreviations': {
             'gh': 'https://github.com/{0}.git',
             'gl': 'https://gitlab.com/{0}.git',


### PR DESCRIPTION
I always have a folder where I do my developing. For example '/projects'. I would like to specify that folder a the default output_dir in the config. This change is not breaking anything just adding a feature.