### PR TITLE
Added timeout on request.get() for ensuring that if a recipient serve…

### DIFF
--- a/cookiecutter/zipfile.py
+++ b/cookiecutter/zipfile.py
@@ -49,7 +49,8 @@ def unzip(
 
         if download:
             # (Re) download the zipfile
-            r = requests.get(zip_uri, stream=True)
+            # OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
+            r = requests.get(zip_uri, stream=True, timeout=100)
             with open(zip_path, 'wb') as f:
                 for chunk in r.iter_content(chunk_size=1024):
                     if chunk:  # filter out keep-alive new chunks

--- a/cookiecutter/zipfile.py
+++ b/cookiecutter/zipfile.py
@@ -49,7 +49,6 @@ def unzip(
 
         if download:
             # (Re) download the zipfile
-            # OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
             r = requests.get(zip_uri, stream=True, timeout=100)
             with open(zip_path, 'wb') as f:
                 for chunk in r.iter_content(chunk_size=1024):


### PR DESCRIPTION
We have detected this issue on branch `main` of `cokkiecutter` project on the version with commit hash `e9b3b8`.  This issue can be addressed as a api usage issue. 

**Fixes for api usage issue:**
In file: `cookiecutter/zipfile.py`, method `unzip` a request is made without a timeout parameter. If the recipient server is unavailable to service the request, [application making the request may stall indefinitely. ](https://docs.python-requests.org/en/master/user/advanced/#timeouts)our intelligent code repair system **iCR** suggested that a timeout value should be specified.

This issue was detected by our **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. You will get more info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)