### PR TITLE
Remove universal bdist_wheel option; use "python -m build"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,19 +99,19 @@ submodules: ## Pull and update git submodules recursively
 .PHONY: release
 release: clean ## Package and upload release
 	@echo "+ $@"
-	@python setup.py sdist bdist_wheel
+	@python -m build
 	@twine upload -r $(PYPI_SERVER) dist/*
 
 .PHONY: sdist
 sdist: clean ## Build sdist distribution
 	@echo "+ $@"
-	@python setup.py sdist
+	@python -m build --sdist
 	@ls -l dist
 
 .PHONY: wheel
-wheel: clean ## Build bdist_wheel distribution
+wheel: clean ## Build wheel distribution
 	@echo "+ $@"
-	@python setup.py bdist_wheel
+	@python -m build --wheel
 	@ls -l dist
 
 .PHONY: help

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,9 +8,6 @@ statistics = 1
 # black official is 88
 max-line-length = 88
 
-[bdist_wheel]
-universal = 1
-
 [tool:pytest]
 testpaths = tests
 addopts = -vvv --cov-report term-missing --cov=cookiecutter


### PR DESCRIPTION
The main change in this PR is to remove the universal bdist_wheel option, which provides a wheel file [`cookiecutter-2.1.1-py2.py3-none-any.whl `](https://pypi.org/project/cookiecutter/2.1.1/#files) with misleading "py2" in the name. The fix included here creates `cookiecutter-2.1.2.dev0-py3-none-any.whl`, as this is a Python 3 only project.

Other changes to Makefile are to use `python -m build` (i.e. PyPA's [build](https://github.com/pypa/build)) instead of `python setup.py` ([article](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html)).