### PR TITLE
Fix nested templates in Git repository

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -138,7 +138,7 @@ def cookiecutter(
                 r'\((.*?)\)', context["cookiecutter"]["template"]
             ).group(1)
             return cookiecutter(
-                template=os.path.join(template, nested_template),
+                template=os.path.join(repo_dir, nested_template),
                 checkout=checkout,
                 no_input=no_input,
                 extra_context=extra_context,


### PR DESCRIPTION
Cookiecutter fails when using Git repositories with nested templates.

This ensures the second call to `cookiecutter` uses the existing clone rather than issuing an invalid Git clone call, which references a subdirectory of a repository rather than a valid repository.

An alternative approach would be to use the `directory` parameter to specify the path within the Git repository.