### PR TITLE
Added support for providing human-readable prompts to the different variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ parts/
 sdist/
 var/
 venv/
-*.egg-info/
+.venv/
+*.egg-info
 .installed.cfg
 *.egg
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Projects are generated to your current directory or to the target directory if s
   ```py
   {{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}.py
   ```
-- Simply define your template variables in a `cookiecutter.json` file.
+- Simply define your template variables in a `cookiecutter.json` file. You can also add human-readable questions that will be prompted to the user for each variable using the `__prompts__` key.
   For example:
 
   ```json
@@ -126,7 +126,7 @@ Projects are generated to your current directory or to the target directory if s
     "release_date": "2013-07-10",
     "year": "2013",
     "version": "0.1.1",
-    "__questions__": {
+    "__prompts__": {
       "full_name": "Provide your full name",
       "email": "Provide your email"
     }

--- a/README.md
+++ b/README.md
@@ -125,7 +125,11 @@ Projects are generated to your current directory or to the target directory if s
     "project_short_description": "Refreshingly simple static site generator.",
     "release_date": "2013-07-10",
     "year": "2013",
-    "version": "0.1.1"
+    "version": "0.1.1",
+    "__questions__": {
+      "full_name": "Provide your full name",
+      "email": "Provide your email"
+    }
   }
   ```
 - Pre- and post-generate hooks: Python or shell scripts to run before or after generating a project.

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -9,17 +9,22 @@ from jinja2.exceptions import UndefinedError
 from cookiecutter.environment import StrictEnvironment
 from cookiecutter.exceptions import UndefinedVariableInTemplate
 
-def read_user_variable(var_name, default_value, descriptions):
+
+def read_user_variable(var_name, default_value, descriptions=None):
     """Prompt user for variable and return the entered value or given default.
 
     :param str var_name: Variable of the context to query the user
     :param default_value: Value that will be returned if no input happens
     """
-    question = descriptions[var_name] if var_name in descriptions.keys() and descriptions[var_name] else var_name
+    question = (
+        descriptions[var_name]
+        if descriptions and var_name in descriptions.keys() and descriptions[var_name]
+        else var_name
+    )
     return click.prompt(question, default=default_value)
 
 
-def read_user_yes_no(var_name, default_value, descriptions):
+def read_user_yes_no(var_name, default_value, descriptions=None):
     """Prompt the user to reply with 'yes' or 'no' (or equivalent values).
 
     - These input values will be converted to ``True``:
@@ -33,7 +38,11 @@ def read_user_yes_no(var_name, default_value, descriptions):
     :param str question: Question to the user
     :param default_value: Value that will be returned if no input happens
     """
-    question = descriptions[var_name] if var_name in descriptions.keys() and descriptions[var_name] else var_name
+    question = (
+        descriptions[var_name]
+        if descriptions and var_name in descriptions.keys() and descriptions[var_name]
+        else var_name
+    )
     return click.prompt(question, default=default_value, type=click.BOOL)
 
 
@@ -45,7 +54,7 @@ def read_repo_password(question):
     return click.prompt(question, hide_input=True)
 
 
-def read_user_choice(var_name, options, descriptions):
+def read_user_choice(var_name, options, descriptions=None):
     """Prompt the user to choose from several options for the given variable.
 
     The first item will be returned if no input happens.
@@ -64,7 +73,11 @@ def read_user_choice(var_name, options, descriptions):
     choices = choice_map.keys()
     default = '1'
 
-    question = descriptions[var_name] if var_name in descriptions.keys() and descriptions[var_name] else f"Select {var_name}"
+    question = (
+        descriptions[var_name]
+        if descriptions and var_name in descriptions.keys() and descriptions[var_name]
+        else f"Select {var_name}"
+    )
 
     choice_lines = ['{} - {}'.format(*c) for c in choice_map.items()]
     prompt = '\n'.join(
@@ -106,7 +119,7 @@ def process_json(user_value, default_value=None):
     return user_dict
 
 
-def read_user_dict(var_name, default_value):
+def read_user_dict(var_name, default_value, descriptions=None):
     """Prompt the user to provide a dictionary of data.
 
     :param str var_name: Variable as specified in the context
@@ -116,8 +129,13 @@ def read_user_dict(var_name, default_value):
     if not isinstance(default_value, dict):
         raise TypeError
 
+    question = (
+        descriptions[var_name]
+        if descriptions and var_name in descriptions.keys() and descriptions[var_name]
+        else var_name
+    )
     user_value = click.prompt(
-        var_name,
+        question,
         default=DEFAULT_DISPLAY,
         type=click.STRING,
         value_proc=functools.partial(process_json, default_value=default_value),
@@ -165,7 +183,9 @@ def render_variable(env, raw, cookiecutter_dict):
     return template.render(cookiecutter=cookiecutter_dict)
 
 
-def prompt_choice_for_config(cookiecutter_dict, env, key, options, no_input, descriptions):
+def prompt_choice_for_config(
+    cookiecutter_dict, env, key, options, no_input, descriptions=None
+):
     """Prompt user with a set of options to choose from.
 
     :param no_input: Do not prompt for user input and return the first available option.
@@ -241,7 +261,7 @@ def prompt_for_config(context, no_input=False):
                 val = render_variable(env, raw, cookiecutter_dict)
 
                 if not no_input and not key.startswith('__'):
-                    val = read_user_dict(key, val)
+                    val = read_user_dict(key, val, descriptions)
 
                 cookiecutter_dict[key] = val
         except UndefinedError as err:

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -10,21 +10,21 @@ from cookiecutter.environment import StrictEnvironment
 from cookiecutter.exceptions import UndefinedVariableInTemplate
 
 
-def read_user_variable(var_name, default_value, questions=None):
+def read_user_variable(var_name, default_value, prompts=None):
     """Prompt user for variable and return the entered value or given default.
 
     :param str var_name: Variable of the context to query the user
     :param default_value: Value that will be returned if no input happens
     """
     question = (
-        questions[var_name]
-        if questions and var_name in questions.keys() and questions[var_name]
+        prompts[var_name]
+        if prompts and var_name in prompts.keys() and prompts[var_name]
         else var_name
     )
     return click.prompt(question, default=default_value)
 
 
-def read_user_yes_no(var_name, default_value, questions=None):
+def read_user_yes_no(var_name, default_value, prompts=None):
     """Prompt the user to reply with 'yes' or 'no' (or equivalent values).
 
     - These input values will be converted to ``True``:
@@ -39,8 +39,8 @@ def read_user_yes_no(var_name, default_value, questions=None):
     :param default_value: Value that will be returned if no input happens
     """
     question = (
-        questions[var_name]
-        if questions and var_name in questions.keys() and questions[var_name]
+        prompts[var_name]
+        if prompts and var_name in prompts.keys() and prompts[var_name]
         else var_name
     )
     return click.prompt(question, default=default_value, type=click.BOOL)
@@ -54,7 +54,7 @@ def read_repo_password(question):
     return click.prompt(question, hide_input=True)
 
 
-def read_user_choice(var_name, options, questions=None):
+def read_user_choice(var_name, options, prompts=None):
     """Prompt the user to choose from several options for the given variable.
 
     The first item will be returned if no input happens.
@@ -74,8 +74,8 @@ def read_user_choice(var_name, options, questions=None):
     default = '1'
 
     question = (
-        questions[var_name]
-        if questions and var_name in questions.keys() and questions[var_name]
+        prompts[var_name]
+        if prompts and var_name in prompts.keys() and prompts[var_name]
         else f"Select {var_name}"
     )
 
@@ -119,7 +119,7 @@ def process_json(user_value, default_value=None):
     return user_dict
 
 
-def read_user_dict(var_name, default_value, questions=None):
+def read_user_dict(var_name, default_value, prompts=None):
     """Prompt the user to provide a dictionary of data.
 
     :param str var_name: Variable as specified in the context
@@ -130,8 +130,8 @@ def read_user_dict(var_name, default_value, questions=None):
         raise TypeError
 
     question = (
-        questions[var_name]
-        if questions and var_name in questions.keys() and questions[var_name]
+        prompts[var_name]
+        if prompts and var_name in prompts.keys() and prompts[var_name]
         else var_name
     )
     user_value = click.prompt(
@@ -184,7 +184,7 @@ def render_variable(env, raw, cookiecutter_dict):
 
 
 def prompt_choice_for_config(
-    cookiecutter_dict, env, key, options, no_input, questions=None
+    cookiecutter_dict, env, key, options, no_input, prompts=None
 ):
     """Prompt user with a set of options to choose from.
 
@@ -193,7 +193,7 @@ def prompt_choice_for_config(
     rendered_options = [render_variable(env, raw, cookiecutter_dict) for raw in options]
     if no_input:
         return rendered_options[0]
-    return read_user_choice(key, rendered_options, questions)
+    return read_user_choice(key, rendered_options, prompts)
 
 
 def prompt_for_config(context, no_input=False):
@@ -205,10 +205,10 @@ def prompt_for_config(context, no_input=False):
     cookiecutter_dict = OrderedDict([])
     env = StrictEnvironment(context=context)
 
-    questions = {}
-    if '__questions__' in context['cookiecutter'].keys():
-        questions = context['cookiecutter']['__questions__']
-        del context['cookiecutter']['__questions__']
+    prompts = {}
+    if '__prompts__' in context['cookiecutter'].keys():
+        prompts = context['cookiecutter']['__prompts__']
+        del context['cookiecutter']['__prompts__']
 
     # First pass: Handle simple and raw variables, plus choices.
     # These must be done first because the dictionaries keys and
@@ -225,7 +225,7 @@ def prompt_for_config(context, no_input=False):
             if isinstance(raw, list):
                 # We are dealing with a choice variable
                 val = prompt_choice_for_config(
-                    cookiecutter_dict, env, key, raw, no_input, questions
+                    cookiecutter_dict, env, key, raw, no_input, prompts
                 )
                 cookiecutter_dict[key] = val
             elif isinstance(raw, bool):
@@ -241,7 +241,7 @@ def prompt_for_config(context, no_input=False):
                 val = render_variable(env, raw, cookiecutter_dict)
 
                 if not no_input:
-                    val = read_user_variable(key, val, questions)
+                    val = read_user_variable(key, val, prompts)
 
                 cookiecutter_dict[key] = val
         except UndefinedError as err:
@@ -260,7 +260,7 @@ def prompt_for_config(context, no_input=False):
                 val = render_variable(env, raw, cookiecutter_dict)
 
                 if not no_input and not key.startswith('__'):
-                    val = read_user_dict(key, val, questions)
+                    val = read_user_dict(key, val, prompts)
 
                 cookiecutter_dict[key] = val
         except UndefinedError as err:

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -64,12 +64,12 @@ def read_user_choice(var_name, options, descriptions):
     choices = choice_map.keys()
     default = '1'
 
-    question = descriptions[var_name] if var_name in descriptions.keys() and descriptions[var_name] else var_name
+    question = descriptions[var_name] if var_name in descriptions.keys() and descriptions[var_name] else f"Select {var_name}"
 
     choice_lines = ['{} - {}'.format(*c) for c in choice_map.items()]
     prompt = '\n'.join(
         (
-            f"Select {question}:",
+            f"{question}:",
             "\n".join(choice_lines),
             f"Choose from {', '.join(choices)}",
         )

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -10,21 +10,21 @@ from cookiecutter.environment import StrictEnvironment
 from cookiecutter.exceptions import UndefinedVariableInTemplate
 
 
-def read_user_variable(var_name, default_value, descriptions=None):
+def read_user_variable(var_name, default_value, questions=None):
     """Prompt user for variable and return the entered value or given default.
 
     :param str var_name: Variable of the context to query the user
     :param default_value: Value that will be returned if no input happens
     """
     question = (
-        descriptions[var_name]
-        if descriptions and var_name in descriptions.keys() and descriptions[var_name]
+        questions[var_name]
+        if questions and var_name in questions.keys() and questions[var_name]
         else var_name
     )
     return click.prompt(question, default=default_value)
 
 
-def read_user_yes_no(var_name, default_value, descriptions=None):
+def read_user_yes_no(var_name, default_value, questions=None):
     """Prompt the user to reply with 'yes' or 'no' (or equivalent values).
 
     - These input values will be converted to ``True``:
@@ -39,8 +39,8 @@ def read_user_yes_no(var_name, default_value, descriptions=None):
     :param default_value: Value that will be returned if no input happens
     """
     question = (
-        descriptions[var_name]
-        if descriptions and var_name in descriptions.keys() and descriptions[var_name]
+        questions[var_name]
+        if questions and var_name in questions.keys() and questions[var_name]
         else var_name
     )
     return click.prompt(question, default=default_value, type=click.BOOL)
@@ -54,7 +54,7 @@ def read_repo_password(question):
     return click.prompt(question, hide_input=True)
 
 
-def read_user_choice(var_name, options, descriptions=None):
+def read_user_choice(var_name, options, questions=None):
     """Prompt the user to choose from several options for the given variable.
 
     The first item will be returned if no input happens.
@@ -74,8 +74,8 @@ def read_user_choice(var_name, options, descriptions=None):
     default = '1'
 
     question = (
-        descriptions[var_name]
-        if descriptions and var_name in descriptions.keys() and descriptions[var_name]
+        questions[var_name]
+        if questions and var_name in questions.keys() and questions[var_name]
         else f"Select {var_name}"
     )
 
@@ -119,7 +119,7 @@ def process_json(user_value, default_value=None):
     return user_dict
 
 
-def read_user_dict(var_name, default_value, descriptions=None):
+def read_user_dict(var_name, default_value, questions=None):
     """Prompt the user to provide a dictionary of data.
 
     :param str var_name: Variable as specified in the context
@@ -130,8 +130,8 @@ def read_user_dict(var_name, default_value, descriptions=None):
         raise TypeError
 
     question = (
-        descriptions[var_name]
-        if descriptions and var_name in descriptions.keys() and descriptions[var_name]
+        questions[var_name]
+        if questions and var_name in questions.keys() and questions[var_name]
         else var_name
     )
     user_value = click.prompt(
@@ -184,7 +184,7 @@ def render_variable(env, raw, cookiecutter_dict):
 
 
 def prompt_choice_for_config(
-    cookiecutter_dict, env, key, options, no_input, descriptions=None
+    cookiecutter_dict, env, key, options, no_input, questions=None
 ):
     """Prompt user with a set of options to choose from.
 
@@ -193,7 +193,7 @@ def prompt_choice_for_config(
     rendered_options = [render_variable(env, raw, cookiecutter_dict) for raw in options]
     if no_input:
         return rendered_options[0]
-    return read_user_choice(key, rendered_options, descriptions)
+    return read_user_choice(key, rendered_options, questions)
 
 
 def prompt_for_config(context, no_input=False):
@@ -205,11 +205,10 @@ def prompt_for_config(context, no_input=False):
     cookiecutter_dict = OrderedDict([])
     env = StrictEnvironment(context=context)
 
-    descriptions = {}
-    if '__internal_use' in context['cookiecutter'].keys():
-        if 'descriptions' in context['cookiecutter']['__internal_use'].keys():
-            descriptions = context['cookiecutter']['__internal_use']['descriptions']
-        del context['cookiecutter']['__internal_use']
+    questions = {}
+    if '__questions__' in context['cookiecutter'].keys():
+        questions = context['cookiecutter']['__questions__']
+        del context['cookiecutter']['__questions__']
 
     # First pass: Handle simple and raw variables, plus choices.
     # These must be done first because the dictionaries keys and
@@ -226,7 +225,7 @@ def prompt_for_config(context, no_input=False):
             if isinstance(raw, list):
                 # We are dealing with a choice variable
                 val = prompt_choice_for_config(
-                    cookiecutter_dict, env, key, raw, no_input, descriptions
+                    cookiecutter_dict, env, key, raw, no_input, questions
                 )
                 cookiecutter_dict[key] = val
             elif isinstance(raw, bool):
@@ -242,7 +241,7 @@ def prompt_for_config(context, no_input=False):
                 val = render_variable(env, raw, cookiecutter_dict)
 
                 if not no_input:
-                    val = read_user_variable(key, val, descriptions)
+                    val = read_user_variable(key, val, questions)
 
                 cookiecutter_dict[key] = val
         except UndefinedError as err:
@@ -261,7 +260,7 @@ def prompt_for_config(context, no_input=False):
                 val = render_variable(env, raw, cookiecutter_dict)
 
                 if not no_input and not key.startswith('__'):
-                    val = read_user_dict(key, val, descriptions)
+                    val = read_user_dict(key, val, questions)
 
                 cookiecutter_dict[key] = val
         except UndefinedError as err:

--- a/docs/advanced/human_readable_prompts.rst
+++ b/docs/advanced/human_readable_prompts.rst
@@ -36,4 +36,3 @@ You can add human-readable prompts that will be shown to the user for each varia
             "black_formatting": "Enable black formatting:"
         }
     }
-

--- a/docs/advanced/human_readable_prompts.rst
+++ b/docs/advanced/human_readable_prompts.rst
@@ -1,0 +1,39 @@
+.. _human-readable-prompts:
+
+Human readable prompts
+--------------------------------
+
+You can add human-readable prompts that will be shown to the user for each variable using the ``__prompts__`` key:
+
+
+.. code-block:: json
+
+    {
+        "package_name": "my-package",
+        "module_name": "{{ cookiecutter.package_name.replace('-', '_') }}",
+        "package_name_stylized": "{{ cookiecutter.module_name.replace('_', ' ').capitalize() }}",
+        "short_description": "A nice python package",
+        "github_username": "your-org-or-username",
+        "full_name": "Firstname Lastname",
+        "email": "email@example.com",
+        "command_line_interface": ["yes", "no"],
+        "init_git": ["yes", "no"],
+        "enable_pre_commit": ["yes", "no"],
+        "documentation_website": ["yes", "no"],
+        "black_formatting": ["yes", "no"],
+        "__prompts__": {
+            "package_name": "Select your package name:",
+            "module_name": "Select your module name:",
+            "package_name_stylized": "Stylized package name:",
+            "short_description": "Short description:",
+            "github_username": "GitHub username or organization:",
+            "full_name": "Author full name:",
+            "email": "Author email:",
+            "command_line_interface": "Add CLI:",
+            "init_git": "Initialize a git repository:",
+            "enable_pre_commit": "Enable pre-commit:",
+            "documentation_website": "Add a documentation website:",
+            "black_formatting": "Enable black formatting:"
+        }
+    }
+

--- a/docs/advanced/index.rst
+++ b/docs/advanced/index.rst
@@ -27,3 +27,4 @@ Various advanced topics regarding cookiecutter usage.
    new_line_characters
    local_extensions
    nested_config_files
+   human_readable_prompts

--- a/docs/cookiecutter.rst
+++ b/docs/cookiecutter.rst
@@ -1,9 +1,8 @@
-===
-API
-===
+cookiecutter package
+====================
 
-This is the Cookiecutter modules API documentation.
-
+Submodules
+----------
 
 cookiecutter.cli module
 -----------------------

--- a/tests/test_cookiecutter_local_with_input.py
+++ b/tests/test_cookiecutter_local_with_input.py
@@ -21,7 +21,7 @@ def test_cookiecutter_local_with_input(monkeypatch):
     """Verify simple cookiecutter run results, without extra_context provided."""
     monkeypatch.setattr(
         'cookiecutter.prompt.read_user_variable',
-        lambda var, default, questions: default,
+        lambda var, default, prompts: default,
     )
     main.cookiecutter('tests/fake-repo-pre/', no_input=False)
     assert os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}')
@@ -36,7 +36,7 @@ def test_cookiecutter_input_extra_context(monkeypatch):
     """Verify simple cookiecutter run results, with extra_context provided."""
     monkeypatch.setattr(
         'cookiecutter.prompt.read_user_variable',
-        lambda var, default, questions: default,
+        lambda var, default, prompts: default,
     )
     main.cookiecutter(
         'tests/fake-repo-pre',

--- a/tests/test_cookiecutter_local_with_input.py
+++ b/tests/test_cookiecutter_local_with_input.py
@@ -20,7 +20,8 @@ def remove_additional_dirs(request):
 def test_cookiecutter_local_with_input(monkeypatch):
     """Verify simple cookiecutter run results, without extra_context provided."""
     monkeypatch.setattr(
-        'cookiecutter.prompt.read_user_variable', lambda var, default: default
+        'cookiecutter.prompt.read_user_variable',
+        lambda var, default, descriptions: default,
     )
     main.cookiecutter('tests/fake-repo-pre/', no_input=False)
     assert os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}')
@@ -34,7 +35,8 @@ def test_cookiecutter_local_with_input(monkeypatch):
 def test_cookiecutter_input_extra_context(monkeypatch):
     """Verify simple cookiecutter run results, with extra_context provided."""
     monkeypatch.setattr(
-        'cookiecutter.prompt.read_user_variable', lambda var, default: default
+        'cookiecutter.prompt.read_user_variable',
+        lambda var, default, descriptions: default,
     )
     main.cookiecutter(
         'tests/fake-repo-pre',

--- a/tests/test_cookiecutter_local_with_input.py
+++ b/tests/test_cookiecutter_local_with_input.py
@@ -21,7 +21,7 @@ def test_cookiecutter_local_with_input(monkeypatch):
     """Verify simple cookiecutter run results, without extra_context provided."""
     monkeypatch.setattr(
         'cookiecutter.prompt.read_user_variable',
-        lambda var, default, descriptions: default,
+        lambda var, default, questions: default,
     )
     main.cookiecutter('tests/fake-repo-pre/', no_input=False)
     assert os.path.isdir('tests/fake-repo-pre/{{cookiecutter.repo_name}}')
@@ -36,7 +36,7 @@ def test_cookiecutter_input_extra_context(monkeypatch):
     """Verify simple cookiecutter run results, with extra_context provided."""
     monkeypatch.setattr(
         'cookiecutter.prompt.read_user_variable',
-        lambda var, default, descriptions: default,
+        lambda var, default, questions: default,
     )
     main.cookiecutter(
         'tests/fake-repo-pre',

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -81,7 +81,7 @@ class TestPrompt:
         """Verify `prompt_for_config` call `read_user_variable` on text request."""
         monkeypatch.setattr(
             'cookiecutter.prompt.read_user_variable',
-            lambda var, default, questions: default,
+            lambda var, default, prompts: default,
         )
 
         cookiecutter_dict = prompt.prompt_for_config(context)
@@ -95,7 +95,7 @@ class TestPrompt:
                     'full_name': 'Your Name',
                     'check': ['yes', 'no'],
                     'nothing': 'ok',
-                    '__questions__': {
+                    '__prompts__': {
                         'full_name': 'Name please',
                         'check': 'Checking',
                     },
@@ -104,19 +104,19 @@ class TestPrompt:
         ],
         ids=['ASCII default prompt/input'],
     )
-    def test_prompt_for_config_with_questions(self, monkeypatch, context):
-        """Verify `prompt_for_config` call `read_user_variable` on text request."""
+    def test_prompt_for_config_with_human_prompts(self, monkeypatch, context):
+        """Verify call `read_user_variable` on request when human-readable prompts."""
         monkeypatch.setattr(
             'cookiecutter.prompt.read_user_variable',
-            lambda var, default, questions: default,
+            lambda var, default, prompts: default,
         )
         monkeypatch.setattr(
             'cookiecutter.prompt.read_user_yes_no',
-            lambda var, default, questions: default,
+            lambda var, default, prompts: default,
         )
         monkeypatch.setattr(
             'cookiecutter.prompt.read_user_choice',
-            lambda var, default, questions: default,
+            lambda var, default, prompts: default,
         )
 
         cookiecutter_dict = prompt.prompt_for_config(context)
@@ -126,7 +126,7 @@ class TestPrompt:
         """Verify `prompt_for_config` call `read_user_variable` on dict request."""
         monkeypatch.setattr(
             'cookiecutter.prompt.read_user_dict',
-            lambda var, default, questions: {"key": "value", "integer": 37},
+            lambda var, default, prompts: {"key": "value", "integer": 37},
         )
         context = {'cookiecutter': {'details': {}}}
 
@@ -195,8 +195,8 @@ class TestPrompt:
             },
         }
 
-    def test_should_render_deep_dict_with_questions(self):
-        """Verify nested structures like dict in dict, rendered correctly when questions."""
+    def test_should_render_deep_dict_with_human_prompts(self):
+        """Verify dict rendered correctly when human-readable prompts."""
         context = {
             'cookiecutter': {
                 'project_name': "Slartibartfast",
@@ -208,7 +208,7 @@ class TestPrompt:
                         "deep_key": "deep_value",
                     },
                 },
-                '__questions__': {'project_name': 'Project name'},
+                '__prompts__': {'project_name': 'Project name'},
             }
         }
         cookiecutter_dict = prompt.prompt_for_config(context, no_input=True)
@@ -224,12 +224,12 @@ class TestPrompt:
             },
         }
 
-    def test_internal_use_no_questions(self):
-        """Verify nested structures like dict in dict, rendered correctly when questions."""
+    def test_internal_use_no_human_prompts(self):
+        """Verify dict rendered correctly when human-readable prompts empty."""
         context = {
             'cookiecutter': {
                 'project_name': "Slartibartfast",
-                '__questions__': {},
+                '__prompts__': {},
             }
         }
         cookiecutter_dict = prompt.prompt_for_config(context, no_input=True)
@@ -241,7 +241,7 @@ class TestPrompt:
         """Verify Jinja2 templating works in unicode prompts."""
         monkeypatch.setattr(
             'cookiecutter.prompt.read_user_variable',
-            lambda var, default, questions: default,
+            lambda var, default, prompts: default,
         )
         context = {
             'cookiecutter': OrderedDict(

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -81,7 +81,7 @@ class TestPrompt:
         """Verify `prompt_for_config` call `read_user_variable` on text request."""
         monkeypatch.setattr(
             'cookiecutter.prompt.read_user_variable',
-            lambda var, default: default,
+            lambda var, default, descriptions: default,
         )
 
         cookiecutter_dict = prompt.prompt_for_config(context)
@@ -91,7 +91,7 @@ class TestPrompt:
         """Verify `prompt_for_config` call `read_user_variable` on dict request."""
         monkeypatch.setattr(
             'cookiecutter.prompt.read_user_dict',
-            lambda var, default: {"key": "value", "integer": 37},
+            lambda var, default, descriptions: {"key": "value", "integer": 37},
         )
         context = {'cookiecutter': {'details': {}}}
 
@@ -163,7 +163,8 @@ class TestPrompt:
     def test_prompt_for_templated_config(self, monkeypatch):
         """Verify Jinja2 templating works in unicode prompts."""
         monkeypatch.setattr(
-            'cookiecutter.prompt.read_user_variable', lambda var, default: default
+            'cookiecutter.prompt.read_user_variable',
+            lambda var, default, descriptions: default,
         )
         context = {
             'cookiecutter': OrderedDict(
@@ -274,7 +275,7 @@ class TestReadUserChoice:
 
         assert not read_user_variable.called
         assert prompt_choice.called
-        read_user_choice.assert_called_once_with('orientation', choices)
+        read_user_choice.assert_called_once_with('orientation', choices, {})
         assert cookiecutter_dict == {'orientation': 'all'}
 
     def test_should_invoke_read_user_variable(self, mocker):
@@ -292,7 +293,7 @@ class TestReadUserChoice:
 
         assert not prompt_choice.called
         assert not read_user_choice.called
-        read_user_variable.assert_called_once_with('full_name', 'Your Name')
+        read_user_variable.assert_called_once_with('full_name', 'Your Name', {})
         assert cookiecutter_dict == {'full_name': 'Audrey Roy'}
 
     def test_should_render_choices(self, mocker):
@@ -327,8 +328,8 @@ class TestReadUserChoice:
         }
         cookiecutter_dict = prompt.prompt_for_config(context)
 
-        read_user_variable.assert_called_once_with('project_name', 'A New Project')
-        read_user_choice.assert_called_once_with('pkg_name', rendered_choices)
+        read_user_variable.assert_called_once_with('project_name', 'A New Project', {})
+        read_user_choice.assert_called_once_with('pkg_name', rendered_choices, {})
         assert cookiecutter_dict == expected
 
 
@@ -376,7 +377,7 @@ class TestPromptChoiceForConfig:
             options=choices,
             no_input=False,  # Ask the user for input
         )
-        read_user_choice.assert_called_once_with('orientation', choices)
+        read_user_choice.assert_called_once_with('orientation', choices, None)
         assert expected_choice == actual_choice
 
 


### PR DESCRIPTION
Hi @pydanny @jensens @ericof @audreyfeldroy, I added support for providing human-readable questions to the different variables

Many issues mentioned it:

* https://github.com/cookiecutter/cookiecutter/issues/30
* https://github.com/cookiecutter/cookiecutter/issues/249
* https://github.com/cookiecutter/cookiecutter/issues/794
* https://github.com/cookiecutter/cookiecutter/issues/1567
* https://github.com/cookiecutter/cookiecutter/issues/1835

A PR has been attempted but abandonned: https://github.com/cookiecutter/cookiecutter/pull/848

There have been lengthy discussions about wherever the json format should completely be changed, introduce breaking change, etc... I took the simplest approach, to **introduce the least amount of technical debt and keep complete backward compatibility** . So that we can merge this feature, really much needed for a templating library, and discuss about changing the JSON format later!

It was quite straightforward to implement, I just added a `__prompts__` object, which takes the variable names as key and the questions to ask the user as values.

Example of a config file:

```json
{
    "package_name": "my-package",
    "module_name": "{{ cookiecutter.package_name.replace('-', '_') }}",
    "short_description": "A nice python package",
    "__prompts__": {
        "package_name": "Select your package name:",
        "module_name": "Select your module name:"
    }
}
```

The 2 first questions will use the description provided, the 3rd one will use the variable name since there is no description provided

**This format stays easy to read, and easy to write**. Once the dev defined all its variables with their default they can copy them, paste them in the `__prompts__` block, and replace the default by the questions one by one. Also wrap something around  2 underscores is a pythonic way to say "this is special" (`__init__`, `__main__`)

<details><summary>In my opinion when you have many variables it is more readable  than a nested dict where some keys are repeated all other the place</summary>

```json
{
    "package_name": {
        "default": "my-package", 
        "prompts": "Your package name",
    },
    "module_name": {
        "default": "{{ cookiecutter.package_name.replace('-', '_') }}", 
        "prompts": "Your package name",
    },
}
```

</details>

It is **100% backward compatible with the previous `cookiecutter.json` format 🎉** so it will not break existing template, it will only make templates that have defined `__prompts__` better!

- [x] **Not a lot of code have been added**, and the changes introduced don't introduce a lot of complexity in the codebase
- [x] I made sure **all tests pass** with `tox`, and I added a few tests for the new feature, to reach **💯% of code coverage**
- [x] I have updated the example in the README to show how to use those new descriptions 
- [x] A page has been added in the advanced tab in readthedocs documentation 

I hope there is no more excuses to not merge this long-awaited feature 😄 I am already using it for my [templates](https://github.com/MaastrichtU-IDS/cookiecutter-python-package/blob/main/cookiecutter.json) and will continue in the future since those templates are fully compatible!

There are no breaking changes so this feature can be pushed to the next minor release without any concern 🥳

Please let me know if we should use something else instead of `__prompts__`, I can make the changes required in a few minutes (maybe `_prompts_` with only 1 underscore? that might be less prone to user mistakes, but the double underscore seems more pythonic) 