### PR TITLE
Docs: Advanced Usage "New in version" unified

### DIFF
--- a/docs/advanced/copy_without_render.rst
+++ b/docs/advanced/copy_without_render.rst
@@ -1,9 +1,7 @@
 .. _copy-without-render:
 
-Copy without Render
--------------------
-
-*New in Cookiecutter 1.1*
+Copy without Render (1.1+)
+--------------------------
 
 To avoid rendering directories and files of a cookiecutter, the `_copy_without_render` key can be used in the `cookiecutter.json`. The value of this key accepts a list of Unix shell-style wildcards::
 

--- a/docs/advanced/directories.rst
+++ b/docs/advanced/directories.rst
@@ -1,9 +1,7 @@
 .. _directories:
 
 Organizing cookiecutters in directories (1.7+)
----------------------------------------------------
-
-*New in Cookiecutter 1.7*
+----------------------------------------------
 
 Cookiecutter introduces the ability to organize several templates in one
 repository or zip file, separating them by directories. This allows using

--- a/docs/advanced/hooks.rst
+++ b/docs/advanced/hooks.rst
@@ -1,7 +1,7 @@
 .. _user-hooks:
 
 Using Pre/Post-Generate Hooks (0.7.0+)
-======================================
+--------------------------------------
 
 You can have Python or Shell scripts that run before and/or after your project
 is generated.

--- a/docs/advanced/new_line_characters.rst
+++ b/docs/advanced/new_line_characters.rst
@@ -1,9 +1,7 @@
 .. _new-lines:
 
-Working with line-ends special symbols LF/CRLF
+Working with line-ends special symbols LF/CRLF (2.0+)
 ----------------------------------------------
-
-*New in Cookiecutter 2.0*
 
 Before version 2.0 Cookiecutter silently used system line end character.
 LF for POSIX and CRLF for Windows. Since version 2.0 this behaviour changed

--- a/docs/advanced/new_line_characters.rst
+++ b/docs/advanced/new_line_characters.rst
@@ -1,7 +1,7 @@
 .. _new-lines:
 
 Working with line-ends special symbols LF/CRLF (2.0+)
-----------------------------------------------
+-----------------------------------------------------
 
 Before version 2.0 Cookiecutter silently used system line end character.
 LF for POSIX and CRLF for Windows. Since version 2.0 this behaviour changed

--- a/docs/advanced/private_variables.rst
+++ b/docs/advanced/private_variables.rst
@@ -1,7 +1,7 @@
 .. _private-variables:
 
-Private Variables
------------------
+Private Variables (2.0+)
+------------------------
 
 Cookiecutter allows the definition private variables - those the user will not be required to fill in - by prepending an underscore to the variable name. These can either be not rendered, by using a prepending underscore, or rendered, prepending a double underscore. For example, the ``cookiecutter.json``::
 

--- a/docs/advanced/replay.rst
+++ b/docs/advanced/replay.rst
@@ -1,9 +1,7 @@
 .. _replay-feature:
 
-Replay Project Generation
--------------------------
-
-*New in Cookiecutter 1.1*
+Replay Project Generation (1.1+)
+--------------------------------
 
 On invocation **Cookiecutter** dumps a json file to ``~/.cookiecutter_replay/`` which enables you to *replay* later on.
 

--- a/docs/advanced/template_extensions.rst
+++ b/docs/advanced/template_extensions.rst
@@ -1,9 +1,7 @@
 .. _`template extensions`:
 
-Template Extensions
--------------------
-
-*New in Cookiecutter 1.4*
+Template Extensions (1.4+)
+--------------------------
 
 A template may extend the Cookiecutter environment with custom `Jinja2 extensions`_,
 that can add extra filters, tests, globals or even extend the parser.


### PR DESCRIPTION
So far, the versions are written differently and sometimes twice. For a new feature they were missing completely.
This is to be made more consistent now.