### PR TITLE
Release 1.7.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,11 @@ History is important, but our current roadmap can be found [here](https://github
 * Do not modify this file, since 1.7.1 Changes are generated on Pull request
 title and will be added before release.
 
-## 1.7.2 (2019-04-21)
+## 1.7.3 (2021-05-14)
+
+* Fixed jinja2 and markupsafe dependencies
+
+## 1.7.2 (2020-04-21)
 
 * Fixed: Jinja2&Six version limits causing build errors with ansible project [@insspb](https://github.com/insspb) (#1385)
 

--- a/cookiecutter/__init__.py
+++ b/cookiecutter/__init__.py
@@ -2,4 +2,4 @@
 
 """Main package for Cookiecutter."""
 
-__version__ = '1.7.2'
+__version__ = '1.7.3'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 
 from setuptools import setup
 
-version = "1.7.2"
+version = "1.7.3"
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')


### PR DESCRIPTION
Release 1.7.3 hotfix in order to sort recent dependency conflicts.

Once merged, clone it and run `make release`.