### PR TITLE
Add missing "parent dir" symbol in tutorial 2

### DIFF
--- a/docs/tutorials/tutorial2.rst
+++ b/docs/tutorials/tutorial2.rst
@@ -66,7 +66,7 @@ By running following command `cookiecutter.zip` will get generated which can be 
 .. code-block:: bash
 
    $ (SOURCE_DIR=$(basename $PWD) ZIP=cookiecutter.zip && # Set variables
-   pushd && # Set parent directory as working directory
+   pushd .. && # Set parent directory as working directory
    zip -r $ZIP $SOURCE_DIR --exclude $SOURCE_DIR/$ZIP --quiet && # ZIP cookiecutter
    mv $ZIP $SOURCE_DIR/$ZIP && # Move ZIP to original directory
    popd && # Restore original work directory


### PR DESCRIPTION
I think I found a typo in tutorial 2 [Create a Cookiecutter From Scratch](https://cookiecutter.readthedocs.io/en/stable/tutorials/tutorial2.html), when trying to reproduce it and getting stuck at [packing cookiecutter into ZIP](https://cookiecutter.readthedocs.io/en/stable/tutorials/tutorial2.html#step-5-pack-cookiecutter-into-zip.

I was able to pack the cookiecutter after adding a parent directory symbol, which was apparently missing in line 2 of the packing script (unless I misunderstood something, which is also probable because I am not familiar with `pushd` and `popd`).

Please feel free to merge/close without comment!