### PR TITLE
Fix FileExistsError when using a relative template path

### DIFF
--- a/cookiecutter/utils.py
+++ b/cookiecutter/utils.py
@@ -121,7 +121,7 @@ def simple_filter(filter_function):
 
 def create_tmp_repo_dir(repo_dir: "os.PathLike[str]") -> Path:
     """Create a temporary dir with a copy of the contents of repo_dir."""
-    repo_dir = Path(repo_dir) if isinstance(repo_dir, str) else repo_dir
+    repo_dir = Path(repo_dir).resolve()
     base_dir = tempfile.mkdtemp(prefix='cookiecutter')
     new_dir = f"{base_dir}/{repo_dir.name}"
     logger.debug(f'Copying repo_dir from {repo_dir} to {new_dir}')


### PR DESCRIPTION
When using a local cookiecutter template that contains a pre_prompt script, cookiecutter will exit with a FileExistsError. 

Reason for the FileExistsError is the input to `create_tmp_repo_dir()` which is just a simple dot. By converting the input into a Path object and using the `Path.resolve()`  method we get the absolute path instead of the relative(`.`) and `shutils.copytree()` runs without an error.

OS: Windows 10
Launch Command: ` cookiecutter . --overwrite-if-exists`
Fixes #1972 