### PR TITLE
Add argument run to pipx command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ The recommended way to use Cookiecutter as a command line utility is to run it w
 # Then it'll create your Python package in the current working directory,
 # based on those values.
 # For the sake of brevity, repos on GitHub can just use the 'gh' prefix
-$ pipx cookiecutter gh:audreyfeldroy/cookiecutter-pypackage
+$ pipx run cookiecutter gh:audreyfeldroy/cookiecutter-pypackage
 ```
 
 **Use a local template**
 
 ```bash
-$ pipx cookiecutter cookiecutter-pypackage/
+$ pipx run cookiecutter cookiecutter-pypackage/
 ```
 
 **Use it from Python**


### PR DESCRIPTION
The "run" seems to be neccessary for the command to work as intended.

Here is what I got when I tried without it:

```bash
❯ pipx cookiecutter gh:audreyfeldroy/cookiecutter-pypackage
usage: pipx [-h] [--version] {install,uninject,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall,reinstall-all,list,run,runpip,ensurepath,environment,completions} ...
pipx: error: argument command: invalid choice: 'cookiecutter' (choose from 'install', 'uninject', 'inject', 'upgrade', 'upgrade-all', 'uninstall', 'uninstall-all', 'reinstall', 'reinstall-all', 'list', 'run', 'runpip', 'ensurepath', 'environment', 'completions')
```