### PR TITLE
Add multi templates management

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: check-xml
       - id: check-yaml
         exclude: "not_rendered.yml|invalid-config.yaml"
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/cookiecutter/find.py
+++ b/cookiecutter/find.py
@@ -8,7 +8,22 @@ from cookiecutter.exceptions import NonTemplatedInputDirException
 logger = logging.getLogger(__name__)
 
 
-def find_templates(repo_dir: "os.PathLike[str]") -> list[Path]:
+def find_template(repo_dir: "os.PathLike[str]") -> Path:
+    """Determine which child directory of ``repo_dir`` is the project template.
+
+    :param repo_dir: Local directory of newly cloned repo.
+    :return: Relative path to project template.
+    """
+    logger.debug('Searching %s for the project template.', repo_dir)
+
+    project_templates = find_templates(repo_dir)
+    project_template = project_templates[0] if project_templates else None
+
+    logger.debug('The project template appears to be %s', project_template)
+    return project_template
+
+
+def find_templates(repo_dir: "os.PathLike[str]") -> list:
     """Determine which child directories of ``repo_dir`` is a project template.
 
     :param repo_dir: Local directory of newly cloned repo.

--- a/cookiecutter/find.py
+++ b/cookiecutter/find.py
@@ -8,20 +8,21 @@ from cookiecutter.exceptions import NonTemplatedInputDirException
 logger = logging.getLogger(__name__)
 
 
-def find_template(repo_dir: "os.PathLike[str]") -> Path:
-    """Determine which child directory of ``repo_dir`` is the project template.
+def find_templates(repo_dir: "os.PathLike[str]") -> list[Path]:
+    """Determine which child directories of ``repo_dir`` is a project template.
 
     :param repo_dir: Local directory of newly cloned repo.
-    :return: Relative path to project template.
+    :return: List of relative path to project templates.
     """
-    logger.debug('Searching %s for the project template.', repo_dir)
+    logger.debug('Searching %s for the project templates.', repo_dir)
 
+    project_templates = []
     for str_path in os.listdir(repo_dir):
         if 'cookiecutter' in str_path and '{{' in str_path and '}}' in str_path:
-            project_template = Path(repo_dir, str_path)
-            break
-    else:
+            project_templates.append(Path(repo_dir, str_path))
+
+    if not project_templates:
         raise NonTemplatedInputDirException
 
-    logger.debug('The project template appears to be %s', project_template)
-    return project_template
+    logger.debug('The project templates appears to be {}'.format(project_templates))
+    return project_templates

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -322,11 +322,17 @@ def generate_files(
 
         # if we created the output directory, then it's ok to remove it
         # if rendering fails
-        delete_project_on_failure = output_directory_created and not keep_project_on_failure
+        delete_project_on_failure = (
+            output_directory_created and not keep_project_on_failure
+        )
 
         if accept_hooks:
             _run_hook_from_repo_dir(
-                repo_dir, 'pre_gen_project', project_dir, context, delete_project_on_failure
+                repo_dir,
+                'pre_gen_project',
+                project_dir,
+                context,
+                delete_project_on_failure,
             )
 
         with work_in(template_dir):
@@ -354,7 +360,9 @@ def generate_files(
                     indir = os.path.normpath(os.path.join(root, copy_dir))
                     outdir = os.path.normpath(os.path.join(project_dir, indir))
                     outdir = env.from_string(outdir).render(**context)
-                    logger.debug('Copying dir %s to %s without rendering', indir, outdir)
+                    logger.debug(
+                        'Copying dir %s to %s without rendering', indir, outdir
+                    )
 
                     # The outdir is not the root dir, it is the dir which marked as copy
                     # only in the config file. If the program hits this line, which means
@@ -370,7 +378,11 @@ def generate_files(
                     unrendered_dir = os.path.join(project_dir, root, d)
                     try:
                         render_and_create_dir(
-                            unrendered_dir, context, output_dir, env, overwrite_if_exists
+                            unrendered_dir,
+                            context,
+                            output_dir,
+                            env,
+                            overwrite_if_exists,
                         )
                     except UndefinedError as err:
                         if delete_project_on_failure:

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -277,6 +277,7 @@ def generate_files(
     skip_if_file_exists=False,
     accept_hooks=True,
     keep_project_on_failure=False,
+    multi_repositories=False,
 ):
     """Render the templates and saves them to files.
 
@@ -290,6 +291,7 @@ def generate_files(
     :param accept_hooks: Accept pre and post hooks if set to `True`.
     :param keep_project_on_failure: If `True` keep generated project directory even when
         generation fails
+    :param multi_repositories: Allow to manage multiple repositories
     """
     project_dirs = []
     for template_dir in find_templates(repo_dir):
@@ -308,7 +310,6 @@ def generate_files(
         except UndefinedError as err:
             msg = f"Unable to create project directory '{unrendered_dir}'"
             raise UndefinedVariableInTemplate(msg, err, context) from err
-        project_dirs.append(project_dir)
 
         # We want the Jinja path and the OS paths to match. Consequently, we'll:
         #   + CD to the template folder
@@ -365,8 +366,8 @@ def generate_files(
                     )
 
                     # The outdir is not the root dir, it is the dir which marked as copy
-                    # only in the config file. If the program hits this line, which means
-                    # the overwrite_if_exists = True, and root dir exists
+                    # only in the config file. If the program hits this line, which
+                    # means the overwrite_if_exists = True, and root dir exists
                     if os.path.isdir(outdir):
                         shutil.rmtree(outdir)
                     shutil.copytree(indir, outdir)
@@ -422,4 +423,6 @@ def generate_files(
                 delete_project_on_failure,
             )
 
-    return project_dirs
+        project_dirs.append(project_dir)
+
+    return project_dirs if multi_repositories else project_dirs[0]

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -35,6 +35,7 @@ def cookiecutter(
     skip_if_file_exists=False,
     accept_hooks=True,
     keep_project_on_failure=False,
+    multi_repositories=False,
 ):
     """
     Run Cookiecutter just as if using it from the command line.
@@ -58,6 +59,7 @@ def cookiecutter(
     :param accept_hooks: Accept pre and post hooks if set to `True`.
     :param keep_project_on_failure: If `True` keep generated project directory even when
         generation fails
+    :param multi_repositories: Allow to manage multiple repositories
     """
     if replay and ((no_input is not False) or (extra_context is not None)):
         err_msg = (
@@ -119,7 +121,7 @@ def cookiecutter(
 
     # Create project from local context and project template.
     with import_patch:
-        results = generate_files(
+        result = generate_files(
             repo_dir=repo_dir,
             context=context,
             overwrite_if_exists=overwrite_if_exists,
@@ -127,13 +129,14 @@ def cookiecutter(
             output_dir=output_dir,
             accept_hooks=accept_hooks,
             keep_project_on_failure=keep_project_on_failure,
+            multi_repositories=multi_repositories,
         )
 
     # Cleanup (if required)
     if cleanup:
         rmtree(repo_dir)
 
-    return results
+    return result
 
 
 class _patch_import_path_for_repo:

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -119,7 +119,7 @@ def cookiecutter(
 
     # Create project from local context and project template.
     with import_patch:
-        result = generate_files(
+        results = generate_files(
             repo_dir=repo_dir,
             context=context,
             overwrite_if_exists=overwrite_if_exists,
@@ -133,7 +133,7 @@ def cookiecutter(
     if cleanup:
         rmtree(repo_dir)
 
-    return result
+    return results
 
 
 class _patch_import_path_for_repo:

--- a/tests/fake-multi-repo-dir/cookiecutter.json
+++ b/tests/fake-multi-repo-dir/cookiecutter.json
@@ -1,0 +1,14 @@
+{
+	"full_name": "Audrey Roy",
+	"email": "audreyr@gmail.com",
+	"github_username": "audreyr",
+	"project_name": "Fake Project",
+	"other_project_name": "Fake Project",
+	"repo_name": "fake-project",
+	"other_repo_name": "other-fake-project",
+	"project_short_description": "This is a fake project.",
+	"other_project_short_description": "This is an other fake project.",
+	"release_date": "2013-07-28",
+	"year": "2013",
+	"version": "0.1"
+}

--- a/tests/fake-multi-repo-dir/{{cookiecutter.other_repo_name}}/README.rst
+++ b/tests/fake-multi-repo-dir/{{cookiecutter.other_repo_name}}/README.rst
@@ -1,0 +1,7 @@
+==================
+Other Fake Project
+==================
+
+Project name: **{{ cookiecutter.other_project_name }}**
+
+Blah!!!!

--- a/tests/fake-multi-repo-dir/{{cookiecutter.repo_name}}/README.rst
+++ b/tests/fake-multi-repo-dir/{{cookiecutter.repo_name}}/README.rst
@@ -1,0 +1,7 @@
+============
+Fake Project
+============
+
+Project name: **{{ cookiecutter.project_name }}**
+
+Blah!!!!

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -8,13 +8,13 @@ from cookiecutter import find
 
 @pytest.fixture(params=['fake-repo-pre', 'fake-repo-pre2'])
 def repo_dir(request):
-    """Fixture returning path for `test_find_templates` test."""
+    """Fixture returning path for `test_find_template` test."""
     return Path('tests', request.param)
 
 
 def test_find_template(repo_dir):
-    """Verify correctness of `find.find_templates` path detection."""
-    templates = find.find_templates(repo_dir=repo_dir)
+    """Verify correctness of `find.find_template` path detection."""
+    template = find.find_template(repo_dir=repo_dir)
 
     test_dir = Path(repo_dir, '{{cookiecutter.repo_name}}')
-    assert test_dir in templates
+    assert template == test_dir

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -8,13 +8,13 @@ from cookiecutter import find
 
 @pytest.fixture(params=['fake-repo-pre', 'fake-repo-pre2'])
 def repo_dir(request):
-    """Fixture returning path for `test_find_template` test."""
+    """Fixture returning path for `test_find_templates` test."""
     return Path('tests', request.param)
 
 
 def test_find_template(repo_dir):
-    """Verify correctness of `find.find_template` path detection."""
-    template = find.find_template(repo_dir=repo_dir)
+    """Verify correctness of `find.find_templates` path detection."""
+    templates = find.find_templates(repo_dir=repo_dir)
 
     test_dir = Path(repo_dir, '{{cookiecutter.repo_name}}')
-    assert template == test_dir
+    assert test_dir in templates

--- a/tests/test_find_multiple.py
+++ b/tests/test_find_multiple.py
@@ -1,0 +1,23 @@
+"""Tests for `cookiecutter.find` module."""
+from pathlib import Path
+
+import pytest
+
+from cookiecutter import find
+
+
+@pytest.fixture(params=['fake-multi-repo-dir'])
+def repo_dir(request):
+    """Fixture returning path for `test_find_template` test."""
+    return Path('tests', request.param)
+
+
+def test_find_templates(repo_dir):
+    """Verify correctness of `find.find_templates` path detection."""
+    templates = find.find_templates(repo_dir=repo_dir)
+
+    test_dirs = [
+        Path(repo_dir, '{{cookiecutter.repo_name}}'),
+        Path(repo_dir, '{{cookiecutter.other_repo_name}}'),
+    ]
+    assert all([test_dir in templates for test_dir in test_dirs])


### PR DESCRIPTION
By using cookiecutter inside a python script to include in a already existing project, i had the need to include more than one template folder (i.e. update several folders inside the project).

Cookiecutter is enough well designed to allow a very simple proposition of this implementation.

Illustration :
```
repo_dir
|- {cookiecutter.repo_name_1}
|- {cookiecutter.repo_name_2}
|- cookiecutter.json
```

cookiecutter.json:
```
{
    "repo_name_1": "my_repo",
    "repo_name_2": "my_other_repo"
}
```