### PR TITLE
Fixing Carriage Return Line Feed (CRLF) order in docs #1792

### DIFF
--- a/docs/advanced/new_line_characters.rst
+++ b/docs/advanced/new_line_characters.rst
@@ -16,7 +16,7 @@ This allow template developers to have both types of files in the same template.
 Developers should correctly configure their ``.gitattributes`` file to avoid line-end character overwrite by git.
 
 The special template variable ``_new_lines`` enforces a specific line ending.
-Acceptable variables: ``'\n\r'`` for CRLF and ``'\n'`` for POSIX.
+Acceptable variables: ``'\r\n'`` for CRLF and ``'\n'`` for POSIX.
 
 Here is example how to force line endings to CRLF on any deployment:
 
@@ -24,5 +24,5 @@ Here is example how to force line endings to CRLF on any deployment:
 
     {
         "project_slug": "sample",
-        "_new_lines": "\n\r"
+        "_new_lines": "\r\n"
     }


### PR DESCRIPTION
In the "Working with line-ends special symbols LF/CRLF" section of the documentation we can see:

The special template variable `_new_lines` enforces a specific line ending. Acceptable variables: `'\n\r'` for CRLF and `'\n'` for POSIX.

Here is example how to force line endings to CRLF on any deployment:

```
{
    "project_slug": "sample",
    "_new_lines": "\n\r"
}
```
But this order is mistaken, since:

"The traditional order, when both control characters are used, is Carriage Return, then Line Feed.

The reason for this goes back to the old ASR-33 Teletype.

When a Carriage Return is issued to an ASR-33, the print head, if it is near the right margin, takes over a tenth of a second to return to the left margin, plus there is a bit of "bounce" when the left margin is hit.

If the order were Line Feed, then Carriage Return, the first printed character might occur a tenth of a second after the Carriage Return, and thus might end up printing (as a smear) halfway across the page. But if Line Feed comes after Carriage Return then the time taken by the Line Feed provides extra time for the print head to complete it's trip."

[StackOverflow](https://stackoverflow.com/questions/1885900/order-of-carriage-return-and-new-line-feed)

So this PR aims at fixing the CRLF order to the traditional `'\r\n'`