### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/PyCQA/doc8
-    rev: 0.11.2
+    rev: v1.1.1
     hooks:
       - id: doc8
         name: doc8
@@ -11,13 +11,13 @@ repos:
         files: \.rst$
         require_serial: true
   - repo: https://github.com/psf/black.git
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
         language_version: python3
         exclude: ^(tests\/hooks-abort-render\/hooks|docs\/HelloCookieCutter1)
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -44,11 +44,11 @@ repos:
           - flake8-black
           - flake8-docstrings
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.4
+    rev: 1.7.5
     hooks:
       - id: bandit
         args: [--ini, .bandit]
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.48"
+    rev: "0.49"
     hooks:
     -   id: check-manifest


### PR DESCRIPTION
This change was generated by running `pre-commit autoupdate`. No manual changes were introduced.

NOTE: This updates bandit, and linting is now failing due to a call to `requests.get()` without a timeout specified. This is addressed separately by PR #1772, which should also be merged.

I recommend signing up at [pre-commit.ci](https://pre-commit.ci/) to ensure that PRs are created by that service automatically to accomplish this.