### PR TITLE
Use pytest 6.0+ compatible [tool.pytest.ini_options] instead of [tool.pytest] on pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-[tool.pytest]
+[tool.pytest.ini_options]
 testpaths = "tests"
 addopts = "-vvv --cov-report term-missing --cov=cookiecutter"
 


### PR DESCRIPTION
We have recently migrated from `setup.cfg` to `pyproject.toml` on https://github.com/cookiecutter/cookiecutter/pull/2040. However, we have encountered an issue with pytest 6.0+ as it uses the `[tool.pytest.ini_options]` section instead of `[tool.pytest]` section on `setup.cfg`. As a result, the expected pytest settings were not being used and the coverage report was not being generated. 

This pull-request fix this error.