### PR TITLE
Preserve boolean types from cookiecutter.json in render_variables()

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -200,7 +200,7 @@ def render_variable(
     env: Environment,
     raw: _Raw,
     cookiecutter_dict: dict[str, Any],
-) -> str:
+) -> Any:
     """Render the next variable to be displayed in the user prompt.
 
     Inside the prompting taken from the cookiecutter.json file, this renders
@@ -231,10 +231,17 @@ def render_variable(
     if not isinstance(raw, str):
         raw = str(raw)
 
+    if not isinstance(raw, (str, bool)):
+        raw = str(raw)
+
     template = env.from_string(raw)
 
-    return template.render(cookiecutter=cookiecutter_dict)
+    rendered_value = template.render(cookiecutter=cookiecutter_dict)
 
+    if rendered_value.lower() in ["true", "false"]:
+        return rendered_value.lower() == "true"
+
+    return rendered_value
 
 def _prompts_from_options(options: dict) -> dict:
     """Process template options and return friendly prompt information."""

--- a/tests/test_generate_file.py
+++ b/tests/test_generate_file.py
@@ -11,7 +11,7 @@ from jinja2.exceptions import TemplateSyntaxError
 
 from cookiecutter import generate
 from cookiecutter.environment import StrictEnvironment
-
+from cookiecutter.prompt import render_variable
 
 @pytest.fixture(scope='function', autouse=True)
 def tear_down():
@@ -54,6 +54,13 @@ def test_generate_file(env) -> None:
     generated_text = Path('tests/files/cheese.txt').read_text()
     assert generated_text == 'Testing cheese'
 
+def test_boolean_variable_preserved(env):
+    """Ensure booleans in cookiecutter.json remain booleans when rendered in Jinja2."""
+    cookiecutter_dict = {"my_var": True}
+
+    result = render_variable(env, "{{ cookiecutter.my_var }}", cookiecutter_dict)
+
+    assert result is True
 
 def test_generate_file_jsonify_filter(env) -> None:
     """Verify jsonify filter works during files generation process."""


### PR DESCRIPTION
Pull request fixes issue where boolean values in created 'cookiecutter.json' are converted into strings. Now the 'render_variable()' function preserves boolean values instead of turning everything from the .json into strings

### Issue Addressed
Fixes #2126 

-Resolves issue where: 
boolean 'true' or 'false' in 'cookiecutter.json' would be rendered as string instead of boolean. 

Now *booleans remain booleans** after rendering in render_variable(), string value are unaffected

### Testing
Added test in tests/test_generate_file.py titled 'def test_boolean_variable_preserved'

All other tests pass except test 'test_should_invoke_main' which failed BEFORE and AFTER my changes. Appears to be issue with missing dependency ('binaryornot') didn't look into it much