### PR TITLE
Use UTF-8 for file reading/writing

### DIFF
--- a/cookiecutter/__init__.py
+++ b/cookiecutter/__init__.py
@@ -6,7 +6,7 @@ def _get_version() -> str:
     """Read VERSION.txt and return its contents."""
     path = Path(__file__).parent.resolve()
     version_file = path / "VERSION.txt"
-    return version_file.read_text().strip()
+    return version_file.read_text(encoding="utf-8").strip()
 
 
 __version__ = _get_version()

--- a/cookiecutter/replay.py
+++ b/cookiecutter/replay.py
@@ -31,7 +31,7 @@ def dump(replay_dir: "os.PathLike[str]", template_name: str, context: dict):
 
     replay_file = get_file_name(replay_dir, template_name)
 
-    with open(replay_file, 'w') as outfile:
+    with open(replay_file, 'w', encoding="utf-8") as outfile:
         json.dump(context, outfile, indent=2)
 
 
@@ -42,7 +42,7 @@ def load(replay_dir, template_name):
 
     replay_file = get_file_name(replay_dir, template_name)
 
-    with open(replay_file) as infile:
+    with open(replay_file, encoding="utf-8") as infile:
         context = json.load(infile)
 
     if 'cookiecutter' not in context:


### PR DESCRIPTION
## Changes
- Read `VERSION.txt` using UTF-8
- Read and write replay JSON using UTF-8

## Notes
I'm trying to add `-X warn_default_encoding` to `beeware/briefcase`'s test suite....but it seems to require _everything_ to explicitly specify encodings.