### PR TITLE
Log the error message when git clone fails, not just the return code

### DIFF
--- a/cookiecutter/vcs.py
+++ b/cookiecutter/vcs.py
@@ -115,6 +115,7 @@ def clone(repo_url, checkout=None, clone_to_dir='.', no_input=False):
                     'The {} branch of repository {} could not found, '
                     'have you made a typo?'.format(checkout, repo_url)
                 )
+            logger.error('git clone failed with error: %s', output)
             raise
 
     return repo_dir


### PR DESCRIPTION
I was trying to run the below command and getting a git error:
```
cookiecutter(template='https://github.com/drivendata/cookiecutter-data-science')
```


The current behavior only displays the return code of the git process:
```
subprocess.CalledProcessError: Command '['git', 'clone', 'https://github.com/drivendata/cookiecutter-data-science']' returned non-zero exit status 128.
```
I think it would be helpful to print the actual git output:
```
Cloning into 'cookiecutter-data-science'...
fatal: unable to access 'https://github.com/drivendata/cookiecutter-data-science/': SSL certificate problem: unable to get local issuer certificate

```

For what it's worth, I was then able to resolve the error (on windows) by setting the below:
```
git config --global http.sslbackend schannel
```

More info:  https://stackoverflow.com/questions/23885449/unable-to-resolve-unable-to-get-local-issuer-certificate-using-git-on-windows