### PR TITLE
add: ability to select multiple choices

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -10,11 +10,11 @@ from collections import OrderedDict
 from collections.abc import Iterator
 from itertools import starmap
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union, TextIO, TypeVar, overload
+from typing import TYPE_CHECKING, Any, TextIO, TypeVar, Union, overload
 
 from jinja2.exceptions import UndefinedError
-from rich.text import Text, TextType
 from rich.prompt import Confirm, InvalidResponse, Prompt, PromptBase
+from rich.text import Text, TextType
 from typing_extensions import TypeAlias
 
 from cookiecutter.exceptions import UndefinedVariableInTemplate


### PR DESCRIPTION
Added the ability to make a multi-choice multiple choice prompt. It can be achieved like so:
```json
{
  "fruits": ["pineapple", "tomato", "squash", "eggplant", "peach", "avacado"],
  "__prompts__": {
    "fruits": {
      "__prompt__": "Which of these is your favorite fruit? (You can choose more than one)",
      "__multi__": true,
      "pineapple": "🍍",
      "tomato": "🍅",
      "squash": "🎃",
      "eggplant": "🍆",
      "peach": "🍑",
      "avacado": "🥑",
    }
  }
}
```
