### PR TITLE
Update repository.py / Fix placement of verbose mode flag in regular …

### DIFF
--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -19,6 +19,7 @@ REPO_REGEX = re.compile(r"""(?x)             # Verbose mode.
     (\w+@[\w\.]+)                            # something like user@...
 )""")
 
+
 def is_repo_url(value: str) -> bool:
     """Return True if value is a repository URL."""
     return bool(REPO_REGEX.match(value))

--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -13,17 +13,11 @@ from cookiecutter.zipfile import unzip
 if TYPE_CHECKING:
     from pathlib import Path
 
-REPO_REGEX = re.compile(
-    r"""
-# something like git:// ssh:// file:// etc.
-((((git|hg)\+)?(git|ssh|file|https?):(//)?)
- |                                      # or
- (\w+@[\w\.]+)                          # something like user@...
-)
-""",
-    re.VERBOSE,
-)
-
+REPO_REGEX = re.compile(r"""(?x)             # Verbose mode.
+    ((((git|hg)\+)?(git|ssh|https?):(//)?)   # Something like git:// ssh:// etc.
+    |                                        # or
+    (\w+@[\w\.]+)                            # something like user@...
+)""")
 
 def is_repo_url(value: str) -> bool:
     """Return True if value is a repository URL."""

--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -13,11 +13,14 @@ from cookiecutter.zipfile import unzip
 if TYPE_CHECKING:
     from pathlib import Path
 
-REPO_REGEX = re.compile(r"""(?x)             # Verbose mode.
-    ((((git|hg)\+)?(git|ssh|https?):(//)?)   # Something like git:// ssh:// etc.
-    |                                        # or
-    (\w+@[\w\.]+)                            # something like user@...
-)""")
+REPO_REGEX = re.compile(r"""(?x)              # Verbose mode
+    (
+        ((git|hg)\+)?(git|ssh|https?|file)    # Protocols
+        ://
+    )
+    |                                         # or
+    (\w+@[\w\.]+)                             # user@hostname
+""")
 
 
 def is_repo_url(value: str) -> bool:


### PR DESCRIPTION
…expression

Move the verbose mode flag (?x) outside of the regular expression string to comply with correct syntax. Placing the flag inside the string caused a compilation error due to it not being recognized as a valid regular expression modifier.