### PR TITLE
Rename `master` to `main` so CI runs correctly on merge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: CI/CD Tests
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
   pull_request:


### PR DESCRIPTION
CI does not run when PRs merge to `main`. This is caused by an out-of-date CI configuration, which targets `master`, not `main`.

This PR changes the CI configuration so CI will start running again when PRs merge to `main`.