### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@
 # - No echo/group commands shown.
 # - Shared bootstrap steps are DRY via YAML anchors.
 
-name: CI/CD Tests (version 2)
+name: Tests
 
 on:
   push:
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-    name: Tests on Python versions 3.9–>3.13 • "${{ matrix.os }}" (via just, uv, pytest, pytest-pretty)
+    name: Tests on Python versions 3.10–>3.13 • "${{ matrix.os }}" (via just, uv, pytest, pytest-pretty)
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:

--- a/justfile
+++ b/justfile
@@ -23,7 +23,6 @@ lint-check:
 
 # Run all the tests for all the supported Python versions
 test-all:
-    uv run --python=3.9 --isolated --group test -- pytest
     uv run --python=3.10 --isolated --group test -- pytest
     uv run --python=3.11 --isolated --group test -- pytest
     uv run --python=3.12 --isolated --group test -- pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -43,7 +42,7 @@ dependencies = [
     "arrow",
     "rich",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.urls]
 Homepage = "https://github.com/cookiecutter/cookiecutter"


### PR DESCRIPTION
Removed Python 3.9 from CI, justfile, and project metadata. Updated minimum required Python version to 3.10 in pyproject.toml and adjusted workflow and test matrix accordingly.