### PR TITLE
Add a Dependabot config to autoupdate GitHub workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR adds a Dependabot configuration for GitHub workflow actions. Each month, Dependabot will look for new action versions and will submit a PR to update the action versions so they don't fall out of date.

For example, when this merges, you can expect a PR from Dependabot to update `actions/setup-python` from v3 to v4.