### PR TITLE
Added: Readthedocs build config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.10"
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+sphinx:
+   configuration: docs/conf.py
+formats:
+  - htmlzip
+  - pdf
+  - epub
+python:
+   install:
+   - requirements: docs/requirements.txt
+   - method: pip
+     path: .


### PR DESCRIPTION
Motivation: We want our CI/CD tests pass with same config, as in real build. for this we need control on build settings.