### PR TITLE
fix issue where empty list causes a crash due to index out of range

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -275,6 +275,8 @@ def prompt_choice_for_config(
     """
     rendered_options = [render_variable(env, raw, cookiecutter_dict) for raw in options]
     if no_input:
+        if len(rendered_options) == 0:
+            return ""
         return rendered_options[0]
     return read_user_choice(key, rendered_options, prompts, prefix)
 

--- a/tests/test-pyhooks/cookiecutter.json
+++ b/tests/test-pyhooks/cookiecutter.json
@@ -1,4 +1,5 @@
 {
   "pyhooks": "fake-project",
-  "project_title": "Project Title"
+  "project_title": "Project Title",
+  "empty_list": []
 }


### PR DESCRIPTION
Resolves #2065. Also see #2066 for more context

- change `prompt_choice_for_config` to return an empty string when the list is empty
- add an empty list to one of the test `cookiecutter.json` files