### PR TITLE
Support `--directory` in abbreviation definitions

### DIFF
--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -34,16 +34,21 @@ def expand_abbreviations(template, abbreviations):
     :param template: The project template name.
     :param abbreviations: Abbreviation definitions.
     """
-    if template in abbreviations:
-        return abbreviations[template]
-
     # Split on colon. If there is no colon, rest will be empty
     # and prefix will be the whole template
     prefix, sep, rest = template.partition(':')
-    if prefix in abbreviations:
-        return abbreviations[prefix].format(rest)
 
-    return template
+    if prefix in abbreviations:
+        expansion = abbreviations[prefix]
+        directory = None
+        if isinstance(expansion, dict):
+            directory = expansion.get('directory', None)
+            expansion = expansion['expansion']
+        if rest:
+            return expansion.format(rest), directory
+        return expansion, directory
+
+    return template, None
 
 
 def repository_has_cookiecutter_json(repo_directory):
@@ -90,7 +95,8 @@ def determine_repo_dir(
         after the template has been instantiated.
     :raises: `RepositoryNotFound` if a repository directory could not be found.
     """
-    template = expand_abbreviations(template, abbreviations)
+    template, abbrev_directory = expand_abbreviations(template, abbreviations)
+    directory = directory or abbrev_directory
 
     if is_zip_file(template):
         unzipped_dir = unzip(

--- a/docs/advanced/user_config.rst
+++ b/docs/advanced/user_config.rst
@@ -33,6 +33,9 @@ Example user config:
         pp: https://github.com/audreyr/cookiecutter-pypackage.git
         gh: https://github.com/{0}.git
         bb: https://bitbucket.org/{0}
+        advanced:
+            expansion: https://github.com/{0}/cookiecutter-repo.git
+            directory: my-cutter
 
 Possible settings are:
 
@@ -51,3 +54,7 @@ Possible settings are:
   `cookiecutter pp`, or `cookiecutter gh:audreyr/cookiecutter-pypackage`.
   The `gh` (github), `bb` (bitbucket), and `gl` (gitlab) abbreviations shown
   above are actually built in, and can be used without defining them yourself.
+  To specify the ``--directory`` option in abbreviations, write the
+  abbreviation as a mapping. The key ``expansion`` must contain the expanded
+  repository string and the key ``directory`` the subdirectory of that
+  repository.

--- a/tests/repository/test_abbreviation_expansion.py
+++ b/tests/repository/test_abbreviation_expansion.py
@@ -13,6 +13,7 @@ from cookiecutter.repository import expand_abbreviations
         ('xx:a', {'xx': '<{0}>'}, '<a>'),
         ('gh:a', {'gh': '<{0}>'}, '<a>'),
         ('xx:a', {'xx': '<>'}, '<>'),
+        ('advanced', {'advanced': {'expansion': 'exp'}}, 'exp'),
         (
             'gh:pydanny/cookiecutter-django',
             BUILTIN_ABBREVIATIONS,
@@ -35,6 +36,7 @@ from cookiecutter.repository import expand_abbreviations
         'Expansion prefix',
         'expansion_override_builtin',
         'expansion_prefix_ignores_suffix',
+        'abbreviation_with_advanced_expansion',
         'Correct expansion for builtin abbreviations (github)',
         'Correct expansion for builtin abbreviations (gitlab)',
         'Correct expansion for builtin abbreviations (bitbucket)',
@@ -42,7 +44,7 @@ from cookiecutter.repository import expand_abbreviations
 )
 def test_abbreviation_expansion(template, abbreviations, expected_result):
     """Verify abbreviation unpacking."""
-    expanded = expand_abbreviations(template, abbreviations)
+    expanded, _ = expand_abbreviations(template, abbreviations)
     assert expanded == expected_result
 
 
@@ -50,3 +52,17 @@ def test_abbreviation_expansion_prefix_not_0_in_braces():
     """Verify abbreviation unpacking raises error on incorrect index."""
     with pytest.raises(IndexError):
         expand_abbreviations('xx:a', {'xx': '{1}'})
+
+
+def test_abbreviation_with_directory():
+    """Verify that we can expand advanced abbreviations with a directory"""
+    template = "my-abbreviation"
+    abbreviations = {
+        "my-abbreviation": {
+            "expansion": "the-expansion",
+            "directory": "the-directory",
+        }
+    }
+    expanded, directory = expand_abbreviations(template, abbreviations)
+    assert expanded == "the-expansion"
+    assert directory == "the-directory"

--- a/tests/repository/test_is_repo_url.py
+++ b/tests/repository/test_is_repo_url.py
@@ -71,5 +71,5 @@ def test_expand_abbreviations():
     # First `repository.expand_abbreviations` needs to translate it
     assert is_repo_url(template) is False
 
-    expanded_template = expand_abbreviations(template, BUILTIN_ABBREVIATIONS)
+    expanded_template, _ = expand_abbreviations(template, BUILTIN_ABBREVIATIONS)
     assert is_repo_url(expanded_template) is True


### PR DESCRIPTION
This PR adds support to specify a "directory" in an abbreviation (as in the `--directory` CLI argument).

In order to support this while still being backwards compatible, the code needed a slight adaptation in how expansions are executed.

When this is merged, a user can write abbreviations in two variants:

* simple: A simple string. This is the same behaviour as currently exists in cookie-cutter
* advanced: A mapping. This new format allows to add the `directory` option.

This change also opens up the possibility to add more keys to abbreviations, opening up the doors to more advanced abbreviation handling, while still keeping backwards compatibility.