### PR TITLE
1928 - allow for customised naming of hooks and sort hooks for execution

### DIFF
--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -27,17 +27,19 @@ EXIT_SUCCESS = 0
 def valid_hook(hook_file, hook_name):
     """Determine if a hook file is valid.
 
+    Hook name must be a substring of an element in _HOOKS variable to be valid.
+
     :param hook_file: The hook file to consider for validity
     :param hook_name: The hook to find
     :return: The hook file validity
     """
     filename = os.path.basename(hook_file)
     basename = os.path.splitext(filename)[0]
-    matching_hook = basename == hook_name
-    supported_hook = basename in _HOOKS
+    matching_hook = hook_name in basename
+    supported_hook = [i for i in _HOOKS if i in basename]
     backup_file = filename.endswith('~')
 
-    return matching_hook and supported_hook and not backup_file
+    return matching_hook and bool(supported_hook) and not backup_file
 
 
 def find_hook(hook_name, hooks_dir='hooks'):
@@ -59,10 +61,9 @@ def find_hook(hook_name, hooks_dir='hooks'):
         return None
 
     scripts = []
-    for hook_file in os.listdir(hooks_dir):
+    for hook_file in sorted(os.listdir(hooks_dir)):
         if valid_hook(hook_file, hook_name):
             scripts.append(os.path.abspath(os.path.join(hooks_dir, hook_file)))
-
     if len(scripts) == 0:
         return None
     return scripts

--- a/docs/advanced/hooks.rst
+++ b/docs/advanced/hooks.rst
@@ -21,6 +21,9 @@ Creating Hooks
 
 Hooks are added to the ``hooks/`` folder of your template. Both Python and Shell scripts are supported.
 
+You can create multiple hooks of the same type which run in order.
+i.e. post_gen_project_1.py would run first, post_gen_project_2.sh would run second.
+
 **Python Hooks Structure:**
 
 .. code-block::


### PR DESCRIPTION
__Issue__
https://github.com/cookiecutter/cookiecutter/issues/1928 

__Testing__
Created ```post_gen_project_2.sh``` in new cookiecutter template with
```
#!/bin/bash

touch test_post_gen_project_2
```
Verified that this file is created, and the files are run in sorted order.

__Documentation__
Updated documentation with this new functionality