### PR TITLE
allow jinja 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md', encoding='utf-8') as readme_file:
 
 requirements = [
     'binaryornot>=0.4.4',
-    'Jinja2<3.0.0',
+    'Jinja2<4.0.0',
     'click>=7.0',
     'pyyaml>=5.3.1',
     'jinja2-time>=0.2.0',


### PR DESCRIPTION
Jinja 3.0.0 has just been released 
https://jinja.palletsprojects.com/en/3.0.x/changes/#version-3-0-1

We depend on both cookiecutter and Jinja2, but cookiecutter is preventing us from updating Jinja2.
(see https://github.com/inmanta/inmanta-core/pull/2921)

I understand if you consider it too soon to merge this in.