### PR TITLE
Fix replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Adapted from https://github.com/github/gitignore/blob/main/Python.gitignore
 
+tests/tmp/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -110,6 +110,7 @@ def cookiecutter(
         }
         context_for_prompting = {}
         context_for_prompting['cookiecutter'] = items_for_prompting
+        context = context_from_replayfile
         logger.debug('prompting context: %s', context_for_prompting)
     else:
         context = generate_context(

--- a/tests/fake-repo-replay/cookiecutter.json
+++ b/tests/fake-repo-replay/cookiecutter.json
@@ -1,0 +1,11 @@
+{
+  "full_name": "Audrey Roy",
+  "email": "audreyr@gmail.com",
+  "github_username": "audreyr",
+  "project_name": "Replay Project",
+  "repo_name": "{{ cookiecutter.project_name|lower|replace(' ', '-') }}",
+  "description": "original",
+  "release_date": "2013-07-28",
+  "year": "2013",
+  "version": "0.1"
+}

--- a/tests/fake-repo-replay/{{cookiecutter.repo_name}}/README.md
+++ b/tests/fake-repo-replay/{{cookiecutter.repo_name}}/README.md
@@ -1,0 +1,1 @@
+{{cookiecutter.description}}

--- a/tests/test-replay/valid_replay.json
+++ b/tests/test-replay/valid_replay.json
@@ -1,0 +1,9 @@
+{
+  "cookiecutter": {
+    "version": "0.1.0",
+    "email": "raphael@hackebrot.de",
+    "full_name": "Raphael Pierzina",
+    "github_username": "hackebrot",
+    "description": "replayed"
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,6 +139,22 @@ def test_cli_replay_file(mocker, cli_runner):
     )
 
 
+def test_cli_replay_generated(mocker, cli_runner):
+    """Test cli invocation correctly generates a project with replay."""
+    template_path = 'tests/fake-repo-replay/'
+    result = cli_runner(
+        template_path,
+        '--replay-file',
+        'tests/test-replay/valid_replay.json',
+        '-o',
+        'tests/tmp/',
+        '-v',
+    )
+    assert result.exit_code == 0
+    assert open('tests/tmp/fake-project-templated/README.md').read() == 'replayed'
+    utils.rmtree('tests/tmp')
+
+
 @pytest.mark.usefixtures('remove_fake_project_dir')
 def test_cli_exit_on_noinput_and_replay(mocker, cli_runner):
     """Test cli invocation fail if both `no-input` and `replay` flags passed."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -656,13 +656,3 @@ def test_cli_with_json_decoding_error(cli_runner):
     # this point.
     path = os.path.sep.join(['tests', 'fake-repo-bad-json', 'cookiecutter.json'])
     assert path in result.output
-
-
-@pytest.mark.usefixtures('remove_fake_project_dir')
-def test_prompt_when_replyfile_not_full(mocker):
-    """Test execute prompt when replayfile not full."""
-    mock_prompt = mocker.patch('cookiecutter.main.prompt_for_config')
-    cookiecutter(
-        'tests/fake-repo-pre/', replay='tests/test-replay/cookiedozer_load.json'
-    )
-    assert mock_prompt.called

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,17 @@ def remove_fake_project_dir(request):
 
 
 @pytest.fixture
+def remove_tmp_dir(request):
+    """Remove the fake project directory created during the tests."""
+
+    def fin_remove_tmp_dir():
+        if os.path.isdir('tests/tmp'):
+            utils.rmtree('tests/tmp')
+
+    request.addfinalizer(fin_remove_tmp_dir)
+
+
+@pytest.fixture
 def make_fake_project_dir(request):
     """Create a fake project to be overwritten in the according tests."""
     os.makedirs('fake-project')
@@ -139,6 +150,7 @@ def test_cli_replay_file(mocker, cli_runner):
     )
 
 
+@pytest.mark.usefixtures('remove_tmp_dir')
 def test_cli_replay_generated(mocker, cli_runner):
     """Test cli invocation correctly generates a project with replay."""
     template_path = 'tests/fake-repo-replay/'
@@ -151,8 +163,7 @@ def test_cli_replay_generated(mocker, cli_runner):
         '-v',
     )
     assert result.exit_code == 0
-    assert open('tests/tmp/fake-project-templated/README.md').read() == 'replayed'
-    utils.rmtree('tests/tmp')
+    assert open('tests/tmp/replay-project/README.md').read().strip() == 'replayed'
 
 
 @pytest.mark.usefixtures('remove_fake_project_dir')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -78,6 +78,7 @@ def test_replay_load_template_name(
         'cookiecutter': {}
     }
     mocker.patch('cookiecutter.main.generate_files')
+    mocker.patch('cookiecutter.main.dump')
 
     cookiecutter(
         '.',
@@ -100,6 +101,7 @@ def test_custom_replay_file(monkeypatch, mocker, user_config_file):
         'cookiecutter': {}
     }
     mocker.patch('cookiecutter.main.generate_files')
+    mocker.patch('cookiecutter.main.dump')
 
     cookiecutter(
         '.',


### PR DESCRIPTION
An error where the context defined in the replay file was not taken into account was introduced with https://github.com/cookiecutter/cookiecutter/pull/1758 (which added prompts for entries missing from the replay file). It seems to impact a few people: https://github.com/cookiecutter/cookiecutter/issues/1900 and https://github.com/cookiecutter/cookiecutter/issues/1902)

This PR:
- Properly uses the context extracted from the replay file
- Fix the tests related to it, removed one useless test (too many mocks, the tests are just testing mocks at some point :p)

Closes https://github.com/cookiecutter/cookiecutter/issues/1900 
Closes https://github.com/cookiecutter/cookiecutter/issues/1902

@ericof @kurtmckee 