### PR TITLE
Fix #2094: Added support for numbers in random_ascii_string function with successful tests

### DIFF
--- a/cookiecutter/extensions.py
+++ b/cookiecutter/extensions.py
@@ -40,11 +40,26 @@ class RandomStringExtension(Extension):
         """Jinja2 Extension Constructor."""
         super().__init__(environment)
 
-        def random_ascii_string(length: int, punctuation: bool = False) -> str:
+        def random_ascii_string(
+            length: int, number: bool = False, punctuation: bool = False
+        ) -> str:
+            """Generate a random ASCII string.
+
+            Args:
+                length (int): Length of the generated string.
+                number (bool): Whether to include digits.
+                punctuation (bool): Whether to include punctuation.
+
+            Returns:
+                str: Random ASCII string.
+            """
+            corpus = string.ascii_letters  # Start with letters
+
+            if number:
+                corpus += string.digits  # Add digits if requested
             if punctuation:
-                corpus = f'{string.ascii_letters}{string.punctuation}'
-            else:
-                corpus = string.ascii_letters
+                corpus += string.punctuation  # Add punctuation if requested
+
             return "".join(choice(corpus) for _ in range(length))
 
         environment.globals.update(random_ascii_string=random_ascii_string)

--- a/docs/advanced/template_extensions.rst
+++ b/docs/advanced/template_extensions.rst
@@ -102,6 +102,18 @@ Outputs:
 
     fQupUkY}W!)!
 
+The second argument controls if punctuation and special characters ``!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~`` should be present in the result:
+
+.. code-block:: jinja
+
+    {{ random_ascii_string(12, number=True, punctuation=True) }}
+
+Outputs:
+
+.. code-block:: text
+
+    Q76Om4s(x!=}
+
 Slugify extension
 ~~~~~~~~~~~~~~~~~
 

--- a/tests/files/{{cookiecutter.random_string_file}}.txt
+++ b/tests/files/{{cookiecutter.random_string_file}}.txt
@@ -1,1 +1,1 @@
-{{ random_ascii_string(length, punctuation) }}
+{{ random_ascii_string(length, number, punctuation) }}

--- a/tests/test_generate_file.py
+++ b/tests/test_generate_file.py
@@ -68,12 +68,18 @@ def test_generate_file_jsonify_filter(env) -> None:
 
 
 @pytest.mark.parametrize("length", (10, 40))
+@pytest.mark.parametrize("number", (True, False))
 @pytest.mark.parametrize("punctuation", (True, False))
-def test_generate_file_random_ascii_string(env, length, punctuation) -> None:
+def test_generate_file_random_ascii_string(env, length, number, punctuation) -> None:
     """Verify correct work of random_ascii_string extension on file generation."""
     infile = 'tests/files/{{cookiecutter.random_string_file}}.txt'
     data = {'random_string_file': 'cheese'}
-    context = {"cookiecutter": data, "length": length, "punctuation": punctuation}
+    context = {
+        "cookiecutter": data,
+        "length": length,
+        "number": number,
+        "punctuation": punctuation,
+    }
     generate.generate_file(project_dir=".", infile=infile, context=context, env=env)
     assert os.path.isfile('tests/files/cheese.txt')
     generated_text = Path('tests/files/cheese.txt').read_text()


### PR DESCRIPTION
Fixes #2094
### What does this PR do?
This Pull Request adds support for numbers in the random_ascii_string function. A new number parameter has been added that, when set to True, allows the generated string to include digits alongside letters and optional punctuation.
