### PR TITLE
Adopt setuptools-scm packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
           pip install tox virtualenv
       - name: Lint
         run: "tox -e lint"
+      - name: Packaging
+        run: "tox -e packaging"
       - name: Safety
         run: "tox -e safety"
   build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,17 @@
+[build-system]
+requires = [
+  "setuptools >= 42.0.0",  # required by pyproject+setuptools_scm integration
+  "setuptools_scm[toml] >= 3.5.0",  # required for "no-local-version" scheme
+  "setuptools_scm_git_archive >= 1.0",
+  "wheel",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 skip-string-normalization = true
 exclude = '/(tests/hooks-abort-render/hooks|docs\/HelloCookieCutter1)/'
 line-length = 88
 target-version = ['py36']
+
+[tool.setuptools_scm]
+local_scheme = "no-local-version"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,77 @@
+[metadata]
+name = cookiecutter
+url = https://github.com/cookiecutter/cookiecutter
+project_urls =
+  Bug Tracker = https://github.com/cookiecutter/cookiecutter/issues
+  CI: GitHub = https://github.com/cookiecutter/cookiecutter/actions
+  Documentation = https://cookiecutter.readthedocs.io/
+  Source Code = https://github.com/cookiecutter/cookiecutter
+description =
+    A command-line utility that creates projects from project
+    templates, e.g. creating a Python package project from a
+    Python package project template.
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Audrey Feldroy
+author_email = audreyr@gmail.com
+maintainer = Audrey Feldroy
+maintainer_email = audreyr@gmail.com
+license = BSD
+license_file = LICENSE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Intended Audience :: Developers
+    Natural Language :: English
+    License :: OSI Approved :: BSD License
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Programming Language :: Python
+    Topic :: Software Development
+keywords =
+    cookiecutter
+    Python
+    projects
+    project templates
+    Jinja2
+    skeleton
+    scaffolding
+    project directory
+    package
+    packaging
+
+[options]
+use_scm_version = True
+python_requires = >=3.6
+; package_dir =
+;   = src
+packages = cookiecutter
+zip_safe = False
+
+# These are required during `setup.py` run:
+setup_requires =
+  setuptools_scm>=1.15.0
+  setuptools_scm_git_archive>=1.0
+
+install_requires =
+    binaryornot>=0.4.4
+    Jinja2>=2.7,<4.0.0
+    click>=7.0,<8.0.0
+    pyyaml>=5.3.1
+    jinja2-time>=0.2.0
+    python-slugify>=4.0.0
+    requests>=2.23.0
+
+[options.entry_points]
+console_scripts =
+  cookiecutter = cookiecutter.__main__:main
+
 [flake8]
 ignore = BLK100,E231,W503
 
@@ -11,7 +85,7 @@ statistics = 1
 max-line-length = 88
 
 [bdist_wheel]
-universal = 1
+universal = false
 
 [tool:pytest]
 testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -1,70 +1,13 @@
-#!/usr/bin/env python
-"""cookiecutter distutils configuration."""
-from setuptools import setup
+#! /usr/bin/env python3
+"""cookiecutter distutils configuration.
 
-version = "2.0.0"
+The presence of this file ensures the support
+of pip editable mode *with setuptools only*.
+"""
+import setuptools
 
-with open('README.md', encoding='utf-8') as readme_file:
-    readme = readme_file.read()
-
-requirements = [
-    'binaryornot>=0.4.4',
-    'Jinja2>=2.7,<4.0.0',
-    'click>=7.0,<8.0.0',
-    'pyyaml>=5.3.1',
-    'jinja2-time>=0.2.0',
-    'python-slugify>=4.0.0',
-    'requests>=2.23.0',
-]
-
-setup(
-    name='cookiecutter',
-    version=version,
-    description=(
-        'A command-line utility that creates projects from project '
-        'templates, e.g. creating a Python package project from a '
-        'Python package project template.'
-    ),
-    long_description=readme,
-    long_description_content_type='text/markdown',
-    author='Audrey Feldroy',
-    author_email='audreyr@gmail.com',
-    url='https://github.com/cookiecutter/cookiecutter',
-    packages=['cookiecutter'],
-    package_dir={'cookiecutter': 'cookiecutter'},
-    entry_points={'console_scripts': ['cookiecutter = cookiecutter.__main__:main']},
-    include_package_data=True,
-    python_requires='>=3.6',
-    install_requires=requirements,
-    license='BSD',
-    zip_safe=False,
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "Intended Audience :: Developers",
-        "Natural Language :: English",
-        "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Programming Language :: Python",
-        "Topic :: Software Development",
-    ],
-    keywords=[
-        "cookiecutter",
-        "Python",
-        "projects",
-        "project templates",
-        "Jinja2",
-        "skeleton",
-        "scaffolding",
-        "project directory",
-        "package",
-        "packaging",
-    ],
+# https://github.com/jazzband/pip-tools/issues/1278
+setuptools.setup(
+    use_scm_version={"local_scheme": "no-local-version"},
+    setup_requires=["setuptools_scm[toml]>=3.5.0"],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -43,3 +43,28 @@ commands =
     safety check --full-report
 deps =
     safety
+
+[testenv:packaging]
+description =
+  Build package, verify metadata, install package and assert behavior when ansible is missing.
+deps =
+  build
+  twine
+skip_install = true
+commands =
+  {envpython} -c 'import os.path, shutil, sys; \
+  dist_dir = os.path.join("{toxinidir}", "dist"); \
+  os.path.isdir(dist_dir) or sys.exit(0); \
+  print("Removing \{!s\} contents...".format(dist_dir), file=sys.stderr); \
+  shutil.rmtree(dist_dir)'
+  # build using moder python build (PEP-517)
+  {envpython} -m build \
+    --sdist \
+    --wheel \
+    --outdir {toxinidir}/dist/ \
+    {toxinidir}
+  # Validate metadata using twine
+  twine check {toxinidir}/dist/*
+  # Install the wheel
+  sh -c "python3 -m pip install {toxinidir}/dist/*.whl"
+whitelist_externals = sh


### PR DESCRIPTION
One direct benefit of this change is that package version is no longer hardcoded and is generated based on last tag.

Related: #1555