### PR TITLE
feat: Add resolved template repository path as _repo_dir to the context

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -109,6 +109,9 @@ def cookiecutter(
         # include template dir or url in the context dict
         context['cookiecutter']['_template'] = template
 
+        # include repo dir or url in the context dict
+        context['cookiecutter']['_repo_dir'] = repo_dir
+
         # include output+dir in the context dict
         context['cookiecutter']['_output_dir'] = os.path.abspath(output_dir)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -398,6 +398,7 @@ def test_echo_undefined_variable_error(output_dir, cli_runner):
             'github_username': 'hackebrot',
             'project_slug': 'testproject',
             '_template': template_path,
+            '_repo_dir': template_path,
             '_output_dir': output_dir,
         }
     }


### PR DESCRIPTION
This PR contains a small change, which includes the resolved repository path from the `determine_repo_dir` as item `_repo_dir` to the Cookiecutter context. 

This allows to define Python packages in the template and to reference them by extending the `sys.path` with normal import statements, e.g. in hook scripts.

__Sample:__

```python
import os
import requests
import shutil
import sys

from dateutil import parser as dateparser

from subprocess import Popen

sys.path.append("{{ cookiecutter._repo_dir }}")  # <= extend sys.path

from utils.version import Version # <= use module from internal package

# Get the root project directory
PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)

def _error_exit(msg):
    # exits with status 1 to indicate failure
    sys.stderr.write("ERROR: %s\n" % msg)
    sys.exit(1)
```

