### PR TITLE
add req rich for better prompt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ requirements = [
     'jinja2-time>=0.2.0',
     'python-slugify>=4.0.0',
     'requests>=2.23.0',
+    'rich>=12.5.0 ; python_version>="3.6"',
 ]
 
 setup(


### PR DESCRIPTION
Hello,

[rich](https://github.com/Textualize/rich) is a very beautiful and popular Python text formatting in the terminal, and as cookiecutter displays text in terminal, it might be useful to add it in the requirements, this makes users no more need to install `rick` package after the installation of `cookiecutter`, if the authors of the template want to use `rich text` in the **pre and post hook scripts**.

If we dont add `rick` in the requirements, the authors must guide users to install it seperately, and sometimes it might be not easy as expected.

And as we just add `rich` in the requirements, this PR won't force people to use it, but ease people who want to use it.