### PR TITLE
fix: add chardet dependency version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ keywords = [
     "packaging",
 ]
 dependencies = [
+    "chardet>=5.0.0,<6.0.0",
     "binaryornot>=0.4.4",
     "Jinja2>=2.7,<4.0.0",
     "click>=7.0,<9.0.0",


### PR DESCRIPTION
This pull request adds a new dependency to the project. The `chardet` library has been included in the `dependencies` section of `pyproject.toml` to ensure proper character encoding detection.

* Added `chardet>=5.0.0,<6.0.0` to the `dependencies` list in `pyproject.toml`.

Reason:

Dependency: `binaryornot` uses -> `chardet`, and chardet introduced breaking changes (7.0.0):

![Screenshot 2026-03-04 at 16 49 36](https://github.com/user-attachments/assets/c2f7835f-3b08-4bfc-b55e-70e2a772ed84)

![Screenshot 2026-03-04 at 16 51 45](https://github.com/user-attachments/assets/7f1df8d5-3c4c-436b-99ca-0d5c0251ee11)

Let's set constraints on the dependency tree.