### PR TITLE
Follow PyPA guide to release package using GitHub Actions.

### DIFF
--- a/.github/workflows/pip-publish.yml
+++ b/.github/workflows/pip-publish.yml
@@ -8,19 +8,32 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
+
     - uses: actions/checkout@v2
+
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: "3.7"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install setuptools wheel twine
-    - name: Package project
-      run: python setup.py sdist bdist_wheel
-    - name: Upload distributions
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: twine upload dist/*
+        python-version: 3.9
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish a Python distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pip-publish.yml
+++ b/.github/workflows/pip-publish.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-latest
+
+    environment:
+      name: pypi.org
+      url: https://pypi.org/project/cookiecutter/
+
     steps:
 
     - uses: actions/checkout@v2


### PR DESCRIPTION
As documented [here](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/), we move to [pypa/gh-action-pypi-publish@release/v1](https://github.com/marketplace/actions/pypi-publish)

This closes #1681 