### PR TITLE
fix: handle binaryornot detection failures gracefully

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -218,7 +218,18 @@ def generate_file(
 
     # Just copy over binary files. Don't render.
     logger.debug("Check %s to see if it's a binary", infile)
-    if is_binary(infile):
+    try:
+        file_is_binary = is_binary(infile)
+    except (NameError, TypeError):
+        # binaryornot is incompatible with newer versions of chardet (7.x+)
+        # which can return None for the encoding.  When detection fails, treat
+        # the file as binary so it is safely copied without rendering.
+        logger.warning(
+            "Unable to detect whether %s is a binary file, treating it as binary.",
+            infile,
+        )
+        file_is_binary = True
+    if file_is_binary:
         logger.debug('Copying binary %s to %s without rendering', infile, outfile)
         shutil.copyfile(infile, outfile)
         shutil.copymode(infile, outfile)

--- a/tests/test_generate_file.py
+++ b/tests/test_generate_file.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from jinja2 import FileSystemLoader
@@ -193,3 +194,46 @@ def test_generate_file_handles_mixed_line_endings(env) -> None:
         simple_text = f.readline()
     assert simple_text in ('newline is CRLF\r\n', 'newline is CRLF\n')
     assert f.newlines in ('\r\n', '\n')
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        NameError("name 'unicode' is not defined"),
+        TypeError("decode() argument 'encoding' must be str, not None"),
+    ],
+    ids=["NameError", "TypeError"],
+)
+def test_generate_file_treats_file_as_binary_when_detection_fails(
+    monkeypatch, env, tmp_path, exception
+) -> None:
+    """Regression test for https://github.com/cookiecutter/cookiecutter/issues/2197.
+
+    When ``binaryornot`` raises ``NameError`` or ``TypeError`` (e.g. due to
+    chardet 7.x returning ``None`` for the encoding), the file should be
+    treated as binary and copied without rendering.
+    """
+    # generate_file uses relative infile paths joined with project_dir.
+    # Simulate the real workflow: chdir to the template dir, use a relative
+    # infile, and point project_dir at a separate output directory.
+    infile = "somefile.ttf"
+    template_dir = tmp_path / "template"
+    template_dir.mkdir()
+    (template_dir / infile).write_bytes(b"\x00\x01\x02binary-content")
+
+    out_dir = tmp_path / "output"
+    out_dir.mkdir()
+
+    monkeypatch.chdir(template_dir)
+
+    with mock.patch("cookiecutter.generate.is_binary", side_effect=exception):
+        generate.generate_file(
+            project_dir=str(out_dir),
+            infile=infile,
+            context={'cookiecutter': {}},
+            env=env,
+        )
+
+    outfile = out_dir / infile
+    assert outfile.exists()
+    assert outfile.read_bytes() == b"\x00\x01\x02binary-content"


### PR DESCRIPTION
## Summary

Fixes #2197.

When `chardet` 7.x+ is installed, `binaryornot.check.is_binary()` can raise:
- **`TypeError`**: `chardet.detect()` returns `None` for the encoding, and `binaryornot` passes it to `bytes.decode(encoding=None)`
- **`NameError`**: `binaryornot`'s Python 2 fallback calls `unicode()` which doesn't exist on Python 3

This crashes `generate_file()` for binary files like `.ttf` fonts.

**Fix**: Wrap the `is_binary()` call in a `try/except (NameError, TypeError)` so that when detection fails, the file is treated as binary and safely copied without attempting Jinja2 rendering. A warning is logged when this fallback triggers.

**Changes:**
- `cookiecutter/generate.py`: Catch `NameError` and `TypeError` from `is_binary()`, default to treating the file as binary
- `tests/test_generate_file.py`: Parametrized regression test covering both exception types

## Test plan

- [x] 14/14 `test_generate_file.py` tests pass (12 existing + 2 new parametrized)
- [x] 274 passed across full suite (errors in unrelated test modules due to missing optional deps)
- [x] `ruff check` and `ruff format` clean
- [ ] CI workflows pass on this PR

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)