### PR TITLE
Add documentation for running mypy on generated projects (fix #2116)

### DIFF
--- a/docs/advanced/index.rst
+++ b/docs/advanced/index.rst
@@ -28,3 +28,32 @@ Various advanced topics regarding cookiecutter usage.
    local_extensions
    nested_config_files
    human_readable_prompts
+
+Running mypy and other static analysis tools
+--------------------------------------------
+
+Cookiecutter templates themselves are not valid Python projects. For example,
+a module or directory named ``{{ cookiecutter.project_name }}`` cannot be
+recognized as a valid Python package by tools such as ``mypy`` due to the
+presence of template variables.
+
+To use static analysis tools like ``mypy`` or ``ruff``, first generate a
+project from the template and then run the tool on the **generated project**.
+
+A common approach in tests is to use ``pytest-cookies`` to bake a project and
+run checks on the resulting code::
+
+    def test_project_passes_mypy(cookies):
+        result = cookies.bake(extra_context={"project_name": "example_project"})
+        assert result.exit_code == 0
+        project_path = result.project
+
+        completed = subprocess.run(
+            ["mypy", "."],
+            cwd=project_path,
+            check=False,
+        )
+        assert completed.returncode == 0
+
+This ensures that static analysis is performed on real generated code, not the
+template files.


### PR DESCRIPTION
This PR adds a new section to the Advanced Usage documentation explaining how
tools like `mypy` behave with Cookiecutter templates, and why static analysis
must be run on the generated project rather than the template itself.

The new section describes the underlying issue encountered in #2116, where
`{{ cookiecutter.project_name }}` is not a valid Python package name for mypy,
and provides guidance for running static analysis correctly.

An example using `pytest-cookies` is included to show how to bake a project in
tests and run `mypy` on the resulting code.

Fixes #2116.