### PR TITLE
Update README.md to fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ cookiecutter('gh:audreyfeldroy//cookiecutter-pypackage.git')
 - Employ Jinja2 for all templating needs.
 - Define template variables easily with `cookiecutter.json`.
 
-[Learn More](https://cookiecutter.readthedocs.io/en/latest/template-author.html)
+[Learn More](https://cookiecutter.readthedocs.io/en/latest/tutorials/)
 
 ## Available Templates
 


### PR DESCRIPTION
'Learn More' link under 'For Template Creators' was pointing a 404 not found page.