### PR TITLE
Develop - Adding --dump-input option

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -151,6 +151,11 @@ def list_installed_templates(default_config, passed_config_file):
     is_flag=True,
     help='Do not delete project folder on failure',
 )
+@click.option(
+    '--dump-input',
+    is_flag=True,
+    help="Add user input to generated .cookiecutter.json"
+)
 def main(
     template,
     extra_context,
@@ -169,6 +174,7 @@ def main(
     replay_file,
     list_installed,
     keep_project_on_failure,
+    dump_input
 ):
     """Create a project from a Cookiecutter project template (TEMPLATE).
 
@@ -214,6 +220,7 @@ def main(
             skip_if_file_exists=skip_if_file_exists,
             accept_hooks=_accept_hooks,
             keep_project_on_failure=keep_project_on_failure,
+            dump_input=dump_input
         )
     except (
         ContextDecodingException,

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -277,6 +277,7 @@ def generate_files(
     skip_if_file_exists=False,
     accept_hooks=True,
     keep_project_on_failure=False,
+    dump_input=False
 ):
     """Render the templates and saves them to files.
 
@@ -290,6 +291,8 @@ def generate_files(
     :param accept_hooks: Accept pre and post hooks if set to `True`.
     :param keep_project_on_failure: If `True` keep generated project directory even when
         generation fails
+    :param dump_input: If 'True' the user input will be added to the generated template in a new file named:
+        '.cookiecutter.json'
     """
     template_dir = find_template(repo_dir)
     logger.debug('Generating project from %s...', template_dir)
@@ -321,6 +324,12 @@ def generate_files(
     # if we created the output directory, then it's ok to remove it
     # if rendering fails
     delete_project_on_failure = output_directory_created and not keep_project_on_failure
+
+    # Add user input if required
+    if dump_input:
+        user_input_file_path = os.path.join(project_dir, '.cookiecutter.json')
+        with open(user_input_file_path, 'w') as user_input_file:
+            json.dump(context['cookiecutter'], user_input_file, indent=2)
 
     if accept_hooks:
         _run_hook_from_repo_dir(

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -129,6 +129,7 @@ def cookiecutter(
             output_dir=output_dir,
             accept_hooks=accept_hooks,
             keep_project_on_failure=keep_project_on_failure,
+            dump_input=dump_input
         )
 
     # Cleanup (if required)

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -35,6 +35,7 @@ def cookiecutter(
     skip_if_file_exists=False,
     accept_hooks=True,
     keep_project_on_failure=False,
+    dump_input=False
 ):
     """
     Run Cookiecutter just as if using it from the command line.
@@ -58,6 +59,7 @@ def cookiecutter(
     :param accept_hooks: Accept pre and post hooks if set to `True`.
     :param keep_project_on_failure: If `True` keep generated project directory even when
         generation fails
+    :param dump_input: If 'True' the user input will be saved in new created file named .cookiecutter.json
     """
     if replay and ((no_input is not False) or (extra_context is not None)):
         err_msg = (


### PR DESCRIPTION
Usage: add the --dump-input for creating a new file named .cookiecutter.json with the user input in it. 