### PR TITLE
Fix Python version number in `cookiecutter --version` and test on Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,10 +42,12 @@ jobs:
           - "macos-py37"
           - "macos-py38"
           - "macos-py39"
+          - "macos-py310"
 
           - "windows-py37"
           - "windows-py38"
           - "windows-py39"
+          - "windows-py310"
 
         include:
           - name: "ubuntu-py37"
@@ -77,6 +79,10 @@ jobs:
             python: "3.9"
             os: macos-latest
             tox_env: "py39"
+          - name: "macos-py310"
+            python: "3.10"
+            os: macos-latest
+            tox_env: "py310"
 
           - name: "windows-py37"
             python: "3.7"
@@ -90,6 +96,10 @@ jobs:
             python: "3.9"
             os: windows-latest
             tox_env: "py39"
+          - name: "windows-py310"
+            python: "3.10"
+            os: windows-latest
+            tox_env: "py310"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
           - "ubuntu-py37"
           - "ubuntu-py38"
           - "ubuntu-py39"
+          - "ubuntu-py310"
 
           - "macos-py37"
           - "macos-py38"
@@ -59,6 +60,10 @@ jobs:
             python: "3.9"
             os: ubuntu-latest
             tox_env: "py39"
+          - name: "ubuntu-py310"
+            python: "3.10"
+            os: ubuntu-latest
+            tox_env: "py310"
 
           - name: "macos-py37"
             python: "3.7"

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -25,7 +25,7 @@ from cookiecutter.config import get_user_config
 
 def version_msg():
     """Return the Cookiecutter version, location and Python powering it."""
-    python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
+    python_version = f'{sys.version_info.major}.{sys.version_info.minor}'
     location = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     message = 'Cookiecutter %(version)s from {} (Python {})'
     return message.format(location, python_version)

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -25,7 +25,7 @@ from cookiecutter.config import get_user_config
 
 def version_msg():
     """Return the Cookiecutter version, location and Python powering it."""
-    python_version = f'{sys.version_info.major}.{sys.version_info.minor}'
+    python_version = sys.version
     location = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     message = 'Cookiecutter %(version)s from {} (Python {})'
     return message.format(location, python_version)

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -25,7 +25,7 @@ from cookiecutter.config import get_user_config
 
 def version_msg():
     """Return the Cookiecutter version, location and Python powering it."""
-    python_version = sys.version[:3]
+    python_version = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
     location = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     message = 'Cookiecutter %(version)s from {} (Python {})'
     return message.format(location, python_version)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,8 @@ def test_cli_version(cli_runner, version_cli_flag):
     assert result.exit_code == 0
     assert result.output.startswith('Cookiecutter')
 
+def test_version_msg():
+    print("to do")
 
 @pytest.mark.usefixtures('make_fake_project_dir', 'remove_fake_project_dir')
 def test_cli_error_on_existing_output_directory(cli_runner):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,18 +57,6 @@ def test_cli_version(cli_runner, version_cli_flag):
     assert result.output.startswith('Cookiecutter')
 
 
-def test_cli_version_python(cli_runner, version_cli_flag):
-    """Verify correct Python version output by `cookiecutter` on cli invocation."""
-    result = cli_runner(version_cli_flag)
-    python_major_number = sys.version_info.major
-    python_minor_number = sys.version_info.minor
-    version_output_string = result.output[:-1]
-    version_output_string = version_output_string[-5:-1]
-    if version_output_string[0] == ' ':
-        version_output_string = version_output_string[1:]
-    assert f'{python_major_number}.{python_minor_number}' == version_output_string
-
-
 @pytest.mark.usefixtures('make_fake_project_dir', 'remove_fake_project_dir')
 def test_cli_error_on_existing_output_directory(cli_runner):
     """Test cli invocation without `overwrite-if-exists` fail if dir exist."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,14 +51,14 @@ def version_cli_flag(request):
 
 
 def test_cli_version(cli_runner, version_cli_flag):
-    """Verify correct version output by `cookiecutter` on cli invocation."""
+    """Verify Cookiecutter version output by `cookiecutter` on cli invocation."""
     result = cli_runner(version_cli_flag)
     assert result.exit_code == 0
     assert result.output.startswith('Cookiecutter')
 
 
-def test_version_msg(cli_runner, version_cli_flag):
-    """Verify correct output for Cookiecutter Python version."""
+def test_cli_version_python(cli_runner, version_cli_flag):
+    """Verify correct Python version output by `cookiecutter` on cli invocation."""
     result = cli_runner(version_cli_flag)
     python_major_number = sys.version_info.major
     python_minor_number = sys.version_info.minor
@@ -66,12 +66,7 @@ def test_version_msg(cli_runner, version_cli_flag):
     version_output_string = version_output_string[-5:-1]
     if version_output_string[0] == ' ':
         version_output_string = version_output_string[1:]
-    if version_output_string[-1] == ')':
-        version_output_string = version_output_string[:-1]
-    assert (
-        str(python_major_number) + '.' + str(python_minor_number)
-        == version_output_string
-    )
+    assert f'{python_major_number}.{python_minor_number}' == version_output_string
 
 
 @pytest.mark.usefixtures('make_fake_project_dir', 'remove_fake_project_dir')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,8 +4,6 @@ import json
 import os
 import re
 
-import sys
-
 
 import pytest
 from click.testing import CliRunner

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,9 @@ import json
 import os
 import re
 
+import sys
+
+
 import pytest
 from click.testing import CliRunner
 
@@ -53,8 +56,23 @@ def test_cli_version(cli_runner, version_cli_flag):
     assert result.exit_code == 0
     assert result.output.startswith('Cookiecutter')
 
-def test_version_msg():
-    print("to do")
+
+def test_version_msg(cli_runner, version_cli_flag):
+    """Verify correct output for Cookiecutter Python version."""
+    result = cli_runner(version_cli_flag)
+    python_major_number = sys.version_info.major
+    python_minor_number = sys.version_info.minor
+    version_output_string = result.output[:-1]
+    version_output_string = version_output_string[-5:-1]
+    if version_output_string[0] == ' ':
+        version_output_string = version_output_string[1:]
+    if version_output_string[-1] == ')':
+        version_output_string = version_output_string[:-1]
+    assert (
+        str(python_major_number) + '.' + str(python_minor_number)
+        == version_output_string
+    )
+
 
 @pytest.mark.usefixtures('make_fake_project_dir', 'remove_fake_project_dir')
 def test_cli_error_on_existing_output_directory(cli_runner):

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py37
     py38
     py39
+    py310
 minversion = 3.14.2
 requires =
     virtualenv >= 20.4.5


### PR DESCRIPTION
Closes #1619

- On Python 3.10 `cookiecutter --version` now prints Python 3.10 instead of Python 3.1
- Added test to verify this behavior 
- Added cross-platform Python 3.10 CI environments