### PR TITLE
Include pyyaml in test_requirements.txt

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,5 @@
+freezegun
 pytest
 pytest-cov
 pytest-mock
-freezegun
+pyyaml


### PR DESCRIPTION
After cloning the project, I needed to install `pyyaml` to run `pytest`