### PR TITLE
Add pre-prompt rewrite example to usage.rst (Fixes #2011)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -53,6 +53,19 @@ repository::
 You will be prompted to enter a bunch of project config values. (These are
 defined in the project's `cookiecutter.json`.)
 
+
+Example of a pre-prompt rewrite in `cookiecutter.json`:
+
+.. code-block:: json
+
+    {
+      "project_name": "My Cool Project",
+      "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}"
+    }
+
+In this example, `project_slug` is automatically generated from `project_name`.
+
+
 Then, Cookiecutter will generate a project from the template, using the values
 that you entered. It will be placed in your current directory.
 


### PR DESCRIPTION
This PR improves the documentation by adding an example to `usage.rst` that demonstrates how to use a pre-prompt rewrite in `cookiecutter.json`.

Specifically, it shows how to auto-generate one variable (e.g., `project_slug`) based on another (e.g., `project_name`) using Jinja2 templating.

This helps users understand how to avoid redundant inputs and streamline their project setup.

Fixes #2011
