### PR TITLE
setup: fix version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """cookiecutter distutils configuration."""
 from setuptools import setup
 
-version = "2.0.0"
+version = "2.0.2"
 
 with open('README.md', encoding='utf-8') as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
minor change to fix the version number in setup.py. that mistake leads
to wrong version numbers on the local installation
