### PR TITLE
Replace poyo with pyyaml.

### DIFF
--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -4,7 +4,6 @@ import copy
 import logging
 import os
 
-import poyo
 import yaml
 
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -5,6 +5,7 @@ import logging
 import os
 
 import poyo
+import yaml
 
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
 
@@ -62,11 +63,11 @@ def get_config(config_path):
     logger.debug('config_path is %s', config_path)
     with open(config_path, encoding='utf-8') as file_handle:
         try:
-            yaml_dict = poyo.parse_string(file_handle.read())
-        except poyo.exceptions.PoyoException as e:
+            yaml_dict = yaml.safe_load(file_handle)
+        except yaml.YAMLError as e:
             raise InvalidConfiguration(
-                'Unable to parse YAML file {}. Error: {}'.format(config_path, e)
-            )
+                'Unable to parse YAML file {}.'.format(config_path)
+            ) from e
 
     config_dict = merge_configs(DEFAULT_CONFIG, yaml_dict)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     'binaryornot>=0.4.4',
     'Jinja2<3.0.0',
     'click>=7.0',
-    'poyo>=0.5.0',
+    'pyyaml>=5.3.1',
     'jinja2-time>=0.2.0',
     'python-slugify>=4.0.0',
     'requests>=2.23.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,13 @@ from cookiecutter import utils
 
 
 USER_CONFIG = """
-cookiecutters_dir: "{cookiecutters_dir}"
-replay_dir: "{replay_dir}"
+cookiecutters_dir: '{cookiecutters_dir}'
+replay_dir: '{replay_dir}'
 """
+# In YAML, double quotes mean to use escape sequences.
+# Single quotes mean we will have unescaped backslahes.
+# http://blogs.perl.org/users/tinita/2018/03/
+# strings-in-yaml---to-quote-or-not-to-quote.html
 
 
 def backup_dir(original_dir, backup_dir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 """pytest fixtures which are globally available throughout the suite."""
-import logging
 import os
 import shutil
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,9 +175,3 @@ def user_config_file(user_dir, user_config_data):
     config_text = USER_CONFIG.format(**user_config_data)
     config_file.write(config_text)
     return str(config_file)
-
-
-@pytest.fixture(autouse=True)
-def disable_poyo_logging():
-    """Fixture that disables poyo logging."""
-    logging.getLogger('poyo').setLevel(logging.WARNING)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -499,7 +499,11 @@ def test_debug_list_installed_templates(cli_runner, debug_file, user_config_path
     fake_template_dir = os.path.dirname(os.path.abspath('fake-project'))
     os.makedirs(os.path.dirname(user_config_path))
     with open(user_config_path, 'w') as config_file:
-        config_file.write('cookiecutters_dir: "%s"' % fake_template_dir)
+        # In YAML, double quotes mean to use escape sequences.
+        # Single quotes mean we will have unescaped backslahes.
+        # http://blogs.perl.org/users/tinita/2018/03/
+        # strings-in-yaml---to-quote-or-not-to-quote.html
+        config_file.write("cookiecutters_dir: '%s'" % fake_template_dir)
     open(os.path.join('fake-project', 'cookiecutter.json'), 'w').write('{}')
 
     result = cli_runner(

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -2,6 +2,7 @@
 import os
 
 import pytest
+import yaml
 
 from cookiecutter import config
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
@@ -82,13 +83,13 @@ def test_get_config_does_not_exist():
 def test_invalid_config():
     """An invalid config file should raise an `InvalidConfiguration` \
     exception."""
+    expected_error_msg = (
+        'Unable to parse YAML file tests/test-config/invalid-config.yaml.'
+    )
     with pytest.raises(InvalidConfiguration) as exc_info:
         config.get_config('tests/test-config/invalid-config.yaml')
-
-    expected_error_msg = (
-        'Unable to parse YAML file tests/test-config/invalid-config.yaml. Error: '
-    )
-    assert expected_error_msg in str(exc_info.value)
+        assert expected_error_msg in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, yaml.YAMLError)
 
 
 def test_get_config_with_defaults():


### PR DESCRIPTION
I was about to open an issue on poyo when I realized there's a much more fundamental question I should be asking: given that pyyaml was "adopted" two years ago, does it still make sense to maintain an entire separate YAML parser for cookiecutter?

This came up a bit before. https://github.com/cookiecutter/cookiecutter/pull/1136#issuecomment-512501467

I could be wrong, but I sort of had the impression nobody with cookiecutter ever really *wanted* to be in the business of YAML parsing in the first place, and that poyo was just an act of desperation --- IIRC, with the half-complete migration to BitBucket, it wasn't even clear where you would go to contribute any fixes you needed. At this point, pyyaml is owned by The YAML Project and lives on GitHub with cookiecutter: https://github.com/yaml/pyyaml

It seems like it might be worth folding poyo into pyyaml, if there's anything cookiecutter needs that pyyaml doesn't currently have.

At this point `pip install pyyaml` just works on Linux and Windows. I'm opening this as a PR rather than an issue to show what a small change we're really talking about here --- anecdotally, the drop-in replacement in this branch just works.

(This turned out a bit more complicated than just replacing the parsing call, but it's all to do with testing --- some tests were writing out test config files that, as it turned out, were not actually valid YAML. That's one of the things about having a separate hand-rolled parser; the language it actually represents tends to drift without anyone noticing, with the obvious implications for debugging.)