### PR TITLE
Add simple_test for custom test extensions

### DIFF
--- a/cookiecutter/utils.py
+++ b/cookiecutter/utils.py
@@ -116,3 +116,15 @@ def simple_filter(filter_function):
 
     SimpleFilterExtension.__name__ = filter_function.__name__
     return SimpleFilterExtension
+
+
+def simple_test(test_function):
+    """Decorate a function to wrap it in a simplified jinja2 extension."""
+
+    class SimpleTestExtension(Extension):
+        def __init__(self, environment):
+            super().__init__(environment)
+            environment.tests[test_function.__name__] = test_function
+
+    SimpleTestExtension.__name__ = test_function.__name__
+    return SimpleTestExtension

--- a/docs/advanced/local_extensions.rst
+++ b/docs/advanced/local_extensions.rst
@@ -54,6 +54,28 @@ It's likely that we'd only want to register a single function as a filter. For t
 
 This snippet will achieve the exact same result as the previous one.
 
+Similarly, to register a single function as a test extension we can use
+the ``simple_test`` decorator:
+
+.. code-block:: json
+
+    {
+        "project_slug": "Foobar",
+        "year": "{% now 'utc', '%Y' %}",
+        "_extensions": ["local_extensions.simpletestextesion"]
+    }
+
+.. code-block:: python
+
+    from cookiecutter.utils import simple_test
+
+
+    @simple_test
+    def simpletestextesion(v):
+        return v in [True, "True", "true]
+
+
+
 For complex use cases, a python module ``local_extensions`` (a folder with an ``__init__.py``) can also be created in the template root.
 Here, for example, a module ``main.py`` would have to export all extensions with ``from .main import FoobarExtension, simplefilterextension`` or ``from .main import *`` in the ``__init__.py``.
 

--- a/tests/test-extensions/local_extension/cookiecutter.json
+++ b/tests/test-extensions/local_extension/cookiecutter.json
@@ -2,8 +2,11 @@
   "project_slug": "Foobar",
   "test_value_class_based": "{{cookiecutter.project_slug | foobar}}",
   "test_value_function_based": "{{cookiecutter.project_slug | simplefilterextension}}",
+  "test_value_function_test_pos_based": "{% if 'XAX' is palindrome%}PASS1{%else%}PASS1{% endif %}",
+  "test_value_function_test_neg_based": "{% if 'XAY' is palindrome%}FAIL2{%else%}PASS2{% endif %}",
   "_extensions": [
     "local_extensions.simplefilterextension",
+    "local_extensions.palindrome",
     "local_extensions.FoobarExtension"
   ]
 }

--- a/tests/test-extensions/local_extension/local_extensions/__init__.py
+++ b/tests/test-extensions/local_extension/local_extensions/__init__.py
@@ -1,1 +1,1 @@
-from .main import FoobarExtension, simplefilterextension  # noqa
+from .main import FoobarExtension, simplefilterextension, palindrome  # noqa

--- a/tests/test-extensions/local_extension/local_extensions/main.py
+++ b/tests/test-extensions/local_extension/local_extensions/main.py
@@ -1,7 +1,7 @@
 """Provides custom extension, exposing a ``foobar`` filter."""
 
 from jinja2.ext import Extension
-from cookiecutter.utils import simple_filter
+from cookiecutter.utils import simple_filter, simple_test
 
 
 class FoobarExtension(Extension):
@@ -17,3 +17,10 @@ class FoobarExtension(Extension):
 def simplefilterextension(v):
     """Provide a simple function-based filter extension."""
     return v.upper()
+
+
+@simple_test
+def palindrome(v):
+    """Provide a simple function-based test extension."""
+    v_reverse =  v[::-1]
+    return v_reverse == v

--- a/tests/test-extensions/local_extension/{{cookiecutter.project_slug}}/HISTORY.rst
+++ b/tests/test-extensions/local_extension/{{cookiecutter.project_slug}}/HISTORY.rst
@@ -6,3 +6,5 @@ History
 
 First release of {{cookiecutter.test_value_class_based}} on PyPI.
 {{cookiecutter.test_value_function_based}}
+Is palindrome: {{ cookiecutter.test_value_function_test_pos_based }}
+Is not palindrome: {{ cookiecutter.test_value_function_test_neg_based }}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -439,6 +439,10 @@ def test_local_extension(tmpdir, cli_runner):
     content = Path(output_dir, 'Foobar', 'HISTORY.rst').read_text()
     assert 'FoobarFoobar' in content
     assert 'FOOBAR' in content
+    assert 'PASS1' in content
+    assert 'FAIL2' not in content
+    assert 'PASS2' in content
+    assert 'FAIL2' not in content
 
 
 def test_local_extension_not_available(tmpdir, cli_runner):


### PR DESCRIPTION
Currently there is a decorator to create a simple filter Jinja extension. This PR adds a similar decorator to create custom test extensions. Included is the decorator, test updatres, and docs updates