### PR TITLE
Replace poyo with ruyaml.

### DIFF
--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -4,7 +4,7 @@ import copy
 import logging
 import os
 
-import yaml
+import ruyaml
 
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
 
@@ -62,8 +62,8 @@ def get_config(config_path):
     logger.debug('config_path is %s', config_path)
     with open(config_path, encoding='utf-8') as file_handle:
         try:
-            yaml_dict = yaml.safe_load(file_handle)
-        except yaml.YAMLError as e:
+            yaml_dict = ruyaml.YAML(typ='safe').load(file_handle)
+        except ruyaml.YAMLError as e:
             raise InvalidConfiguration(
                 'Unable to parse YAML file {}.'.format(config_path)
             ) from e

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -5,6 +5,8 @@ import logging
 import os
 
 import ruyaml
+from ruyaml import YAMLError
+yaml = ruyaml.YAML(typ='safe')
 
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
 
@@ -62,8 +64,8 @@ def get_config(config_path):
     logger.debug('config_path is %s', config_path)
     with open(config_path, encoding='utf-8') as file_handle:
         try:
-            yaml_dict = ruyaml.YAML(typ='safe').load(file_handle)
-        except ruyaml.YAMLError as e:
+            yaml_dict = yaml.load(file_handle)
+        except YAMLError as e:
             raise InvalidConfiguration(
                 'Unable to parse YAML file {}.'.format(config_path)
             ) from e

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -7,6 +7,7 @@ import os
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
 
 from ruyaml import YAMLError
+
 # from yaml import YAMLError
 import ruyaml
 

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -6,7 +6,10 @@ import os
 
 import ruyaml
 from ruyaml import YAMLError
+
 yaml = ruyaml.YAML(typ='safe')
+# import yaml
+# To swap, all we need to do is swap these lines above.
 
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
 

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -4,7 +4,6 @@ import copy
 import logging
 import os
 
-import poyo
 import yaml
 
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -4,14 +4,15 @@ import copy
 import logging
 import os
 
-import ruyaml
+from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
+
 from ruyaml import YAMLError
+# from yaml import YAMLError
+import ruyaml
 
 yaml = ruyaml.YAML(typ='safe')
 # import yaml
 # To swap, all we need to do is swap these lines above.
-
-from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
 
 logger = logging.getLogger(__name__)
 

--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -5,6 +5,7 @@ import logging
 import os
 
 import poyo
+import yaml
 
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
 
@@ -62,11 +63,11 @@ def get_config(config_path):
     logger.debug('config_path is %s', config_path)
     with open(config_path, encoding='utf-8') as file_handle:
         try:
-            yaml_dict = poyo.parse_string(file_handle.read())
-        except poyo.exceptions.PoyoException as e:
+            yaml_dict = yaml.safe_load(file_handle)
+        except yaml.YAMLError as e:
             raise InvalidConfiguration(
-                'Unable to parse YAML file {}. Error: {}'.format(config_path, e)
-            )
+                'Unable to parse YAML file {}.'.format(config_path)
+            ) from e
 
     config_dict = merge_configs(DEFAULT_CONFIG, yaml_dict)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     'binaryornot>=0.4.4',
     'Jinja2<3.0.0',
     'click>=7.0',
-    'pyyaml>=5.3.1',
+    'ruyaml',
     'jinja2-time>=0.2.0',
     'python-slugify>=4.0.0',
     'requests>=2.23.0',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     'binaryornot>=0.4.4',
     'Jinja2<3.0.0',
     'click>=7.0',
-    'poyo>=0.5.0',
+    'pyyaml>=5.3.1',
     'jinja2-time>=0.2.0',
     'python-slugify>=4.0.0',
     'requests>=2.23.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,13 @@ from cookiecutter import utils
 
 
 USER_CONFIG = """
-cookiecutters_dir: "{cookiecutters_dir}"
-replay_dir: "{replay_dir}"
+cookiecutters_dir: '{cookiecutters_dir}'
+replay_dir: '{replay_dir}'
 """
+# In YAML, double quotes mean to use escape sequences.
+# Single quotes mean we will have unescaped backslahes.
+# http://blogs.perl.org/users/tinita/2018/03/
+# strings-in-yaml---to-quote-or-not-to-quote.html
 
 
 def backup_dir(original_dir, backup_dir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 """pytest fixtures which are globally available throughout the suite."""
-import logging
 import os
 import shutil
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,9 +175,3 @@ def user_config_file(user_dir, user_config_data):
     config_text = USER_CONFIG.format(**user_config_data)
     config_file.write(config_text)
     return str(config_file)
-
-
-@pytest.fixture(autouse=True)
-def disable_poyo_logging():
-    """Fixture that disables poyo logging."""
-    logging.getLogger('poyo').setLevel(logging.WARNING)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -499,7 +499,11 @@ def test_debug_list_installed_templates(cli_runner, debug_file, user_config_path
     fake_template_dir = os.path.dirname(os.path.abspath('fake-project'))
     os.makedirs(os.path.dirname(user_config_path))
     with open(user_config_path, 'w') as config_file:
-        config_file.write('cookiecutters_dir: "%s"' % fake_template_dir)
+        # In YAML, double quotes mean to use escape sequences.
+        # Single quotes mean we will have unescaped backslahes.
+        # http://blogs.perl.org/users/tinita/2018/03/
+        # strings-in-yaml---to-quote-or-not-to-quote.html
+        config_file.write("cookiecutters_dir: '%s'" % fake_template_dir)
     open(os.path.join('fake-project', 'cookiecutter.json'), 'w').write('{}')
 
     result = cli_runner(

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -2,6 +2,7 @@
 import os
 
 import pytest
+import yaml
 
 from cookiecutter import config
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
@@ -82,13 +83,13 @@ def test_get_config_does_not_exist():
 def test_invalid_config():
     """An invalid config file should raise an `InvalidConfiguration` \
     exception."""
+    expected_error_msg = (
+        'Unable to parse YAML file tests/test-config/invalid-config.yaml.'
+    )
     with pytest.raises(InvalidConfiguration) as exc_info:
         config.get_config('tests/test-config/invalid-config.yaml')
-
-    expected_error_msg = (
-        'Unable to parse YAML file tests/test-config/invalid-config.yaml. Error: '
-    )
-    assert expected_error_msg in str(exc_info.value)
+        assert expected_error_msg in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, yaml.YAMLError)
 
 
 def test_get_config_with_defaults():

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -2,7 +2,7 @@
 import os
 
 import pytest
-import yaml
+import ruyaml
 
 from cookiecutter import config
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
@@ -89,7 +89,7 @@ def test_invalid_config():
     with pytest.raises(InvalidConfiguration) as exc_info:
         config.get_config('tests/test-config/invalid-config.yaml')
         assert expected_error_msg in str(exc_info.value)
-        assert isinstance(exc_info.value.__cause__, yaml.YAMLError)
+        assert isinstance(exc_info.value.__cause__, ruyaml.YAMLError)
 
 
 def test_get_config_with_defaults():

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 from ruyaml import YAMLError
+# from yaml import YAMLError
 
 from cookiecutter import config
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 from ruyaml import YAMLError
+
 # from yaml import YAMLError
 
 from cookiecutter import config

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -2,7 +2,7 @@
 import os
 
 import pytest
-import ruyaml
+from ruyaml import YAMLError
 
 from cookiecutter import config
 from cookiecutter.exceptions import ConfigDoesNotExistException, InvalidConfiguration
@@ -89,7 +89,7 @@ def test_invalid_config():
     with pytest.raises(InvalidConfiguration) as exc_info:
         config.get_config('tests/test-config/invalid-config.yaml')
         assert expected_error_msg in str(exc_info.value)
-        assert isinstance(exc_info.value.__cause__, ruyaml.YAMLError)
+        assert isinstance(exc_info.value.__cause__, YAMLError)
 
 
 def test_get_config_with_defaults():


### PR DESCRIPTION
https://github.com/cookiecutter/cookiecutter/pull/1489 used pyyaml because that's what https://github.com/cookiecutter/cookiecutter/pull/1471 and now https://github.com/cookiecutter/cookiecutter/pull/1497 used, but it would probably be better to use ruyaml, which supports YAML 1.2. (If @ssbarnea agrees.)

(pyyaml has expressed interest in YAML 1.2 and hope springs eternal that eventually pyyaml and ruyaml will merge, but for now ruyaml seems like the way to go, and in any case the difference between pyyaml and ruyaml is less than half a dozen lines so we could switch back if pyyaml updates.)