### PR TITLE
fixing badge display problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![pypi](https://img.shields.io/pypi/v/cookiecutter.svg)](https://pypi.org/project/cookiecutter/)
 [![python](https://img.shields.io/pypi/pyversions/cookiecutter.svg)](https://pypi.org/project/cookiecutter/)
-[![Build Status](https://github.com/cookiecutter/cookiecutter/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/cookiecutter/cookiecutter/actions)
+[![Build Status](https://github.com/cookiecutter/cookiecutter/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/cookiecutter/cookiecutter/actions)
 [![codecov](https://codecov.io/gh/cookiecutter/cookiecutter/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/github/cookiecutter/cookiecutter?branch=master)
 [![discord](https://img.shields.io/badge/Discord-cookiecutter-5865F2?style=flat&logo=discord&logoColor=white)](https://discord.gg/9BrxzPKuEW)
 [![docs](https://readthedocs.org/projects/cookiecutter/badge/?version=latest)](https://readthedocs.org/projects/cookiecutter/?badge=latest)


### PR DESCRIPTION
As shown below, the ['Build Status'] badge doens't show up, due to wrong reference to the tests.yml file. 

![image](https://user-images.githubusercontent.com/61331156/204552673-ca4f19e5-8d4c-4826-aeac-b35166c725f5.png)

I've changed the README.md file, referencing the appropriate path. With the change, the badge appears correctly as shown below. 

![image](https://user-images.githubusercontent.com/61331156/204553032-3fbc3201-e240-4431-bf70-3dfd00fd74a4.png)
