### PR TITLE
Generate Context fails when a default list value provided

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -55,7 +55,7 @@ def apply_overwrites_to_context(context, overwrite_context):
 
         context_value = context[variable]
 
-        if isinstance(context_value, list):
+        if isinstance(context_value, list) and not isinstance(overwrite, list):
             # We are dealing with a choice variable
             if overwrite in context_value:
                 # This overwrite is actually valid for the given context

--- a/tests/test-generate-context/test.json
+++ b/tests/test-generate-context/test.json
@@ -1,1 +1,7 @@
-{"1": 2, "some_key": "some_val"}
+{
+    "1": 2,
+    "some_key": "some_val",
+    "_copy_without_render": [
+        "**/*.txt"
+    ]
+}

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -16,7 +16,13 @@ def context_data():
     """
     context = (
         {'context_file': 'tests/test-generate-context/test.json'},
-        {'test': {'1': 2, 'some_key': 'some_val'}},
+        {
+            'test': {
+                '1': 2,
+                'some_key': 'some_val',
+                '_copy_without_render': ['**/*.txt'],
+            }
+        },
     )
 
     context_with_default = (
@@ -24,7 +30,27 @@ def context_data():
             'context_file': 'tests/test-generate-context/test.json',
             'default_context': {'1': 3},
         },
-        {'test': {'1': 3, 'some_key': 'some_val'}},
+        {
+            'test': {
+                '1': 3,
+                'some_key': 'some_val',
+                '_copy_without_render': ['**/*.txt'],
+            }
+        },
+    )
+
+    context_with_list_default = (
+        {
+            'context_file': 'tests/test-generate-context/test.json',
+            'default_context': {'_copy_without_render': ['**/*.html']},
+        },
+        {
+            'test': {
+                '1': 2,
+                'some_key': 'some_val',
+                '_copy_without_render': ['**/*.html'],
+            }
+        },
     )
 
     context_with_extra = (
@@ -32,7 +58,13 @@ def context_data():
             'context_file': 'tests/test-generate-context/test.json',
             'extra_context': {'1': 4},
         },
-        {'test': {'1': 4, 'some_key': 'some_val'}},
+        {
+            'test': {
+                '1': 4,
+                'some_key': 'some_val',
+                '_copy_without_render': ['**/*.txt'],
+            }
+        },
     )
 
     context_with_default_and_extra = (
@@ -41,11 +73,18 @@ def context_data():
             'default_context': {'1': 3},
             'extra_context': {'1': 5},
         },
-        {'test': {'1': 5, 'some_key': 'some_val'}},
+        {
+            'test': {
+                '1': 5,
+                'some_key': 'some_val',
+                '_copy_without_render': ['**/*.txt'],
+            }
+        },
     )
 
     yield context
     yield context_with_default
+    yield context_with_list_default
     yield context_with_extra
     yield context_with_default_and_extra
 


### PR DESCRIPTION
Hi, I have never contributed to cookiecutter (or any open source to be honest) but gotta say i love cookiecutter.

Currently when including a list in a default context the generate context fails. For example if you had a default context as below with a list value for the "_copy_without_render" key.


```json
{
    "1": 2,
    "some_key": "some_val",
    "_copy_without_render": [
        "**/*.txt"
    ]
}
``` 

In particular in the cruft project there is currently an issue caused by this: https://github.com/cruft/cruft/issues/166

This PR updates the `apply_overwrites_to_context` and updates the tests such that when overwriting, if a list is given this overwrites the whole list.