### PR TITLE
Clarified installation instructions in README.md for pipx alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Install cookiecutter using pip package manager:
 # pipx is strongly recommended.
 pipx install cookiecutter
 
-# If pipx is not an option,
-# you can install cookiecutter in your Python user directory.
+# If pipx is not available, install cookiecutter in your Python user directory using:
 python -m pip install --user cookiecutter
 ```
 


### PR DESCRIPTION
This pull request clarifies the installation instructions for Cookiecutter in the README.md file.

Combines two separate lines regarding pipx and pip installation into a single, clearer sentence.

Makes it easier for new users to understand the alternative installation method if pipx is not available.

Improves overall readability of the Installation section without changing any functionality.

This is a documentation-only change and does not affect the codebase.