### PR TITLE
Fix recursive context overwrites

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -45,7 +45,8 @@ def is_copy_only_path(path, context):
     return False
 
 
-def apply_overwrites_to_context(context, overwrite_context):
+def apply_overwrites_to_context(context, overwrite_context, *,
+                                in_dictionary_variable=False):
     """Modify the given context in place based on the overwrite_context."""
     for variable, overwrite in overwrite_context.items():
         if variable not in context:
@@ -53,33 +54,37 @@ def apply_overwrites_to_context(context, overwrite_context):
             continue
 
         context_value = context[variable]
-
-        if isinstance(context_value, list) and isinstance(overwrite, list):
-            # We are dealing with a multichoice variable
-            # Let's confirm all choices are valid for the given context
-            if set(overwrite).issubset(set(context_value)):
+        if isinstance(context_value, list):
+            if in_dictionary_variable:
                 context[variable] = overwrite
+                continue
+            if isinstance(overwrite, list):
+                # We are dealing with a multichoice variable
+                # Let's confirm all choices are valid for the given context
+                if set(overwrite).issubset(set(context_value)):
+                    context[variable] = overwrite
+                else:
+                    raise ValueError(
+                        f"{overwrite} provided for multi-choice variable "
+                        f"{variable}, but valid choices are {context_value}"
+                    )
             else:
-                raise ValueError(
-                    f"{overwrite} provided for multi-choice variable {variable}, "
-                    f"but valid choices are {context_value}"
-                )
-        elif isinstance(context_value, list):
-            # We are dealing with a choice variable
-            if overwrite in context_value:
-                # This overwrite is actually valid for the given context
-                # Let's set it as default (by definition first item in list)
-                # see ``cookiecutter.prompt.prompt_choice_for_config``
-                context_value.remove(overwrite)
-                context_value.insert(0, overwrite)
-            else:
-                raise ValueError(
-                    f"{overwrite} provided for choice variable {variable}, "
-                    f"but the choices are {context_value}."
-                )
+                # We are dealing with a choice variable
+                if overwrite in context_value:
+                    # This overwrite is actually valid for the given context
+                    # Let's set it as default (by definition first item in list)
+                    # see ``cookiecutter.prompt.prompt_choice_for_config``
+                    context_value.remove(overwrite)
+                    context_value.insert(0, overwrite)
+                else:
+                    raise ValueError(
+                        f"{overwrite} provided for choice variable "
+                        f"{variable}, but the choices are {context_value}."
+                    )
         elif isinstance(context_value, dict) and isinstance(overwrite, dict):
             # Partially overwrite some keys in original dict
-            apply_overwrites_to_context(context_value, overwrite)
+            apply_overwrites_to_context(context_value, overwrite,
+                                        in_dictionary_variable=True)
             context[variable] = context_value
         else:
             # Simply overwrite the value for this variable

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -233,6 +233,7 @@ def test_apply_overwrites_error_additional_values(template_context):
         )
 
 def test_apply_overwrites_in_dictionaries(template_context):
+    """Verify variable overwrite for lists nested in dictionary variables."""
     generate.apply_overwrites_to_context(
         context=template_context,
         overwrite_context={'deployments': {

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -135,6 +135,7 @@ def template_context():
             ('project_name', 'Kivy Project'),
             ('repo_name', '{{cookiecutter.project_name|lower}}'),
             ('orientation', ['all', 'landscape', 'portrait']),
+            ('deployment_regions', ['eu', 'us', 'ap']),
             (
                 'deployments',
                 {
@@ -207,10 +208,9 @@ def test_apply_overwrites_sets_multichoice_values(template_context):
     """Verify variable overwrite for list given multiple valid values."""
     generate.apply_overwrites_to_context(
         context=template_context,
-        overwrite_context={'deployments': {'preprod': ['eu'], 'prod': ['eu']}},
+        overwrite_context={'deployment_regions': ['eu']},
     )
-    assert template_context['deployments']['preprod'] == ['eu']
-    assert template_context['deployments']['prod'] == ['eu']
+    assert template_context['deployment_regions'] == ['eu']
 
 
 def test_apply_overwrites_invalid_multichoice_values(template_context):
@@ -218,7 +218,7 @@ def test_apply_overwrites_invalid_multichoice_values(template_context):
     with pytest.raises(ValueError):
         generate.apply_overwrites_to_context(
             context=template_context,
-            overwrite_context={'deployments': {'preprod': ['na'], 'prod': ['na']}},
+            overwrite_context={'deployment_regions': ['na']},
         )
 
 
@@ -228,9 +228,20 @@ def test_apply_overwrites_error_additional_values(template_context):
         generate.apply_overwrites_to_context(
             context=template_context,
             overwrite_context={
-                'deployments': {'preprod': ['eu', 'na'], 'prod': ['eu', 'na']}
+                'deployment_regions': ['eu', 'na']
             },
         )
+
+def test_apply_overwrites_in_dictionaries(template_context):
+    generate.apply_overwrites_to_context(
+        context=template_context,
+        overwrite_context={'deployments': {
+            'preprod': ['eu'],
+            'prod': ['ap']
+        }},
+    )
+    assert template_context['deployments']['preprod'] == ['eu']
+    assert template_context['deployments']['prod'] == ['ap']
 
 
 def test_apply_overwrites_sets_default_for_choice_variable(template_context):


### PR DESCRIPTION
In 2.2.0, `generate.apply_overwrites_to_context` was amended with a recursive call to allow merging fields inside dictionary variables (#1692 )

In 2.3.0, it was further amended to allow merging of multichoice variables (#1903). 

However, these two changes interact to mean that cookiecutter began treating any list field in a dictionary variable as a choice (see #1954, #1960 for bugs running into this issue). If all the entries in a list field are hashable, then this may not cause problems, but if e.g. you have complex objects with lists of dictionary variables then the call to set introduce in #1903 would also cause a crash.

This PR fixes the merge behaviour by adding a simple recursive flag when applying the overwrites to dictionary variables. Cookiecutter itself will only treat "top-level" lists as choice variables, so this is consistent with the interaction model and the docs which state "The dictionary values can, themselves, be other dictionaries and lists - the data structure can be as deep as you need."