### PR TITLE
cleanup files if panics during hooks - bugfix

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -259,8 +259,8 @@ def _run_hook_from_repo_dir(
         try:
             run_hook(hook_name, project_dir, context)
         except (
-                FailedHookException,
-                UndefinedError,
+            FailedHookException,
+            UndefinedError,
         ):
             if delete_project_on_failure:
                 rmtree(project_dir)

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -258,7 +258,10 @@ def _run_hook_from_repo_dir(
     with work_in(repo_dir):
         try:
             run_hook(hook_name, project_dir, context)
-        except FailedHookException:
+        except (
+                FailedHookException,
+                UndefinedError,
+        ):
             if delete_project_on_failure:
                 rmtree(project_dir)
             logger.error(


### PR DESCRIPTION
Addresses #1754.

Fixed bug where files aren't cleaned up during panics, by adding an additional exception catch.