### PR TITLE
Add [build-system] section to pyproject.toml (#2117)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.pytest.ini_options]
 testpaths = "tests"
 addopts = "-vvv --cov-report term-missing --cov=cookiecutter"


### PR DESCRIPTION
Adds [build-system] section to pyproject.toml for modern packaging standards. This ensures that the project is built using setuptools and wheel, which are the required build dependencies for proper distribution.

By standardizing the build process, this change enhances compatibility with pip and other packaging tools, aligning the project with current best practices in Python packaging.

Closes #2117
