### PR TITLE
Fix issue where the prompts dict was not passed for yes_no questions

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -235,7 +235,7 @@ def prompt_for_config(context, no_input=False):
                         env, raw, cookiecutter_dict
                     )
                 else:
-                    cookiecutter_dict[key] = read_user_yes_no(key, raw)
+                    cookiecutter_dict[key] = read_user_yes_no(key, raw, prompts)
             elif not isinstance(raw, dict):
                 # We are dealing with a regular variable
                 val = render_variable(env, raw, cookiecutter_dict)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -480,7 +480,7 @@ class TestReadUserYesNo(object):
         cookiecutter_dict = prompt.prompt_for_config(context)
 
         assert not read_user_variable.called
-        read_user_yes_no.assert_called_once_with('run_as_docker', run_as_docker)
+        read_user_yes_no.assert_called_once_with('run_as_docker', run_as_docker, {})
         assert cookiecutter_dict == {'run_as_docker': run_as_docker}
 
     def test_boolean_parameter_no_input(self):


### PR DESCRIPTION
Small fix for an issue where the human readable prompts dict was not passed for `yes_no` questions. 

Fixes https://github.com/cookiecutter/cookiecutter/issues/1893