### PR TITLE
Correct broken links to jinja docs for `if` and `for` statements

### DIFF
--- a/docs/advanced/choice_variables.rst
+++ b/docs/advanced/choice_variables.rst
@@ -39,7 +39,7 @@ can be used like this::
 
   {% endif %}
 
-Cookiecutter is using `Jinja2's if conditional expression <http://jinja.pocoo.org/docs/dev/templates/#if>`_ to determine the correct license.
+Cookiecutter is using `Jinja2's if conditional expression <https://jinja.palletsprojects.com/en/latest/templates/#if`_ to determine the correct license.
 
 The created choice variable is still a regular Cookiecutter variable and can be used like this::
 

--- a/docs/advanced/dict_variables.rst
+++ b/docs/advanced/dict_variables.rst
@@ -61,5 +61,5 @@ The above ``file_type`` dictionary variable creates
     {% endfor %}
 
 
-Cookiecutter is using `Jinja2's for expression <http://jinja.pocoo.org/docs/dev/templates/#for>`_ to iterate over the items in the dictionary.
+Cookiecutter is using `Jinja2's for expression <https://jinja.palletsprojects.com/en/latest/templates/#for>`_ to iterate over the items in the dictionary.
 


### PR DESCRIPTION
The current links for jinja statements `if` and `for` are resolving to `Page not found`, updated them to correct pages.