### PR TITLE
fix: Improve error message and auto-detect subdirectories when template

### DIFF
--- a/cookiecutter/repository.py
+++ b/cookiecutter/repository.py
@@ -132,6 +132,24 @@ def determine_repo_dir(
         if repository_has_cookiecutter_json(repo_candidate):
             return repo_candidate, cleanup
 
+    if not directory:
+        subdirs = []
+        for repo_candidate in repository_candidates:
+            if os.path.isdir(repo_candidate):
+                for entry in sorted(os.listdir(repo_candidate)):
+                    subdir = os.path.join(repo_candidate, entry)
+                    if repository_has_cookiecutter_json(subdir):
+                        subdirs.append(entry)
+        if subdirs:
+            msg = (
+                'A valid repository for "{}" could not be found at the root, '
+                'but the following subdirectories contain templates:\n{}\n'
+                'Please use the --directory flag to specify one.'.format(
+                    template, '\n'.join(subdirs)
+                )
+            )
+            raise RepositoryNotFound(msg)
+
     msg = (
         'A valid repository for "{}" could not be found in the following '
         'locations:\n{}'.format(template, '\n'.join(repository_candidates))


### PR DESCRIPTION
Fixes #2191

When a repository contains templates in subdirectories rather than at the root, `determine_repo_dir` in `cookiecutter/repository.py` would raise a generic `RepositoryNotFound` error with no actionable guidance. Users had no way to know the `--directory` flag existed or which subdirectories were valid.

Adds a pre-check in `determine_repo_dir` that scans `repository_candidates` for subdirectories containing a `cookiecutter.json` before falling through to the generic error. When matches are found, raises `RepositoryNotFound` with a message listing the valid subdirectory names and instructing the user to pass `--directory`.

Verified by running `tests/repository/test_determine_repo_dir_finds_subdirectories.py` alongside the full repository test suite, all passing.