### PR TITLE
fix issue where empty list causes a crash due to index out of range

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -275,6 +275,8 @@ def prompt_choice_for_config(
     """
     rendered_options = [render_variable(env, raw, cookiecutter_dict) for raw in options]
     if no_input:
+        if len(rendered_options) == 0:
+            return ""
         return rendered_options[0]
     return read_user_choice(key, rendered_options, prompts, prefix)
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -520,6 +520,18 @@ class TestPromptChoiceForConfig:
         read_user_choice.assert_called_once_with('orientation', choices, None, '')
         assert expected_choice == actual_choice
 
+    def test_empty_list_returns_empty_string(self) -> None:
+        """Verify empty list returns empty string."""
+        context = {'project': 'foobar'}
+        actual_choice = prompt.prompt_choice_for_config(
+            cookiecutter_dict=context,
+            env=environment.StrictEnvironment(),
+            key='orientation',
+            options=[],
+            no_input=True,  # Suppress user input
+        )
+        assert actual_choice == ""
+
 
 class TestReadUserYesNo:
     """Class to unite boolean prompt related tests."""


### PR DESCRIPTION
Fixes the issue where sending an empty list in the options will raise an `IndexError` exception.
