### PR TITLE
Makes order of directory resolving deterministic across different OS

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -392,7 +392,7 @@ def generate_files(
             copy_dirs = []
             render_dirs = []
 
-            for d in dirs:
+            for d in sorted(dirs):
                 d_ = os.path.normpath(os.path.join(root, d))
                 # We check the full path, because that's how it can be
                 # specified in the ``_copy_without_render`` setting, but
@@ -432,7 +432,7 @@ def generate_files(
                     msg = f"Unable to create directory '{_dir}'"
                     raise UndefinedVariableInTemplate(msg, err, context) from err
 
-            for f in files:
+            for f in sorted(files):
                 infile = os.path.normpath(os.path.join(root, f))
                 if is_copy_only_path(infile, context):
                     outfile_tmpl = env.from_string(infile)


### PR DESCRIPTION
The order of items in the `dirnames` and `filenames` lists of `os.walk` appears to differ depending on which operating system is being used.

This PR aims at accounting for this behaviour so that cookiecutter's conflicts handling logic stays consistent across different operating systems.