### PR TITLE
Use load_replay_file directly when file is directly provided.

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -11,7 +11,7 @@ from cookiecutter.config import get_user_config
 from cookiecutter.exceptions import InvalidModeException
 from cookiecutter.generate import generate_context, generate_files
 from cookiecutter.prompt import prompt_for_config
-from cookiecutter.replay import dump, load
+from cookiecutter.replay import dump, load, load_replay_file
 from cookiecutter.repository import determine_repo_dir
 from cookiecutter.utils import rmtree
 
@@ -79,8 +79,7 @@ def cookiecutter(
         if isinstance(replay, bool):
             context = load(config_dict['replay_dir'], template_name)
         else:
-            path, template_name = os.path.split(os.path.splitext(replay)[0])
-            context = load(path, template_name)
+            context = load_replay_file(replay)
     else:
         context_file = os.path.join(repo_dir, 'cookiecutter.json')
         logger.debug('context_file is %s', context_file)

--- a/cookiecutter/replay.py
+++ b/cookiecutter/replay.py
@@ -36,13 +36,8 @@ def dump(replay_dir, template_name, context):
         json.dump(context, outfile, indent=2)
 
 
-def load(replay_dir, template_name):
-    """Read json data from file."""
-    if not isinstance(template_name, str):
-        raise TypeError('Template name is required to be of type str')
-
-    replay_file = get_file_name(replay_dir, template_name)
-
+def load_replay_file(replay_file):
+    """Read cookiecutter's parameter values from replay file."""
     with open(replay_file, 'r') as infile:
         context = json.load(infile)
 
@@ -50,3 +45,12 @@ def load(replay_dir, template_name):
         raise ValueError('Context is required to contain a cookiecutter key')
 
     return context
+
+
+def load(replay_dir, template_name):
+    """Read json data from file."""
+    if not isinstance(template_name, str):
+        raise TypeError('Template name is required to be of type str')
+
+    replay_file = get_file_name(replay_dir, template_name)
+    return load_replay_file(replay_file)


### PR DESCRIPTION
This is built atop https://github.com/cookiecutter/cookiecutter/pull/1490. Look there first. This looks like it's changing more than it is.

All this is really doing is skipping straight to `load_replay_file` when the user directly provided the name of the replay file they want to use.