### PR TITLE
Allow custom jinja block strings for top level template dir

### DIFF
--- a/cookiecutter/find.py
+++ b/cookiecutter/find.py
@@ -8,16 +8,26 @@ from cookiecutter.exceptions import NonTemplatedInputDirException
 logger = logging.getLogger(__name__)
 
 
-def find_template(repo_dir: "os.PathLike[str]") -> Path:
+def find_template(
+    repo_dir: "os.PathLike[str]",
+    block_start_string: str = "{{",
+    block_end_string: str = "}}",
+) -> Path:
     """Determine which child directory of ``repo_dir`` is the project template.
 
     :param repo_dir: Local directory of newly cloned repo.
+    :param block_start_string: Jinja2 block start string.
+    :param block_end_string: Jinja2 block end string.
     :return: Relative path to project template.
     """
     logger.debug('Searching %s for the project template.', repo_dir)
 
     for str_path in os.listdir(repo_dir):
-        if 'cookiecutter' in str_path and '{{' in str_path and '}}' in str_path:
+        if (
+            'cookiecutter' in str_path
+            and block_start_string in str_path
+            and block_end_string in str_path
+        ):
             project_template = Path(repo_dir, str_path)
             break
     else:

--- a/cookiecutter/find.py
+++ b/cookiecutter/find.py
@@ -10,14 +10,14 @@ logger = logging.getLogger(__name__)
 
 def find_template(
     repo_dir: "os.PathLike[str]",
-    block_start_string: str = "{{",
-    block_end_string: str = "}}",
+    variable_start_string: str = "{{",
+    variable_end_string: str = "}}",
 ) -> Path:
     """Determine which child directory of ``repo_dir`` is the project template.
 
     :param repo_dir: Local directory of newly cloned repo.
-    :param block_start_string: Jinja2 block start string.
-    :param block_end_string: Jinja2 block end string.
+    :param variable_start_string: Jinja2 variable start string.
+    :param variable_end_string: Jinja2 variable end string.
     :return: Relative path to project template.
     """
     logger.debug('Searching %s for the project template.', repo_dir)
@@ -25,8 +25,8 @@ def find_template(
     for str_path in os.listdir(repo_dir):
         if (
             'cookiecutter' in str_path
-            and block_start_string in str_path
-            and block_end_string in str_path
+            and variable_start_string in str_path
+            and variable_end_string in str_path
         ):
             project_template = Path(repo_dir, str_path)
             break

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -309,11 +309,15 @@ def generate_files(
     :param keep_project_on_failure: If `True` keep generated project directory even when
         generation fails
     """
-    template_dir = find_template(repo_dir)
-    logger.debug('Generating project from %s...', template_dir)
     context = context or OrderedDict([])
-
     envvars = context.get('cookiecutter', {}).get('_jinja2_env_vars', {})
+    template_dir = find_template(
+        repo_dir,
+        block_start_string=envvars.get('block_start_string'),
+        block_end_string=envvars.get('block_end_string'),
+    )
+
+    logger.debug('Generating project from %s...', template_dir)
 
     unrendered_dir = os.path.split(template_dir)[1]
     ensure_dir_is_templated(unrendered_dir)

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -313,8 +313,8 @@ def generate_files(
     envvars = context.get('cookiecutter', {}).get('_jinja2_env_vars', {})
     template_dir = find_template(
         repo_dir,
-        block_start_string=envvars.get('block_start_string'),
-        block_end_string=envvars.get('block_end_string'),
+        block_start_string=envvars.get('block_start_string', '{{'),
+        block_end_string=envvars.get('block_end_string', '}}'),
     )
 
     logger.debug('Generating project from %s...', template_dir)

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -256,9 +256,13 @@ def render_and_create_dir(
     return dir_to_create, not output_dir_exists
 
 
-def ensure_dir_is_templated(dirname):
+def ensure_dir_is_templated(
+    dirname: str,
+    variable_start_string: str = "{{",
+    variable_end_string: str = "}}",
+):
     """Ensure that dirname is a templated directory name."""
-    if '{{' in dirname and '}}' in dirname:
+    if variable_start_string in dirname and variable_end_string in dirname:
         return True
     else:
         raise NonTemplatedInputDirException
@@ -313,14 +317,18 @@ def generate_files(
     envvars = context.get('cookiecutter', {}).get('_jinja2_env_vars', {})
     template_dir = find_template(
         repo_dir,
-        block_start_string=envvars.get('block_start_string', '{{'),
-        block_end_string=envvars.get('block_end_string', '}}'),
+        variable_start_string=envvars.get('variable_start_string', '{{'),
+        variable_end_string=envvars.get('variable_end_string', '}}'),
     )
 
     logger.debug('Generating project from %s...', template_dir)
 
     unrendered_dir = os.path.split(template_dir)[1]
-    ensure_dir_is_templated(unrendered_dir)
+    ensure_dir_is_templated(
+        unrendered_dir,
+        variable_start_string=envvars.get('variable_start_string', '{{'),
+        variable_end_string=envvars.get('variable_end_string', '}}'),
+    )
     env = StrictEnvironment(context=context, keep_trailing_newline=True, **envvars)
     try:
         project_dir, output_directory_created = render_and_create_dir(


### PR DESCRIPTION
Cookiecutter allows customising the start and end strings for variables in both file and directory templates, but currently hardcodes using the default `{{` and `}}` when searching for the top-level template directory.

This PR fixes this, using the strings from the context when available to search for a template before passing it on.