### PR TITLE
Sourcehut abbreviation [WIP]

### DIFF
--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -16,6 +16,7 @@ BUILTIN_ABBREVIATIONS = {
     'gh': 'https://github.com/{0}.git',
     'gl': 'https://gitlab.com/{0}.git',
     'bb': 'https://bitbucket.org/{0}',
+    'sr': 'https://git.sr.ht/~{0}',
 }
 
 DEFAULT_CONFIG = {

--- a/docs/advanced/user_config.rst
+++ b/docs/advanced/user_config.rst
@@ -49,5 +49,5 @@ Possible settings are:
   the text `{0}`, using standard Python string formatting.  With the above
   aliases, you could use the `cookiecutter-pypackage` template simply by saying
   `cookiecutter pp`, or `cookiecutter gh:audreyr/cookiecutter-pypackage`.
-  The `gh` (github), `bb` (bitbucket), and `gl` (gitlab) abbreviations shown
+  The `gh` (github), `bb` (bitbucket), `sr` (sourcehut), and `gl` (gitlab) abbreviations shown
   above are actually built in, and can be used without defining them yourself.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -42,7 +42,7 @@ To create a project from the cookiecutter-pypackage.git repo template::
 
     $ cookiecutter gh:audreyr/cookiecutter-pypackage
 
-Cookiecutter knows abbreviations for Github (``gh``), Bitbucket (``bb``), and
+Cookiecutter knows abbreviations for Github (``gh``), Bitbucket (``bb``), Sourcehut (``sr``), and
 GitLab (``gl``) projects, but you can also give it the full URL to any
 repository::
 

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -18,6 +18,7 @@ def test_merge_configs():
             'gh': 'https://github.com/{0}.git',
             'gl': 'https://gitlab.com/{0}.git',
             'bb': 'https://bitbucket.org/{0}',
+            'sr': 'https://git.sr.ht/~{0}',
         },
     }
 

--- a/tests/test_get_user_config.py
+++ b/tests/test_get_user_config.py
@@ -57,6 +57,7 @@ def custom_config():
             'gh': 'https://github.com/{0}.git',
             'gl': 'https://gitlab.com/{0}.git',
             'bb': 'https://bitbucket.org/{0}',
+            'sr': 'https://git.sr.ht/~{0}',
             'helloworld': 'https://github.com/hackebrot/helloworld',
         },
     }


### PR DESCRIPTION
Hi, Sourcehut has mercurial repositories also. 

This pr does not support those.

Any ideas how to cover that in a simple way?

It would be cool if the user could just give the `sr` abbreviation and either a git or hg repo as arg and cookiecutter will just dispatch to either `git.sr.ht/~` or `hg.sr.ht/~`