### PR TITLE
Pin chardet version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open('README.md', encoding='utf-8') as readme_file:
 
 requirements = [
     'binaryornot>=0.4.4',
+    'chardet>=4.0.0,<5.0.0',
     'Jinja2>=2.7,<4.0.0',
     'click>=7.0,<9.0.0',
     'pyyaml>=5.3.1',


### PR DESCRIPTION
Currently, `requests>=2.23.0` is used in https://github.com/cookiecutter/cookiecutter/blob/master/setup.py#L16

`requests` `latest` points to `2.28.0`. 

`requests==2.28.0` is not happy with `chardet==5.0.0`.



So `chardet==4.0.0` is required. 


https://github.com/psf/requests/blob/v2.28.0/requests/__init__.py#L75-L79

```python
    if chardet_version:
        major, minor, patch = chardet_version.split(".")[:3]
        major, minor, patch = int(major), int(minor), int(patch)
        # chardet_version >= 3.0.2, < 5.0.0
        assert (3, 0, 2) <= (major, minor, patch) < (5, 0, 0)
```

This dependency conflict can be fixed in next `requests` release as below

https://github.com/psf/requests/blob/main/requests/__init__.py#L75-L79

```python
    if chardet_version:
        major, minor, patch = chardet_version.split(".")[:3]
        major, minor, patch = int(major), int(minor), int(patch)
        # chardet_version >= 3.0.2, < 6.0.0
        assert (3, 0, 2) <= (major, minor, patch) < (6, 0, 0)
```

Related to https://github.com/ansible-community/molecule/pull/3607