### PR TITLE
 Add support for codecommit (GCR)

### DIFF
--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -12,6 +12,9 @@ REPO_REGEX = re.compile(
 ((((git|hg)\+)?(git|ssh|file|https?):(//)?)
  |                                      # or
  (\w+@[\w\.]+)                          # something like user@...
+ |                                      # or
+ (codecommit)(::[\w-]+)?:(//)           # codecommit::us-east-1://... or
+                                        # codecommit://...
 )
 """,
     re.VERBOSE,

--- a/cookiecutter/vcs.py
+++ b/cookiecutter/vcs.py
@@ -39,6 +39,8 @@ def identify_repo(repo_url):
     else:
         if 'git' in repo_url:
             return 'git', repo_url
+        elif 'codecommit' in repo_url:
+            return 'git-remote-codecommit', repo_url
         elif 'bitbucket' in repo_url:
             return 'hg', repo_url
         else:
@@ -80,6 +82,11 @@ def clone(repo_url, checkout=None, clone_to_dir='.', no_input=False):
     repo_name = os.path.split(repo_url)[1]
     if repo_type == 'git':
         repo_name = repo_name.split(':')[-1].rsplit('.git')[0]
+        repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))
+    if repo_type == 'git-remote-codecommit':
+        # override repo type as it is a git extension
+        repo_type = 'git'
+        repo_name = repo_name.split('@')[-1]
         repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))
     if repo_type == 'hg':
         repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))

--- a/tests/repository/test_is_repo_url.py
+++ b/tests/repository/test_is_repo_url.py
@@ -31,6 +31,9 @@ def test_is_zip_file(zipfile):
         'hg+https://private.com/mercurialrepo',
         'https://bitbucket.org/pokoli/cookiecutter.hg',
         'file://server/path/to/repo.git',
+        'codecommit://cookiecutter',
+        'codecommit://test@cookiecutter',
+        'codecommit::eu-central-1://test@cookiecutter',
     ]
 )
 def remote_repo_url(request):

--- a/tests/vcs/test_clone.py
+++ b/tests/vcs/test_clone.py
@@ -88,6 +88,9 @@ def test_clone_should_silent_exit_if_ok_to_reuse(mocker, tmpdir):
         ('git', 'git@host:gitoliterepo', 'gitoliterepo'),
         ('git', 'git@gitlab.com:cookiecutter/cookiecutter.git', 'cookiecutter'),
         ('git', 'git@github.com:cookiecutter/cookiecutter.git', 'cookiecutter'),
+        ('git', 'codecommit://cookiecutter', 'cookiecutter'),
+        ('git', 'codecommit://test@cookiecutter', 'cookiecutter'),
+        ('git', 'codecommit::eu-central-1://test@cookiecutter', 'cookiecutter'),
     ],
 )
 def test_clone_should_invoke_vcs_command(


### PR DESCRIPTION
Resolves #1453

```
→ git remote -v
origin	codecommit::eu-central-1://some-repo (fetch)
origin	codecommit::eu-central-1://some-repo (push)
```

Support for AWS CodeCommit is provided through git-remote-codecommit extension: https://pypi.org/project/git-remote-codecommit/

