### PR TITLE
Add verbose values option to choice options

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -59,7 +59,8 @@ def read_user_choice(var_name, options):
     if not options:
         raise ValueError
 
-    choice_map = OrderedDict((f'{i}', value) for i, value in enumerate(options, 1))
+    choice_map = OrderedDict((f'{i}', value[0] if isinstance(value, tuple) else value for i, value in enumerate(options, 1))
+    values_map = OrderedDict((f'{i}', value[1] if isinstance(value, tuple) else value for i, value in enumerate(options, 1))                             
     choices = choice_map.keys()
     default = '1'
 
@@ -75,7 +76,7 @@ def read_user_choice(var_name, options):
     user_choice = click.prompt(
         prompt, type=click.Choice(choices), default=default, show_choices=False
     )
-    return choice_map[user_choice]
+    return value_map[user_choice]
 
 
 DEFAULT_DISPLAY = 'default'


### PR DESCRIPTION
Requirement:
I need to have verbose human-readable values options being shown to the user while having different values being set to the variable underneath. Example question for FooBarFlags variable:
Choices shown: 1-Foo 2- Bar 3- Both Foo and Bar
Actual values: 1- Foo 2- Bar 3-FooBar

Usage:
{
"FooBarFlag": ["Foo", "Bar", ("Both Foo and Bar", "FooBar")] }