### PR TITLE
Make release-drafter diff only between master releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,5 @@
+filter-by-commitish: true
+commitish: master
 categories:
   - title: 'Breaking Changes'
     labels:


### PR DESCRIPTION
This should restore release-drafter for the 2.0.0 release

Based on this comment on release-drafter: https://github.com/release-drafter/release-drafter/issues/656#issuecomment-806184887

This PR makes release-drafter considering only releases made on master branch.
If we want to support also hotfixes on stable branches we should make a release-drafter config for each `stable/x` branch