### PR TITLE
fixed the override not working with copy only dir #1650

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -333,6 +333,7 @@ def generate_files(
                 # specified in the ``_copy_without_render`` setting, but
                 # we store just the dir name
                 if is_copy_only_path(d_, context):
+                    logger.debug('Found copy only path %s', d)
                     copy_dirs.append(d)
                 else:
                     render_dirs.append(d)
@@ -342,6 +343,10 @@ def generate_files(
                 outdir = os.path.normpath(os.path.join(project_dir, indir))
                 outdir = env.from_string(outdir).render(**context)
                 logger.debug('Copying dir %s to %s without rendering', indir, outdir)
+
+                # if the outdir is there, it must be a overwrite execution
+                if os.path.isdir(outdir):
+                    shutil.rmtree(outdir)
                 shutil.copytree(indir, outdir)
 
             # We mutate ``dirs``, because we only want to go through these dirs

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -346,8 +346,10 @@ def generate_files(
                 outdir = env.from_string(outdir).render(**context)
                 logger.debug('Copying dir %s to %s without rendering', indir, outdir)
 
-                # if the outdir is there, it must be a overwrite execution
-                if os.path.isdir(outdir) and overwrite_if_exists:
+                # The outdir is not the root dir, it is the dir which marked as copy
+                # only in the config file. If the program hits this line, which means
+                # the overwrite_if_exists = True, and root dir exists
+                if os.path.isdir(outdir):
                     shutil.rmtree(outdir)
                 shutil.copytree(indir, outdir)
 

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -345,7 +345,7 @@ def generate_files(
                 logger.debug('Copying dir %s to %s without rendering', indir, outdir)
 
                 # if the outdir is there, it must be a overwrite execution
-                if os.path.isdir(outdir):
+                if os.path.isdir(outdir) and overwrite_if_exists:
                     shutil.rmtree(outdir)
                 shutil.copytree(indir, outdir)
 

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -277,6 +277,8 @@ def generate_files(
     :param output_dir: Where to output the generated project dir into.
     :param overwrite_if_exists: Overwrite the contents of the output directory
         if it exists.
+    :param skip_if_file_exists: Skip the files in the corresponding directories
+        if they already exist
     :param accept_hooks: Accept pre and post hooks if set to `True`.
     :param keep_project_on_failure: If `True` keep generated project directory even when
         generation fails

--- a/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/README.rst
+++ b/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/README.rst
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.render_test}}

--- a/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/README.txt
+++ b/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/README.txt
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.render_test}}

--- a/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/rendered/not_rendered.yml
+++ b/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/rendered/not_rendered.yml
@@ -1,0 +1,2 @@
+---
+- name: {{cookiecutter.render_test}}

--- a/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-not-rendered/README.rst
+++ b/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-not-rendered/README.rst
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.render_test}}

--- a/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.md
+++ b/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.md
@@ -1,0 +1,3 @@
+# Fake Project
+
+{{cookiecutter.render_test}}

--- a/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.rst
+++ b/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.rst
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.render_test}}

--- a/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.txt
+++ b/tests/test-generate-copy-without-render-override/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}-rendered/README.txt
@@ -1,0 +1,5 @@
+============
+Fake Project
+============
+
+{{cookiecutter.render_test}}

--- a/tests/test_generate_copy_without_render_override.py
+++ b/tests/test_generate_copy_without_render_override.py
@@ -1,0 +1,95 @@
+"""Verify correct work of `_copy_without_render` context option."""
+import os
+
+import pytest
+
+from cookiecutter import generate
+from cookiecutter import utils
+
+
+@pytest.fixture
+def remove_test_dir():
+    """Fixture. Remove the folder that is created by the test."""
+    yield
+    if os.path.exists('test_copy_without_render'):
+        utils.rmtree('test_copy_without_render')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_test_dir')
+def test_generate_copy_without_render_extensions():
+    """Verify correct work of `_copy_without_render` context option.
+
+    Some files/directories should be rendered during invocation,
+    some just copied, without any modification.
+    """
+
+    # first run
+    generate.generate_files(
+        context={
+            'cookiecutter': {
+                'repo_name': 'test_copy_without_render',
+                'render_test': 'I have been rendered!',
+                '_copy_without_render': [
+                    '*not-rendered',
+                    'rendered/not_rendered.yml',
+                    '*.txt',
+                    '{{cookiecutter.repo_name}}-rendered/README.md',
+                ],
+            }
+        },
+        repo_dir='tests/test-generate-copy-without-render-override',
+    )
+
+    # second run with override flag to True
+    generate.generate_files(
+        context={
+            'cookiecutter': {
+                'repo_name': 'test_copy_without_render',
+                'render_test': 'I have been rendered!',
+                '_copy_without_render': [
+                    '*not-rendered',
+                    'rendered/not_rendered.yml',
+                    '*.txt',
+                    '{{cookiecutter.repo_name}}-rendered/README.md',
+                ],
+            }
+        },
+        overwrite_if_exists=True,
+        repo_dir='tests/test-generate-copy-without-render',
+    )
+
+    dir_contents = os.listdir('test_copy_without_render')
+
+    assert 'test_copy_without_render-not-rendered' in dir_contents
+    assert 'test_copy_without_render-rendered' in dir_contents
+
+    with open('test_copy_without_render/README.txt') as f:
+        assert '{{cookiecutter.render_test}}' in f.read()
+
+    with open('test_copy_without_render/README.rst') as f:
+        assert 'I have been rendered!' in f.read()
+
+    with open(
+        'test_copy_without_render/test_copy_without_render-rendered/README.txt'
+    ) as f:
+        assert '{{cookiecutter.render_test}}' in f.read()
+
+    with open(
+        'test_copy_without_render/test_copy_without_render-rendered/README.rst'
+    ) as f:
+        assert 'I have been rendered' in f.read()
+
+    with open(
+        'test_copy_without_render/'
+        'test_copy_without_render-not-rendered/'
+        'README.rst'
+    ) as f:
+        assert '{{cookiecutter.render_test}}' in f.read()
+
+    with open('test_copy_without_render/rendered/not_rendered.yml') as f:
+        assert '{{cookiecutter.render_test}}' in f.read()
+
+    with open(
+        'test_copy_without_render/' 'test_copy_without_render-rendered/' 'README.md'
+    ) as f:
+        assert '{{cookiecutter.render_test}}' in f.read()

--- a/tests/test_generate_copy_without_render_override.py
+++ b/tests/test_generate_copy_without_render_override.py
@@ -22,7 +22,6 @@ def test_generate_copy_without_render_extensions():
     Some files/directories should be rendered during invocation,
     some just copied, without any modification.
     """
-
     # first run
     generate.generate_files(
         context={


### PR DESCRIPTION
Fixed the issue of failure execution when
- the `overwrite_if_exists=True`
- there are copy only directories in the context
