### PR TITLE
Add support for adding human-readable labels for choices when defining multiple choices questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ Projects are generated to your current directory or to the target directory if s
       "email": "Provide your email",
       "linting": {
         "__prompt__": "Which linting tool do you want to use?",
-          "ruff": "Ruff",
-          "flake8": "Flake8",
-          "none": "No linting tool"
+        "ruff": "Ruff",
+        "flake8": "Flake8",
+        "none": "No linting tool"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Projects are generated to your current directory or to the target directory if s
   ```py
   {{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}.py
   ```
-- Simply define your template variables in a `cookiecutter.json` file. You can also add human-readable questions that will be prompted to the user for each variable using the `__prompts__` key.
+- Simply define your template variables in a `cookiecutter.json` file. You can also add human-readable questions and choices that will be prompted to the user for each variable using the `__prompts__` key.
   For example:
 
   ```json
@@ -126,9 +126,16 @@ Projects are generated to your current directory or to the target directory if s
     "release_date": "2013-07-10",
     "year": "2013",
     "version": "0.1.1",
+    "linting": ["ruff", "flake8", "none"],
     "__prompts__": {
       "full_name": "Provide your full name",
-      "email": "Provide your email"
+      "email": "Provide your email",
+      "linting": {
+        "__prompt__": "Which linting tool do you want to use?",
+          "ruff": "Ruff",
+          "flake8": "Flake8",
+          "none": "No linting tool"
+      }
     }
   }
   ```

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -72,14 +72,23 @@ def read_user_choice(var_name, options, prompts=None):
     choice_map = OrderedDict((f'{i}', value) for i, value in enumerate(options, 1))
     choices = choice_map.keys()
     default = '1'
-
-    question = (
-        prompts[var_name]
-        if prompts and var_name in prompts.keys() and prompts[var_name]
-        else f"Select {var_name}"
-    )
-
+    question = f"Select {var_name}"
     choice_lines = ['{} - {}'.format(*c) for c in choice_map.items()]
+
+    # Handle if human-readable prompt is provided
+    if prompts and var_name in prompts.keys():
+        if isinstance(prompts[var_name], str):
+            question = prompts[var_name]
+        else:
+            if "__prompt__" in prompts[var_name]:
+                question = prompts[var_name]["__prompt__"]
+            choice_lines = [
+                f"{i} - {prompts[var_name][p]}"
+                if p in prompts[var_name]
+                else f"{i} - {p}"
+                for i, p in choice_map.items()
+            ]
+
     prompt = '\n'.join(
         (
             f"{question}:",

--- a/docs/advanced/human_readable_prompts.rst
+++ b/docs/advanced/human_readable_prompts.rst
@@ -3,7 +3,10 @@
 Human readable prompts
 --------------------------------
 
-You can add human-readable prompts that will be shown to the user for each variable using the ``__prompts__`` key:
+You can add human-readable prompts that will be shown to the user for each variable using the ``__prompts__`` key.
+For multiple choices questions you can also provide labels for each option.
+
+See the following cookiecutter config as example:
 
 
 .. code-block:: json
@@ -16,11 +19,8 @@ You can add human-readable prompts that will be shown to the user for each varia
         "github_username": "your-org-or-username",
         "full_name": "Firstname Lastname",
         "email": "email@example.com",
-        "command_line_interface": ["yes", "no"],
-        "init_git": ["yes", "no"],
-        "enable_pre_commit": ["yes", "no"],
-        "documentation_website": ["yes", "no"],
-        "black_formatting": ["yes", "no"],
+        "init_git": true,
+        "linting": ["ruff", "flake8", "none"],
         "__prompts__": {
             "package_name": "Select your package name:",
             "module_name": "Select your module name:",
@@ -31,8 +31,11 @@ You can add human-readable prompts that will be shown to the user for each varia
             "email": "Author email:",
             "command_line_interface": "Add CLI:",
             "init_git": "Initialize a git repository:",
-            "enable_pre_commit": "Enable pre-commit:",
-            "documentation_website": "Add a documentation website:",
-            "black_formatting": "Enable black formatting:"
+            "linting": {
+                "__prompt__": "Which linting tool do you want to use?",
+                "ruff": "Ruff",
+                "flake8": "Flake8",
+                "none": "No linting tool"
+            }
         }
     }

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -2,6 +2,7 @@
 import platform
 from collections import OrderedDict
 
+import click
 import pytest
 
 from cookiecutter import prompt, exceptions, environment
@@ -121,6 +122,48 @@ class TestPrompt:
 
         cookiecutter_dict = prompt.prompt_for_config(context)
         assert cookiecutter_dict == context['cookiecutter']
+
+    @pytest.mark.parametrize(
+        'context',
+        [
+            {
+                'cookiecutter': {
+                    'full_name': 'Your Name',
+                    'check': ['yes', 'no'],
+                    '__prompts__': {
+                        'check': 'Checking',
+                    },
+                }
+            },
+            {
+                'cookiecutter': {
+                    'full_name': 'Your Name',
+                    'check': ['yes', 'no'],
+                    '__prompts__': {
+                        'full_name': 'Name please',
+                        'check': {'__prompt__': 'Checking', 'yes': 'Yes', 'no': 'No'},
+                    },
+                }
+            },
+            {
+                'cookiecutter': {
+                    'full_name': 'Your Name',
+                    'check': ['yes', 'no'],
+                    '__prompts__': {
+                        'full_name': 'Name please',
+                        'check': {'no': 'No'},
+                    },
+                }
+            },
+        ],
+    )
+    def test_prompt_for_config_with_human_choices(self, monkeypatch, context):
+        """Test prompts when human-readable labels for user choices."""
+        runner = click.testing.CliRunner()
+        with runner.isolation(input="\n\n\n"):
+            cookiecutter_dict = prompt.prompt_for_config(context)
+
+        assert dict(cookiecutter_dict) == {'full_name': 'Your Name', 'check': 'yes'}
 
     def test_prompt_for_config_dict(self, monkeypatch):
         """Verify `prompt_for_config` call `read_user_variable` on dict request."""


### PR DESCRIPTION
Add support for adding human-readable labels for choices when defining multiple choices questions. As mentioned by @henryiii  in https://github.com/cookiecutter/cookiecutter/pull/1881

Example JSON:

```json
{
  "full_name": "Audrey Roy Greenfeld",
  "email": "audreyr@gmail.com",
  "linting": ["ruff", "flake8", "none"],
  "__prompts__": {
    "full_name": "Provide your full name",
    "email": "Provide your email",
    "linting": {
      "__prompt__": "Which linting tool do you want to use?",
      "ruff": "Ruff",
      "flake8": "Flake8",
      "none": "No linting tool"
    }
  }
}
```

Previous behaviors are still working (no `__prompts__` and providing just a string to the multiple choices `__prompt__`)

The README.md and readthedocs page for human-readable prompts have been updated accordingly