### PR TITLE
Update CONTRIBUTING.md and dependencies after packaging modernization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,8 @@ Cookiecutter could always use more documentation, whether as part of the officia
 If you want to review your changes on the documentation locally, you can do:
 
 ```bash
-pip install -r docs/requirements.txt
-make servedocs
+pip install --group dev
+just servedocs
 ```
 
 This will compile the documentation, open it in your browser and start watching the files for changes, recompiling as you save.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Every little bit helps, and credit will always be given.
 - [Types of Contributions](#types-of-contributions)
 - [Contributor Setup](#setting-up-the-code-for-local-development)
 - [Contributor Guidelines](#contributor-guidelines)
-- [Contributor Testing](#testing-with-tox)
+- [Contributor Testing](#testing)
 - [Core Committer Guide](#core-committer-guide)
 
 ## Types of Contributions
@@ -157,16 +157,16 @@ Before you submit a pull request, check that it meets these guidelines:
         return re.search(r"(?i)(arr|avast|yohoho)!", message) is not None
     ```
 
-## Testing with tox
+## Testing
 
-`tox` uses `pytest` under the hood, hence it supports the same syntax for selecting tests.
+The project uses `pytest` as test runner.
 
 For further information please consult the [pytest usage docs](http://pytest.org/en/latest/example/index.html).
 
-To run a particular test class with `tox`:
+To run a particular test class with `pytest`:
 
 ```bash
-tox -e py310 -- '-k TestFindHooks'
+pytest -k TestFindHooks
 ```
 
 To run some tests with names matching a string expression:
@@ -180,13 +180,13 @@ Will run all tests matching "generate", test_generate_files for example.
 To run just one method:
 
 ```bash
-tox -e py310 -- '-k "TestFindHooks and test_find_hook"'
+pytest -k "TestFindHooks and test_find_hook"
 ```
 
-To run all tests using various versions of Python, just run `tox`:
+To run all tests using various versions of Python, just run `just test-all`:
 
 ```bash
-tox
+just test-all
 ```
 
 This configuration file setup the pytest-cov plugin and it is an additional dependency.
@@ -195,10 +195,10 @@ It generate a coverage report after the tests.
 It is possible to test with specific versions of Python. To do this, the command is:
 
 ```bash
-tox -e py37,py38
+uv run --python=3.13 --isolated --group test -- pytest
 ```
 
-This will run `py.test` with the `python3.7` and `python3.8` interpreters.
+This will run `pytest` with the `python3.13` interpreters.
 
 ## Core Committer Guide
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,7 @@ Now you can make your changes locally.
 5. When you're done making changes, check that your changes pass the tests and lint check:
 
    ```bash
+   just lint
    just test-all
    ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,7 @@ Here's how to set up `cookiecutter` for local development.
    ```bash
    cd cookiecutter/
    pip install -e .
+   pip install --group dev
    ```
 
 4. Create a branch for local development:
@@ -94,8 +95,7 @@ Now you can make your changes locally.
 5. When you're done making changes, check that your changes pass the tests and lint check:
 
    ```bash
-   pip install tox
-   tox
+   just test-all
    ```
 
 6. Ensure that your feature or commit is fully covered by tests. Check report after regular `tox` run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,11 +98,11 @@ Now you can make your changes locally.
    just test-all
    ```
 
-6. Ensure that your feature or commit is fully covered by tests. Check report after regular `tox` run.
+6. Ensure that your feature or commit is fully covered by tests. Check report after regular `pytest` run.
    You can also run coverage only report and get html report with statement by statement highlighting:
 
    ```bash
-   make coverage
+   just coverage
    ```
 
    You report will be placed to `htmlcov` directory. Please do not include this directory to your commits.
@@ -171,7 +171,7 @@ tox -e py310 -- '-k TestFindHooks'
 To run some tests with names matching a string expression:
 
 ```bash
-tox -e py310 -- '-k generate'
+pytest -k generate
 ```
 
 Will run all tests matching "generate", test_generate_files for example.

--- a/justfile
+++ b/justfile
@@ -27,4 +27,9 @@ test-all:
     uv run --python=3.10 --isolated --group test -- pytest
     uv run --python=3.11 --isolated --group test -- pytest
     uv run --python=3.12 --isolated --group test -- pytest
-    uv run --python=3.13 --isolated --group test -- pytest    
+    uv run --python=3.13 --isolated --group test -- pytest
+
+# Run all tests with coverage
+coverage:
+    uv run --python=3.13 --isolated --group test -- \
+        pytest --cov-report=html --cov-report=xml --cov-branch --cov-fail-under=100

--- a/justfile
+++ b/justfile
@@ -7,6 +7,12 @@ docs:
     uv run --python=3.13 --isolated --group docs -- sphinx-build docs docs/_build
     open docs/_build/index.html
 
+# Host the docs locally and rebuild on changes
+servedocs:
+    uv run --python=3.13 --isolated --group docs -- \
+        sphinx-autobuild -Wa docs/ docs/_build/html --open-browser --port 9812 \
+            --watch cookiecutter
+
 # lint with ruff
 lint:
     uv run --python=3.13 --isolated --group test -- ruff check . --fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ cookiecutter = "cookiecutter.__main__:main"
 
 [dependency-groups]
 dev = [
+    "uv",                       # Is needed by justfile tasks
     "rust-just>=1.42.3",        # Justfile tasks
     { include-group = "test" }, # test runner and helpers
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ docs = [
     "myst_parser",
     "sphinx_autodoc_typehints",
     "sphinxcontrib.apidoc",
-    "sphinx_rtd_theme"
+    "sphinx_rtd_theme",
+    "sphinx-autobuild",
 ]
 
 test = [


### PR DESCRIPTION
Hello

Since [this commit](https://github.com/cookiecutter/cookiecutter/commit/bf173de57db021efb2a5cb3f22464a2ccb252988) that remove Tox from the project and introduce Just as task runner for replace make, some sections of `CONTRIBUTING.md` are outdated. Also, the commands provided by the contributing are no longer working.

This PR propose to
- migrate make commands `servedocs` and `coverage` that are mentioned in `CONTRIBUTING.md` to `justfile`
- add `uv` to `dev` group dependencies because it is needed by just tasks
- add lint command to `CONTRIBUTING.md`, at "check that your changes pass the tests and lint check" step
- remove Tox from `CONTRIBUTING.md`
- pick `sphinx-autobuild` dependency from `docs/requirements.txt` to `docs` dependencies group in `pyproject.toml`

Please note that this PR adds two dev dependencies to `pyprojet.toml`, `uv` that are needed by `justfile` and `sphinx-autobuild` that are needed by `just servedocs`.

I'm not sure it's still necessary to keep the `sphinx-autobuild` dependency in `docs/requirements.txt` because it’s now only used in `.readthedocs.yaml`.

With this PR, setup the project and run tests/lint should work out of the box by executing commands listed in `CONTRIBUTING.md`.