### PR TITLE
Standardize newlines for all platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,5 @@
-*           text=auto
-# CRLF sets for test files! Or tests will fail on CI/CD
-*crlf.txt   text eol=crlf
-simple-with-newline-crlf.txt        text eol=crlf
-simple-with-newline.txt             text eol=lf
-*_crlf_newlines.txt                 text eol=crlf
-*_lf_newlines.txt                   text eol=lf
+# By default, all text files should use LF newlines.
+*       text=auto eol=lf
+
+# Use CRLF newlines for text files containing "crlf" in their names.
+*crlf*  text=auto eol=crlf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,16 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
       - id: mixed-line-ending
+        name: "Enforce LF newlines on most files"
+        args:
+          - "--fix=lf"
+        # Exclude files with "crlf" in their names.
+        exclude: "crlf"
+      - id: mixed-line-ending
+        name: "Enforce CRLF newlines on files named '*crlf*'"
+        args:
+          - "--fix=crlf"
+        files: "crlf"
       - id: fix-byte-order-marker
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable


### PR DESCRIPTION
This resolves pre-commit hook failures that occur on Windows. The `.gitattributes` file forced CRLF newlines on all files via "text=auto", which caused linting to fail.

LF newlines are now enforced for all files except those with "crlf" in their filenames.