### PR TITLE
Convert CLI provided strings to booleans for boolean config variables

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from binaryornot.check import is_binary
 from jinja2 import Environment, FileSystemLoader
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError
+from rich.prompt import InvalidResponse
 
 from cookiecutter.exceptions import (
     ContextDecodingException,
@@ -20,6 +21,7 @@ from cookiecutter.exceptions import (
 )
 from cookiecutter.find import find_template
 from cookiecutter.hooks import run_hook_from_repo_dir
+from cookiecutter.prompt import YesNoPrompt
 from cookiecutter.utils import (
     create_env_with_context,
     make_sure_path_exists,
@@ -96,6 +98,16 @@ def apply_overwrites_to_context(
                 context_value, overwrite, in_dictionary_variable=True
             )
             context[variable] = context_value
+        elif isinstance(context_value, bool) and isinstance(overwrite, str):
+            # We are dealing with a boolean variable
+            # Convert overwrite to its boolean counterpart
+            try:
+                context[variable] = YesNoPrompt().process_response(overwrite)
+            except InvalidResponse:
+                raise ValueError(
+                    f"{overwrite} provided for variable "
+                    f"{variable} could not be converted to a boolean."
+                )
         else:
             # Simply overwrite the value for this variable
             context[variable] = overwrite

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -106,11 +106,11 @@ def apply_overwrites_to_context(
             # Convert overwrite to its boolean counterpart
             try:
                 context[variable] = YesNoPrompt().process_response(overwrite)
-            except InvalidResponse:
+            except InvalidResponse as err:
                 raise ValueError(
                     f"{overwrite} provided for variable "
                     f"{variable} could not be converted to a boolean."
-                )
+                ) from err
         else:
             # Simply overwrite the value for this variable
             context[variable] = overwrite

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -8,6 +8,7 @@ import pytest
 
 from cookiecutter import generate
 from cookiecutter.exceptions import ContextDecodingException
+from cookiecutter.prompt import YesNoPrompt
 
 
 def context_data():
@@ -362,3 +363,24 @@ def test_apply_overwrites_in_nested_dict_additional_values():
     )
 
     assert generated_context == expected_context
+
+
+@pytest.mark.parametrize(
+    "overwrite_value, expected",
+    [(bool_string, {'key': True}) for bool_string in YesNoPrompt.yes_choices]
+    + [(bool_string, {'key': False}) for bool_string in YesNoPrompt.no_choices],
+)
+def test_apply_overwrites_overwrite_value_as_boolean_string(overwrite_value, expected):
+    """Verify boolean conversion for valid overwrite values."""
+    context = {'key': not expected['key']}
+    overwrite_context = {'key': overwrite_value}
+    generate.apply_overwrites_to_context(context, overwrite_context)
+    assert context == expected
+
+
+def test_apply_overwrites_error_overwrite_value_as_boolean_string():
+    """Verify boolean conversion for invalid overwrite values."""
+    context = {'key': True}
+    overwrite_context = {'key': 'invalid'}
+    with pytest.raises(ValueError):
+        generate.apply_overwrites_to_context(context, overwrite_context)


### PR DESCRIPTION
Fixes #1973 - a bug where the override value provided via command line wasn't being properly converted to its boolean counterpart.

Since override values from the command line are interpreted as strings, we need to convert the override value to a boolean if it's overriding a boolean variable.

I'm a total Python newbie so please let me know if there's anything I can change to make this better.