### PR TITLE
Fixing Issue #2114 Attribute _path Defined Outside __init__

### DIFF
--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -203,12 +203,12 @@ def cookiecutter(
 class _patch_import_path_for_repo:  # noqa: N801
     def __init__(self, repo_dir: Path | str) -> None:
         self._repo_dir = f"{repo_dir}" if isinstance(repo_dir, Path) else repo_dir
-        self._path = None  # Intialize _path to None
+        self._path: list[str] | None = None  # Intialize _path to None
 
     def __enter__(self) -> None:
         self._path = copy(sys.path)
         sys.path.append(self._repo_dir)
 
-    def __exit__(self, _type, _value, _traceback):  # type: ignore[no-untyped-def]
+    def __exit__(self, _type, _value, _traceback) -> None:  # type: ignore[no-untyped-def]
         if self._path is not None:  # Check if _path is initialized
             sys.path = self._path

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -203,10 +203,12 @@ def cookiecutter(
 class _patch_import_path_for_repo:  # noqa: N801
     def __init__(self, repo_dir: Path | str) -> None:
         self._repo_dir = f"{repo_dir}" if isinstance(repo_dir, Path) else repo_dir
+        self._path = None # Intialize _path to None
 
     def __enter__(self) -> None:
         self._path = copy(sys.path)
         sys.path.append(self._repo_dir)
 
     def __exit__(self, _type, _value, _traceback):  # type: ignore[no-untyped-def]
-        sys.path = self._path
+        if self._path is not None: # Check if _path is initialized
+            sys.path = self._path

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -119,18 +119,13 @@ def test_custom_replay_file(monkeypatch, mocker, user_config_file) -> None:
 
 
 def test_patch_import_path_for_repo():
-    """Test the _patch_import_path_for_repo context manager."""
-    original_sys_path = sys.path[:]  
+    original_sys_path = sys.path[:]
     repo_dir = '/fake/repo/path'
 
-    with _patch_import_path_for_repo(repo_dir):
-        assert sys.path[-1] == repo_dir
-
-    assert sys.path == original_sys_path
-
     patch = _patch_import_path_for_repo(repo_dir)
-    patch._path = None
+
+    patch.__enter__()
+    assert sys.path[-1] == repo_dir
+
     patch.__exit__(None, None, None)
     assert sys.path == original_sys_path
-
-

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -119,6 +119,7 @@ def test_custom_replay_file(monkeypatch, mocker, user_config_file) -> None:
 
 
 def test_patch_import_path_for_repo():
+    """Test the _patch_import_path_for_repo context manager."""
     original_sys_path = sys.path[:]
     repo_dir = '/fake/repo/path'
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -122,12 +122,17 @@ def test_custom_replay_file(monkeypatch, mocker, user_config_file) -> None:
 
 def test_patch_import_path_for_repo():
     """Test the _patch_import_path_for_repo context manager."""
-    original_sys_path = sys.path[:]
+    original_sys_path = sys.path[:]  
     repo_dir = '/fake/repo/path'
 
     with _patch_import_path_for_repo(repo_dir):
         assert sys.path[-1] == repo_dir
 
+    assert sys.path == original_sys_path
+
+    patch = _patch_import_path_for_repo(repo_dir)
+    patch._path = None
+    patch.__exit__(None, None, None)
     assert sys.path == original_sys_path
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,11 @@
 """Collection of tests around cookiecutter's replay feature."""
 
+import sys 
+
 from cookiecutter.main import cookiecutter
+
+from cookiecutter.main import _patch_import_path_for_repo
+
 
 
 def test_original_cookiecutter_options_preserved_in__cookiecutter(
@@ -114,3 +119,15 @@ def test_custom_replay_file(monkeypatch, mocker, user_config_file) -> None:
         '.',
         'custom-replay-file',
     )
+
+def test_patch_import_path_for_repo():
+    """Test the _patch_import_path_for_repo context manager."""
+    original_sys_path = sys.path[:]
+    repo_dir = '/fake/repo/path'
+
+    with _patch_import_path_for_repo(repo_dir):
+        assert sys.path[-1] == repo_dir
+
+    assert sys.path == original_sys_path
+
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -123,9 +123,11 @@ def test_patch_import_path_for_repo():
     repo_dir = '/fake/repo/path'
 
     patch = _patch_import_path_for_repo(repo_dir)
-
     patch.__enter__()
     assert sys.path[-1] == repo_dir
+    patch.__exit__(None, None, None)
+    assert sys.path == original_sys_path
 
+    patch = _patch_import_path_for_repo(repo_dir)
     patch.__exit__(None, None, None)
     assert sys.path == original_sys_path


### PR DESCRIPTION
Pull Request addresses the issue #[2114](https://github.com/cookiecutter/cookiecutter/issues/2114#issue-2670485270).

Ensured _path properly initialized in _patch_import_path_for_repo Class.
Previous behavior: Allowed _path to be initialized only when _enter_ function was called.
Could lead to potential issues in the case _exit_ was invoked without prior _enter_ which could cause an AttributeError. (As mentioned in the #[2114](https://github.com/cookiecutter/cookiecutter/issues/2114#issue-2670485270) issue)
PR updates to initialize _path in __init__ function and include an if statement for it in the __exit__ function.

New unit test test_patch_import_path_for_repo was added in the test_main.py file and made sure all test passed at 100%.