### PR TITLE
Remove newline from description field in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,7 @@ project_urls =
   CI: GitHub = https://github.com/cookiecutter/cookiecutter/actions
   Documentation = https://cookiecutter.readthedocs.io/
   Source Code = https://github.com/cookiecutter/cookiecutter
-description =
-    A command-line utility that creates projects from project
-    templates, e.g. creating a Python package project from a
-    Python package project template.
+description = A command-line utility that creates projects from project templates, e.g. creating a Python package project from a Python package project template.
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = Audrey Feldroy


### PR DESCRIPTION
Try to fix this issue https://github.com/cookiecutter/cookiecutter/issues/1614

Info to fix find in:
* https://setuptools.pypa.io/en/latest/userguide/declarative_config.html?highlight=setup.cfg
* https://github.com/pypa/setuptools/issues/1390#ref-pullrequest-1055003577


##  Before
```python
pip install -e /home/thomas/Work/tests/cookiecutter
Defaulting to user installation because normal site-packages is not writeable
Obtaining file:///home/thomas/Work/tests/cookiecutter
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3 /home/thomas/.local/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmptgk2ykzc
       cwd: /home/thomas/Work/tests/cookiecutter
  Complete output (37 lines):
  running dist_info
  creating /tmp/pip-modern-metadata-fcez5afp/cookiecutter.egg-info
  writing /tmp/pip-modern-metadata-fcez5afp/cookiecutter.egg-info/PKG-INFO
  Traceback (most recent call last):
    File "/home/thomas/.local/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
      main()
    File "/home/thomas/.local/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/home/thomas/.local/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 164, in prepare_metadata_for_build_wheel
      return hook(metadata_directory, config_settings)
    File "/tmp/pip-build-env-hozahlxj/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 174, in prepare_metadata_for_build_wheel
      self.run_setup()
    File "/tmp/pip-build-env-hozahlxj/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 158, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 10, in <module>
      setuptools.setup(
    File "/tmp/pip-build-env-hozahlxj/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 153, in setup
      return distutils.core.setup(**attrs)
    File "/usr/lib/python3.8/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/lib/python3.8/distutils/dist.py", line 966, in run_commands
      self.run_command(cmd)
    File "/usr/lib/python3.8/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/tmp/pip-build-env-hozahlxj/overlay/lib/python3.8/site-packages/setuptools/command/dist_info.py", line 31, in run
      egg_info.run()
    File "/tmp/pip-build-env-hozahlxj/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 292, in run
      writer(self, ep.name, os.path.join(self.egg_info, ep.name))
    File "/tmp/pip-build-env-hozahlxj/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 656, in write_pkg_info
      metadata.write_pkg_info(cmd.egg_info)
    File "/usr/lib/python3.8/distutils/dist.py", line 1117, in write_pkg_info
      self.write_pkg_file(pkg_info)
    File "/tmp/pip-build-env-hozahlxj/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 167, in write_pkg_file
      write_field('Summary', single_line(self.get_description()))
    File "/tmp/pip-build-env-hozahlxj/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 151, in single_line
      raise ValueError('Newlines are not allowed')
  ValueError: Newlines are not allowed
  ----------------------------------------
WARNING: Discarding file:///home/thomas/Work/tests/cookiecutter. Command errored out with exit status 1: /usr/bin/python3 /home/thomas/.local/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmptgk2ykzc Check the logs for full command output.
ERROR: Command errored out with exit status 1: /usr/bin/python3 /home/thomas/.local/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmptgk2ykzc Check the logs for full command output.
```

-----

## After
```python
pip install -e /home/thomas/Work/tests/cookiecutter
Defaulting to user installation because normal site-packages is not writeable
Obtaining file:///home/thomas/Work/tests/cookiecutter
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: requests>=2.23.0 in /home/thomas/.local/lib/python3.8/site-packages (from cookiecutter==2.0.0a1.dev5) (2.24.0)
Requirement already satisfied: jinja2-time>=0.2.0 in /home/thomas/.local/lib/python3.8/site-packages (from cookiecutter==2.0.0a1.dev5) (0.2.0)
Requirement already satisfied: binaryornot>=0.4.4 in /home/thomas/.local/lib/python3.8/site-packages (from cookiecutter==2.0.0a1.dev5) (0.4.4)
Requirement already satisfied: pyyaml>=5.3.1 in /usr/lib/python3/dist-packages (from cookiecutter==2.0.0a1.dev5) (5.3.1)
Requirement already satisfied: python-slugify>=4.0.0 in /home/thomas/.local/lib/python3.8/site-packages (from cookiecutter==2.0.0a1.dev5) (4.0.1)
Requirement already satisfied: click<9.0.0,>=7.0 in /home/thomas/.local/lib/python3.8/site-packages (from cookiecutter==2.0.0a1.dev5) (7.1.2)
Requirement already satisfied: Jinja2<4.0.0,>=2.7 in /home/thomas/.local/lib/python3.8/site-packages (from cookiecutter==2.0.0a1.dev5) (2.11.2)
Requirement already satisfied: chardet>=3.0.2 in /usr/lib/python3/dist-packages (from binaryornot>=0.4.4->cookiecutter==2.0.0a1.dev5) (3.0.4)
Requirement already satisfied: MarkupSafe>=0.23 in /usr/lib/python3/dist-packages (from Jinja2<4.0.0,>=2.7->cookiecutter==2.0.0a1.dev5) (1.1.0)
Requirement already satisfied: arrow in /home/thomas/.local/lib/python3.8/site-packages (from jinja2-time>=0.2.0->cookiecutter==2.0.0a1.dev5) (0.17.0)
Requirement already satisfied: text-unidecode>=1.3 in /home/thomas/.local/lib/python3.8/site-packages (from python-slugify>=4.0.0->cookiecutter==2.0.0a1.dev5) (1.3)
Requirement already satisfied: idna<3,>=2.5 in /usr/lib/python3/dist-packages (from requests>=2.23.0->cookiecutter==2.0.0a1.dev5) (2.8)
Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/lib/python3/dist-packages (from requests>=2.23.0->cookiecutter==2.0.0a1.dev5) (1.25.8)
Requirement already satisfied: certifi>=2017.4.17 in /usr/lib/python3/dist-packages (from requests>=2.23.0->cookiecutter==2.0.0a1.dev5) (2019.11.28)
Requirement already satisfied: python-dateutil>=2.7.0 in /usr/lib/python3/dist-packages (from arrow->jinja2-time>=0.2.0->cookiecutter==2.0.0a1.dev5) (2.7.3)
Installing collected packages: cookiecutter
  Attempting uninstall: cookiecutter
    Found existing installation: cookiecutter 2.0.0a1.dev5
    Uninstalling cookiecutter-2.0.0a1.dev5:
      Successfully uninstalled cookiecutter-2.0.0a1.dev5
  Running setup.py develop for cookiecutter
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/thomas/Work/tests/cookiecutter/setup.py'"'"'; __file__='"'"'/home/thomas/Work/tests/cookiecutter/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps --user --prefix=
         cwd: /home/thomas/Work/tests/cookiecutter/
    Complete output (32 lines):
    running develop
    /tmp/pip-build-env-s22a9ydz/overlay/lib/python3.8/site-packages/setuptools/command/easy_install.py:156: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
      warnings.warn(
    WARNING: The user site-packages directory is disabled.
    /tmp/pip-build-env-s22a9ydz/overlay/lib/python3.8/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
      warnings.warn(
    error: can't create or remove files in install directory
    
    The following error occurred while trying to add or remove files in the
    installation directory:
    
        [Errno 13] Permission denied: '/usr/local/lib/python3.8/dist-packages/test-easy-install-133040.write-test'
    
    The installation directory you specified (via --install-dir, --prefix, or
    the distutils default setting) was:
    
        /usr/local/lib/python3.8/dist-packages/
    
    Perhaps your account does not have write access to this directory?  If the
    installation directory is a system-owned directory, you may need to sign in
    as the administrator or "root" account.  If you do not have administrative
    access to this machine, you may wish to choose a different installation
    directory, preferably one that is listed in your PYTHONPATH environment
    variable.
    
    For information on other options, you may wish to consult the
    documentation at:
    
      https://setuptools.readthedocs.io/en/latest/deprecated/easy_install.html
    
    Please make the appropriate changes for your system and try again.
    
    ----------------------------------------
  Rolling back uninstall of cookiecutter
  Moving to /home/thomas/.local/bin/cookiecutter
   from /tmp/pip-uninstall-obx6lq9_/cookiecutter
  Moving to /home/thomas/.local/lib/python3.8/site-packages/cookiecutter-2.0.0a1.dev5.dist-info/
   from /home/thomas/.local/lib/python3.8/site-packages/~ookiecutter-2.0.0a1.dev5.dist-info
  Moving to /home/thomas/.local/lib/python3.8/site-packages/cookiecutter/
   from /home/thomas/.local/lib/python3.8/site-packages/~ookiecutter
ERROR: Command errored out with exit status 1: /usr/bin/python3 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/thomas/Work/tests/cookiecutter/setup.py'"'"'; __file__='"'"'/home/thomas/Work/tests/cookiecutter/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps --user --prefix= Check the logs for full command output.
```