### PR TITLE
Update documentation to mention that output directory is configurable

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -38,7 +38,8 @@ of this.
 Output
 ------
 
-This is what will be generated locally, in your current directory::
+This is what will be generated locally, in your output directory. The output directory defaults to your current directory.
+The location is configurable: see :doc:`cli_options` for details.
 
     mysomething/  <---------- Value corresponding to what you enter at the
     │                         project_name prompt

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -113,6 +113,16 @@ whenever a password is required.
 Keeping your cookiecutters organized
 ------------------------------------
 
+As of the Cookiecutter 1.1.0 release:
+
+* Whenever you generate a project with a cookiecutter, the resulting project
+  is by default stored in your current directory. The location is configurable:
+  see :doc:`cli_options` for details.
+
+* Your cloned cookiecutters are stored by default in your `~/.cookiecutters/`
+  directory (or Windows equivalent). The location is configurable: see
+  :doc:`advanced/user_config` for details.
+
 As of the Cookiecutter 0.7.0 release:
 
 * Whenever you generate a project with a cookiecutter, the resulting project


### PR DESCRIPTION
The documentation says that the output directory is the current directory. However, with PRs https://github.com/cookiecutter/cookiecutter/pull/452 and https://github.com/cookiecutter/cookiecutter/pull/452, it is configurable.

With this commit, the documentation simply links to CLI options page, not to the [CLI option entry on it](https://cookiecutter.readthedocs.io/en/stable/cli_options.html#cmdoption-cookiecutter-o). How do I do that with `:doc`?