### PR TITLE
Update repository.py / Fix handling of file:// URLs in is_repo_url fn

### DIFF
--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -13,16 +13,15 @@ from cookiecutter.zipfile import unzip
 if TYPE_CHECKING:
     from pathlib import Path
 
-REPO_REGEX = re.compile(
-    r"""
-# something like git:// ssh:// file:// etc.
-((((git|hg)\+)?(git|ssh|file|https?):(//)?)
- |                                      # or
- (\w+@[\w\.]+)                          # something like user@...
-)
-""",
-    re.VERBOSE,
-)
+REPO_REGEX = re.compile(r"""
+    (?x)                                        # Verbose mode
+    (
+        ((git|hg)\+)?(git|ssh|https?|file)      # Protocols
+        ://
+    )
+    |                                           # or
+    (\w+@[\w\.]+)                               # user@hostname
+""")
 
 
 def is_repo_url(value: str) -> bool:


### PR DESCRIPTION
This change ensures that file-based repository URLs are correctly identified as valid.
Sry... I don't see CICD-Test for Ubuntu