### PR TITLE
Add optional indent parameter to jsonify extension

### DIFF
--- a/cookiecutter/extensions.py
+++ b/cookiecutter/extensions.py
@@ -27,8 +27,8 @@ class JsonifyExtension(Extension):
         """Initialize the extension with the given environment."""
         super().__init__(environment)
 
-        def jsonify(obj: Any) -> str:
-            return json.dumps(obj, sort_keys=True, indent=4)
+        def jsonify(obj: Any, indent: int = 4) -> str:
+            return json.dumps(obj, sort_keys=True, indent=indent)
 
         environment.filters['jsonify'] = jsonify
 

--- a/docs/advanced/template_extensions.rst
+++ b/docs/advanced/template_extensions.rst
@@ -55,6 +55,21 @@ Would output:
 
     {"a": true}
 
+It supports an optional ``indent`` param, the default value is ``4``:
+
+.. code-block:: jinja
+
+    {% {'a': True, 'foo': 'bar'} | jsonify(2) %}
+
+Would output:
+
+.. code-block:: json
+
+    {
+      "a": true,
+      "foo": "bar"
+    }
+
 Random string extension
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/files/{{cookiecutter.jsonify_file}}.txt
+++ b/tests/files/{{cookiecutter.jsonify_file}}.txt
@@ -1,1 +1,1 @@
-{{ cookiecutter | jsonify }}
+{{ cookiecutter | jsonify(4) }}


### PR DESCRIPTION
I kept the original `4` value as the default value for backwards compatibility