### PR TITLE
Code quality: find.py refactored and type annotated

### DIFF
--- a/cookiecutter/find.py
+++ b/cookiecutter/find.py
@@ -8,7 +8,7 @@ from cookiecutter.exceptions import NonTemplatedInputDirException
 logger = logging.getLogger(__name__)
 
 
-def find_template(repo_dir: os.PathLike[str]) -> Path:
+def find_template(repo_dir: "os.PathLike[str]") -> Path:
     """Determine which child directory of ``repo_dir`` is the project template.
 
     :param repo_dir: Local directory of newly cloned repo.

--- a/cookiecutter/find.py
+++ b/cookiecutter/find.py
@@ -1,31 +1,27 @@
 """Functions for finding Cookiecutter templates and other components."""
 import logging
 import os
+from pathlib import Path
 
 from cookiecutter.exceptions import NonTemplatedInputDirException
 
 logger = logging.getLogger(__name__)
 
 
-def find_template(repo_dir):
-    """Determine which child directory of `repo_dir` is the project template.
+def find_template(repo_dir: os.PathLike[str]) -> Path:
+    """Determine which child directory of ``repo_dir`` is the project template.
 
     :param repo_dir: Local directory of newly cloned repo.
-    :returns project_template: Relative path to project template.
+    :return: Relative path to project template.
     """
     logger.debug('Searching %s for the project template.', repo_dir)
 
-    repo_dir_contents = os.listdir(repo_dir)
-
-    project_template = None
-    for item in repo_dir_contents:
-        if 'cookiecutter' in item and '{{' in item and '}}' in item:
-            project_template = item
+    for str_path in os.listdir(repo_dir):
+        if 'cookiecutter' in str_path and '{{' in str_path and '}}' in str_path:
+            project_template = Path(repo_dir, str_path)
             break
-
-    if project_template:
-        project_template = os.path.join(repo_dir, project_template)
-        logger.debug('The project template appears to be %s', project_template)
-        return project_template
     else:
         raise NonTemplatedInputDirException
+
+    logger.debug('The project template appears to be %s', project_template)
+    return project_template

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ extensions = [
     'sphinx_click.ext',
     'myst_parser',
     'sphinxcontrib.apidoc',
+    'sphinx_autodoc_typehints',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -369,3 +370,6 @@ apidoc_module_dir = "../cookiecutter"
 apidoc_output_dir = "."
 apidoc_toc_file = False
 apidoc_extra_args = ["-t", "_templates"]
+
+autodoc_member_order = "groupwise"
+autodoc_typehints = "none"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ myst-parser>=0.17.2
 sphinx-autobuild>=2021.3.14
 Sphinx>=4.5.0
 sphinxcontrib-apidoc>=0.3.0
+sphinx-autodoc-typehints>=1.18.2

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -1,5 +1,5 @@
 """Tests for `cookiecutter.find` module."""
-import os
+from pathlib import Path
 
 import pytest
 
@@ -9,12 +9,12 @@ from cookiecutter import find
 @pytest.fixture(params=['fake-repo-pre', 'fake-repo-pre2'])
 def repo_dir(request):
     """Fixture returning path for `test_find_template` test."""
-    return os.path.join('tests', request.param)
+    return Path('tests', request.param)
 
 
 def test_find_template(repo_dir):
     """Verify correctness of `find.find_template` path detection."""
     template = find.find_template(repo_dir=repo_dir)
 
-    test_dir = os.path.join(repo_dir, '{{cookiecutter.repo_name}}')
+    test_dir = Path(repo_dir, '{{cookiecutter.repo_name}}')
     assert template == test_dir


### PR DESCRIPTION
Related #1403 

PR #1547 converting os to pathlib silently and implementing a lot of str method calls. It is not what we want, we want to work with Path when it is Path and work with str when str required. 

find module not related to actual work, but require update in test and in module in one time, otherwise it has no sense. 