### PR TITLE
Update the black pre-commit hook URL and version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,8 @@ repos:
         language: python
         files: \.rst$
         require_serial: true
-  - repo: https://github.com/psf/black.git
-    rev: 23.7.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
The black changelog notes that this pre-commit hook's binaries are compiled with mypyc and are ~2x faster.

Nice!