### PR TITLE
support partially overwrite keys in nested dict

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -68,7 +68,7 @@ def apply_overwrites_to_context(context, overwrite_context):
                     "{} provided for choice variable {}, but the "
                     "choices are {}.".format(overwrite, variable, context_value)
                 )
-        if isinstance(context_value, dict) and isinstance(overwrite, dict):
+        elif isinstance(context_value, dict) and isinstance(overwrite, dict):
             # Partially overwrite some keys in original dict
             apply_overwrites_to_context(context_value, overwrite)
             context[variable] = context_value

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -68,6 +68,10 @@ def apply_overwrites_to_context(context, overwrite_context):
                     "{} provided for choice variable {}, but the "
                     "choices are {}.".format(overwrite, variable, context_value)
                 )
+        if isinstance(context_value, dict) and isinstance(overwrite, dict):
+            # Partially overwrite some keys in original dict
+            apply_overwrites_to_context(context_value, overwrite)
+            context[variable] = context_value
         else:
             # Simply overwrite the value for this variable
             context[variable] = overwrite

--- a/tests/test-generate-context/nested_dict.json
+++ b/tests/test-generate-context/nested_dict.json
@@ -1,0 +1,10 @@
+{
+    "full_name": "Raphael Pierzina",
+    "github_username": "hackebrot",
+    "project": {
+        "name": "Kivy Project",
+        "description": "Kivy Project",
+        "repo_name": "{{cookiecutter.project_name|lower}}",
+        "orientation": ["all", "landscape", "portrait"]
+    }
+}

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -202,3 +202,45 @@ def test_apply_overwrites_sets_default_for_choice_variable(template_context):
     )
 
     assert template_context['orientation'] == ['landscape', 'all', 'portrait']
+
+
+def test_apply_overwrites_in_nested_dict():
+    """Verify nested dict in default content settings are correctly replaced."""
+    expected_context = {
+        'nested_dict': OrderedDict(
+            [
+                ('full_name', 'Raphael Pierzina'),
+                ('github_username', 'hackebrot'),
+                (
+                    'project',
+                    OrderedDict(
+                        [
+                            ('name', 'My Kivy Project'),
+                            ('description', 'My Kivy Project'),
+                            ('repo_name', '{{cookiecutter.project_name|lower}}'),
+                            ('orientation', ["all", "landscape", "portrait"]),
+                        ]
+                    ),
+                ),
+            ]
+        )
+    }
+
+    generated_context = generate.generate_context(
+        context_file='tests/test-generate-context/nested_dict.json',
+        default_context={
+            'not_in_template': 'foobar',
+            'project': {
+                'description': 'My Kivy Project',
+            },
+        },
+        extra_context={
+            'also_not_in_template': 'foobar2',
+            'github_username': 'hackebrot',
+            'project': {
+                'name': 'My Kivy Project',
+            },
+        },
+    )
+
+    assert generated_context == expected_context


### PR DESCRIPTION


cookiecutter.json
```json
{
    "full_name": "Raphael Pierzina",
    "github_username": "hackebrot",
    "project": {
        "name": "Kivy Project",
        "description": "Kivy Project description",
    }
}
```

user_config.yaml
```yaml
default_context:
  project:
    name: "My Project"
```

Current generated context:
```json
{
    "full_name": "Raphael Pierzina",
    "github_username": "hackebrot",
    "project": {
        "name": "My Project",
    }
}
```
the whole project is replace by user config instead of replace project.name only.

Expected generated context:
```json
{
    "full_name": "Raphael Pierzina",
    "github_username": "hackebrot",
    "project": {
        "name": "My Project",
        "description": "Kivy Project description",
    }
}
```

