### PR TITLE
Update Python support to 3.9–3.13

### DIFF
--- a/.github/workflows/pip-publish.yml
+++ b/.github/workflows/pip-publish.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
 
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/test.02.yml
+++ b/.github/workflows/test.02.yml
@@ -63,7 +63,7 @@ jobs:
       - *setup_uv
       - *install_just
       - name: Lint Checking • macOS (via just, uv, ruff)
-        run: just lint
+        run: just lint-check
 #   type-check:
 #     name: Type Checking • macOS (via just, uv, ty)
 #     runs-on: macos-latest
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-    name: Tests on Python versions 3.10–>3.13 • "${{ matrix.os }}" (via just, uv, pytest, pytest-pretty)
+    name: Tests on Python versions 3.9–>3.13 • "${{ matrix.os }}" (via just, uv, pytest, pytest-pretty)
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:

--- a/cookiecutter/extensions.py
+++ b/cookiecutter/extensions.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 import string
 import uuid
+from collections.abc import Iterable
 from secrets import choice
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 import arrow
 from jinja2 import Environment, nodes

--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -7,9 +7,10 @@ import os
 import re
 import sys
 from collections import OrderedDict
+from collections.abc import Iterator
 from itertools import starmap
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from jinja2.exceptions import UndefinedError
 from rich.prompt import Confirm, InvalidResponse, Prompt, PromptBase
@@ -193,7 +194,7 @@ def read_user_dict(var_name: str, default_value, prompts=None, prefix: str = "")
     )
 
 
-_Raw: TypeAlias = Union[bool, Dict["_Raw", "_Raw"], List["_Raw"], str, None]
+_Raw: TypeAlias = Union[bool, dict["_Raw", "_Raw"], list["_Raw"], str, None]
 
 
 def render_variable(

--- a/cookiecutter/utils.py
+++ b/cookiecutter/utils.py
@@ -8,8 +8,9 @@ import os
 import shutil
 import stat
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any
 
 from jinja2.ext import Extension
 

--- a/justfile
+++ b/justfile
@@ -4,12 +4,16 @@ list:
 
 # Run all the tests for all the supported Python versions
 test-all:
-    uv run --python=3.8 --isolated --group test -- pytest
     uv run --python=3.9 --isolated --group test -- pytest
     uv run --python=3.10 --isolated --group test -- pytest
     uv run --python=3.11 --isolated --group test -- pytest
     uv run --python=3.12 --isolated --group test -- pytest
+    uv run --python=3.13 --isolated --group test -- pytest
+
+# lint check with ruff
+lint-check:
+    uv run --python=3.13 --isolated --group test -- ruff check --no-fix .    
 
 # lint with ruff
 lint:
-    uv run --python=3.12 --isolated --group test -- ruff check --no-fix .    
+    uv run --python=3.13 --isolated --group test -- ruff check . --fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python",
@@ -43,7 +43,7 @@ dependencies = [
     "arrow",
     "rich",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.urls]
 Homepage = "https://github.com/cookiecutter/cookiecutter"
@@ -80,7 +80,7 @@ ignore = ["D001"]
 
 [tool.ruff]
 
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 
@@ -148,6 +148,7 @@ ignore = [
     "N818",   # Exception name should be named with an Error suffix
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
     "S404",   # `subprocess` module is possibly insecure
+    "TC003",  # Ignore request to put Iterable into TYPE CHECKING block
 ]
 
 exclude = ["tests/**/hooks/*"]

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import os
 import re
 from collections import OrderedDict
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 import pytest
 

--- a/tests/zipfile/test_unzip.py
+++ b/tests/zipfile/test_unzip.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import shutil
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Iterator
 
 import pytest
 


### PR DESCRIPTION
- Fixes #2142
- Supersedes #2143

Dropped support for Python 3.8 and added support for Python 3.13. This is so Cookiecutter is only responsible for current Pythons.

This is across workflows, justfile, and pyproject.toml. Updated type annotations and imports to use collections.abc for Iterator and Iterable, aligning with modern Python standards. Adjusted linting commands and matrix configurations to reflect new Python version support.

Many thanks to @donna008 for their work on this effort.