### PR TITLE
Changes find function, test_find, to use Effect class from pymonad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ parts/
 sdist/
 var/
 venv/
+.venv/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/cookiecutter/find.py
+++ b/cookiecutter/find.py
@@ -4,24 +4,28 @@ import os
 from pathlib import Path
 
 from cookiecutter.exceptions import NonTemplatedInputDirException
+from pymonad.effects import Effect
 
 logger = logging.getLogger(__name__)
 
 
-def find_template(repo_dir: "os.PathLike[str]") -> Path:
+def find_template(repo_dir: "os.PathLike[str]") -> Effect:
     """Determine which child directory of ``repo_dir`` is the project template.
 
     :param repo_dir: Local directory of newly cloned repo.
-    :return: Relative path to project template.
+    :return: Effect representing the relative path to the project template.
     """
-    logger.debug('Searching %s for the project template.', repo_dir)
+    def search_template():
+        logger.debug('Searching %s for the project template.', repo_dir)
 
-    for str_path in os.listdir(repo_dir):
-        if 'cookiecutter' in str_path and '{{' in str_path and '}}' in str_path:
-            project_template = Path(repo_dir, str_path)
-            break
-    else:
+        for str_path in os.listdir(repo_dir):
+            if 'cookiecutter' in str_path and '{{' in str_path and '}}' in str_path:
+                project_template = Path(repo_dir, str_path)
+                return project_template
+
         raise NonTemplatedInputDirException
 
-    logger.debug('The project template appears to be %s', project_template)
-    return project_template
+    return Effect(search_template).map(lambda project_template: (
+        logger.debug('The project template appears to be %s', project_template),
+        project_template
+    ))

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -4,7 +4,12 @@ from pathlib import Path
 import pytest
 
 from cookiecutter import find
+from pymonad.effects import IO
 
+@pytest.fixture
+def mock_logger(mocker):
+    """Fixture to mock the logger."""
+    return mocker.patch("cookiecutter.find.logger")
 
 @pytest.fixture(params=['fake-repo-pre', 'fake-repo-pre2'])
 def repo_dir(request):
@@ -14,7 +19,21 @@ def repo_dir(request):
 
 def test_find_template(repo_dir):
     """Verify correctness of `find.find_template` path detection."""
-    template = find.find_template(repo_dir=repo_dir)
+    effect = find.find_template(repo_dir=repo_dir)
+    template = effect.run()[1]  # Get the second element of the result tuple
 
     test_dir = Path(repo_dir, '{{cookiecutter.repo_name}}')
     assert template == test_dir
+
+def test_find_template_logging(repo_dir, mock_logger):
+    """Verify the logging behavior of `find.find_template`."""
+    effect = find.find_template(repo_dir=repo_dir)
+    result = effect.run()
+
+    assert result[1] == repo_dir / "{{cookiecutter.repo_name}}"
+    mock_logger.debug.assert_called_once_with(
+        "Searching %s for the project template.", repo_dir
+    )
+    mock_logger.debug.assert_called_with(
+        "The project template appears to be %s", repo_dir / "{{cookiecutter.repo_name}}"
+    )


### PR DESCRIPTION
In this refactored code, the find_template function now returns an Effect instance representing the relative path to the project template. The search_template function performs the actual search logic within the effectful computation.

To run the effect and obtain the result, you can use the run() method as follows:

`
result = find_template("/path/to/repo").run()

if isinstance(result, Exception):
    # Handle the exception if the effect raised one
    print("Exception occurred:", result)
else:
    # Process the successful result
    print("The project template is:", result)

`

The refactored code essentially wraps the original functionality of searching for the project template in an Effect instance. This allows you to perform additional operations, such as logging, alongside the effectful computation. By using the Effect monad, you can encapsulate and manage the effectful computation in a more functional programming style.
