### PR TITLE
Support multichoice overwrite

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -58,8 +58,7 @@ def apply_overwrites_to_context(context, overwrite_context):
         if isinstance(context_value, list) and isinstance(overwrite, list):
             # We are dealing with a multichoice variable
             # Let's confirm all choices are valid for the given context
-            common = set(context_value).intersection(set(overwrite))
-            if len(common) == len(overwrite):
+            if set(overwrite).issubset(set(context_value)):
                 context[variable] = overwrite
             else:
                 raise ValueError(

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -55,7 +55,18 @@ def apply_overwrites_to_context(context, overwrite_context):
 
         context_value = context[variable]
 
-        if isinstance(context_value, list):
+        if isinstance(context_value, list) and isinstance(overwrite, list):
+            # We are dealing with a multichoice variable
+            # Let's confirm all choices are valid for the given context
+            common = set(context_value).intersection(set(overwrite))
+            if len(common) == len(overwrite):
+                context[variable] = overwrite
+            else:
+                raise ValueError(
+                    f"{overwrite} provided for multi-choice variable {variable}, "
+                    f"but valid choices are {context_value}"
+                )
+        elif isinstance(context_value, list):
             # We are dealing with a choice variable
             if overwrite in context_value:
                 # This overwrite is actually valid for the given context

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -135,6 +135,13 @@ def template_context():
             ('project_name', 'Kivy Project'),
             ('repo_name', '{{cookiecutter.project_name|lower}}'),
             ('orientation', ['all', 'landscape', 'portrait']),
+            (
+                'deployments',
+                {
+                    'preprod': ['eu', 'us', 'ap'],
+                    'prod': ['eu', 'us', 'ap'],
+                },
+            ),
         ]
     )
 
@@ -193,6 +200,25 @@ def test_apply_overwrites_invalid_overwrite(template_context):
     with pytest.raises(ValueError):
         generate.apply_overwrites_to_context(
             context=template_context, overwrite_context={'orientation': 'foobar'}
+        )
+
+
+def test_apply_overwrites_sets_multichoice_values(template_context):
+    """Verify variable overwrite for list given multiple valid values."""
+    generate.apply_overwrites_to_context(
+        context=template_context,
+        overwrite_context={'deployments': {'preprod': ['eu'], 'prod': ['eu']}},
+    )
+    assert template_context['deployments']['preprod'] == ['eu']
+    assert template_context['deployments']['prod'] == ['eu']
+
+
+def test_apply_overwrites_invalid_multichoice_values(template_context):
+    """Verify variable overwrite for list given invalid list entries not ignored."""
+    with pytest.raises(ValueError):
+        generate.apply_overwrites_to_context(
+            context=template_context,
+            overwrite_context={'deployments': {'preprod': ['na'], 'prod': ['na']}},
         )
 
 

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -222,6 +222,17 @@ def test_apply_overwrites_invalid_multichoice_values(template_context):
         )
 
 
+def test_apply_overwrites_error_additional_values(template_context):
+    """Verify variable overwrite for list given additional entries not ignored."""
+    with pytest.raises(ValueError):
+        generate.apply_overwrites_to_context(
+            context=template_context,
+            overwrite_context={
+                'deployments': {'preprod': ['eu', 'na'], 'prod': ['eu', 'na']}
+            },
+        )
+
+
 def test_apply_overwrites_sets_default_for_choice_variable(template_context):
     """Verify overwritten list member became a default value."""
     generate.apply_overwrites_to_context(


### PR DESCRIPTION
Implements https://github.com/cookiecutter/cookiecutter/issues/1892

Allows multichoice values to be given as overwrite values to lists, where a given overwrite is valid if and only if all values are present in the corresponding context value