### PR TITLE
Upgrade to safety v3

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,5 @@
+security:
+  ignore-vulnerabilities:
+    70612:
+      # Jinja2 `.from_string()` may be "dangerous".
+      reason: "Rendering potentially-unsafe user-supplied templates is core functionality."

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,9 @@ commands = pytest --color=yes --cov-report=html --cov-report=xml --cov-branch --
 
 [testenv:safety]
 description = Check with safety
-deps = safety==2.3.5
-commands = safety --disable-telemetry check --full-report
+recreate = true
+deps = safety>=3,<4
+commands = safety --disable-optional-telemetry check --full-report
 
 
 [testenv:docs]


### PR DESCRIPTION
This PR upgrades safety to v3, and introduces a safety config file to suppress [a vulnerability warning](https://data.safetycli.com/v/70612/97c/).

Closes #2003