### PR TITLE
Update README logo URL to use main branch for stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-    <img alt="cookiecutter Logo" width="200px" src="https://raw.githubusercontent.com/cookiecutter/cookiecutter/3ac078356adf5a1a72042dfe72ebfa4a9cd5ef38/logo/cookiecutter_medium.png">
+    <img alt="cookiecutter Logo" width="200px" src="https://raw.githubusercontent.com/cookiecutter/cookiecutter/main/logo/cookiecutter_medium.png">
 </h1>
 
 <div align="center">


### PR DESCRIPTION
This pull request updates the README logo image URL to reference the main branch instead of a specific commit or older branch, ensuring the logo remains stable and up to date as the repository evolves.
​