### PR TITLE
Fixed: Python code block in the replay documentation

### DIFF
--- a/docs/advanced/replay.rst
+++ b/docs/advanced/replay.rst
@@ -37,7 +37,7 @@ Pass the according option on the CLI:
     cookiecutter --replay gh:hackebrot/cookiedozer
 
 
-Or use the Python API::
+Or use the Python API:
 
 .. code-block:: python
 


### PR DESCRIPTION
In the documentation for the replay functionality, a code block was ill-rendered.
Due to the `::` after the `Or use the Python API`, the following code block was rendered incorrectly.