### PR TITLE
feature: Allow jsonify to be used as function in templating

### DIFF
--- a/cookiecutter/extensions.py
+++ b/cookiecutter/extensions.py
@@ -19,6 +19,7 @@ class JsonifyExtension(Extension):
             return json.dumps(obj, sort_keys=True, indent=4)
 
         environment.filters['jsonify'] = jsonify
+        environment.globals.update(jsonify=jsonify)
 
 
 class RandomStringExtension(Extension):


### PR DESCRIPTION
By allowing jsonify to be used as a function in jinja2 templates it is possible to easily render cookiecutter
context using `{{ jsonify(cookiecutter) }}`.

This can just re-use the existing logic.

Before investing in adding tests I want to check if this would be considered to be pulled in. I can use a local extension on my end so I do not depend on it but it seems something that could be useful to others.