### PR TITLE
Alert user if choice is invalid

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -62,6 +62,10 @@ def apply_overwrites_to_context(context, overwrite_context):
                 # see ``cookiecutter.prompt.prompt_choice_for_config``
                 context_value.remove(overwrite)
                 context_value.insert(0, overwrite)
+            else:
+                raise ValueError("{} provided for choice variable {}, but the "
+                                 "choices are {}.".format(overwrite, variable,
+                                                          context_value))
         else:
             # Simply overwrite the value for this variable
             context[variable] = overwrite

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import shutil
+import warnings
 from collections import OrderedDict
 
 from binaryornot.check import is_binary
@@ -108,7 +109,10 @@ def generate_context(
     # Overwrite context variable defaults with the default context from the
     # user's global config, if available
     if default_context:
-        apply_overwrites_to_context(obj, default_context)
+        try:
+            apply_overwrites_to_context(obj, default_context)
+        except ValueError as ex:
+            warnings.warn("Invalid default received: " + str(ex))
     if extra_context:
         apply_overwrites_to_context(obj, extra_context)
 

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -63,9 +63,10 @@ def apply_overwrites_to_context(context, overwrite_context):
                 context_value.remove(overwrite)
                 context_value.insert(0, overwrite)
             else:
-                raise ValueError("{} provided for choice variable {}, but the "
-                                 "choices are {}.".format(overwrite, variable,
-                                                          context_value))
+                raise ValueError(
+                    "{} provided for choice variable {}, but the "
+                    "choices are {}.".format(overwrite, variable, context_value)
+                )
         else:
             # Simply overwrite the value for this variable
             context[variable] = overwrite

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -182,6 +182,7 @@ def test_apply_overwrites_does_not_modify_choices_for_invalid_overwrite():
 
 
 def test_apply_overwrites_invalid_overwrite(template_context):
+    """Verify variables overwrite for list if variable not in list not ignored."""
     with pytest.raises(ValueError):
         generate.apply_overwrites_to_context(
             context=template_context, overwrite_context={'orientation': 'foobar'}

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -151,15 +151,34 @@ def test_apply_overwrites_sets_non_list_value(template_context):
     assert template_context['repo_name'] == 'foobar'
 
 
-def test_apply_overwrites_does_not_modify_choices_for_invalid_overwrite(
-    template_context,
-):
+def test_apply_overwrites_does_not_modify_choices_for_invalid_overwrite():
     """Verify variables overwrite for list if variable not in list ignored."""
-    generate.apply_overwrites_to_context(
-        context=template_context, overwrite_context={'orientation': 'foobar'}
+    expected_context = {
+        'choices_template': OrderedDict(
+            [
+                ('full_name', 'Raphael Pierzina'),
+                ('github_username', 'hackebrot'),
+                ('project_name', 'Kivy Project'),
+                ('repo_name', '{{cookiecutter.project_name|lower}}'),
+                ('orientation', ["all", "landscape", "portrait"]),
+            ]
+        )
+    }
+
+    generated_context = generate.generate_context(
+        context_file='tests/test-generate-context/choices_template.json',
+        default_context={
+            'not_in_template': 'foobar',
+            'project_name': 'Kivy Project',
+            'orientation': 'foobar',
+        },
+        extra_context={
+            'also_not_in_template': 'foobar2',
+            'github_username': 'hackebrot',
+        },
     )
 
-    assert template_context['orientation'] == ['all', 'landscape', 'portrait']
+    assert generated_context == expected_context
 
 
 def test_apply_overwrites_sets_default_for_choice_variable(template_context):

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -160,7 +160,7 @@ def test_apply_overwrites_does_not_modify_choices_for_invalid_overwrite():
                 ('github_username', 'hackebrot'),
                 ('project_name', 'Kivy Project'),
                 ('repo_name', '{{cookiecutter.project_name|lower}}'),
-                ('orientation', ["all", "landscape", "portrait"]),
+                ('orientation', ['all', 'landscape', 'portrait']),
             ]
         )
     }

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -181,6 +181,13 @@ def test_apply_overwrites_does_not_modify_choices_for_invalid_overwrite():
     assert generated_context == expected_context
 
 
+def test_apply_overwrites_invalid_overwrite(template_context):
+    with pytest.raises(ValueError):
+        generate.apply_overwrites_to_context(
+            context=template_context, overwrite_context={'orientation': 'foobar'}
+        )
+
+
 def test_apply_overwrites_sets_default_for_choice_variable(template_context):
     """Verify overwritten list member became a default value."""
     generate.apply_overwrites_to_context(


### PR DESCRIPTION
If an invalid value is provided for a choice variable (such as from a config file), this alerts the user instead of silently ignoring it.