### PR TITLE
Add new builtin abbreviation "cb" for codeberg.org

### DIFF
--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -23,6 +23,7 @@ BUILTIN_ABBREVIATIONS = {
     'gh': 'https://github.com/{0}.git',
     'gl': 'https://gitlab.com/{0}.git',
     'bb': 'https://bitbucket.org/{0}',
+    'cb': 'https://codeberg.org/{0}.git',
 }
 
 DEFAULT_CONFIG = {

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -42,9 +42,9 @@ To create a project from the cookiecutter-pypackage.git repo template::
 
     $ cookiecutter gh:audreyfeldroy/cookiecutter-pypackage
 
-Cookiecutter knows abbreviations for Github (``gh``), Bitbucket (``bb``), and
-GitLab (``gl``) projects, but you can also give it the full URL to any
-repository::
+Cookiecutter knows abbreviations for Github (``gh``), Bitbucket
+(``bb``), GitLab (``gl``), and Codeberg (``cb``) projects, but you can
+also give it the full URL to any repository::
 
     $ cookiecutter https://github.com/audreyfeldroy/cookiecutter-pypackage.git
     $ cookiecutter git+ssh://git@github.com/audreyfeldroy/cookiecutter-pypackage.git

--- a/tests/repository/test_abbreviation_expansion.py
+++ b/tests/repository/test_abbreviation_expansion.py
@@ -29,6 +29,11 @@ from cookiecutter.repository import expand_abbreviations
             BUILTIN_ABBREVIATIONS,
             'https://bitbucket.org/pydanny/cookiecutter-django',
         ),
+        (
+            'cb:pydanny/cookiecutter-django',
+            BUILTIN_ABBREVIATIONS,
+            'https://codeberg.org/pydanny/cookiecutter-django.git',
+        ),
     ],
     ids=(
         'Simple expansion',
@@ -39,6 +44,7 @@ from cookiecutter.repository import expand_abbreviations
         'Correct expansion for builtin abbreviations (github)',
         'Correct expansion for builtin abbreviations (gitlab)',
         'Correct expansion for builtin abbreviations (bitbucket)',
+        'Correct expansion for builtin abbreviations (codeberg)',
     ),
 )
 def test_abbreviation_expansion(template, abbreviations, expected_result) -> None:

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -19,6 +19,7 @@ def test_merge_configs() -> None:
             'gh': 'https://github.com/{0}.git',
             'gl': 'https://gitlab.com/{0}.git',
             'bb': 'https://bitbucket.org/{0}',
+            'cb': 'https://codeberg.org/{0}.git',
         },
     }
 
@@ -44,6 +45,7 @@ def test_merge_configs() -> None:
             'gh': 'https://github.com/{0}.git',
             'gl': 'https://gitlab.com/hackebrot/{0}.git',
             'bb': 'https://bitbucket.org/{0}',
+            'cb': 'https://codeberg.org/{0}.git',
             'pytest-plugin': 'https://github.com/pytest-dev/pytest-plugin.git',
         },
     }
@@ -74,6 +76,7 @@ def test_get_config() -> None:
             'gh': 'https://github.com/{0}.git',
             'gl': 'https://gitlab.com/{0}.git',
             'bb': 'https://bitbucket.org/{0}',
+            'cb': 'https://codeberg.org/{0}.git',
             'helloworld': 'https://github.com/hackebrot/helloworld',
         },
     }
@@ -118,6 +121,7 @@ def test_get_config_with_defaults() -> None:
             'gh': 'https://github.com/{0}.git',
             'gl': 'https://gitlab.com/{0}.git',
             'bb': 'https://bitbucket.org/{0}',
+            'cb': 'https://codeberg.org/{0}.git',
         },
     }
     assert conf == expected_conf

--- a/tests/test_get_user_config.py
+++ b/tests/test_get_user_config.py
@@ -62,6 +62,7 @@ def custom_config():
             'gh': 'https://github.com/{0}.git',
             'gl': 'https://gitlab.com/{0}.git',
             'bb': 'https://bitbucket.org/{0}',
+            'cb': 'https://codeberg.org/{0}.git',
             'helloworld': 'https://github.com/hackebrot/helloworld',
         },
     }


### PR DESCRIPTION
Long-time cookiecutter user, first-time contributor here. Please consider this humble contribution.

Codeberg[^1] is, by its own definition, 

> a democratic community-driven, non-profit software development platform [...] centered around Codeberg.org, a Forgejo-based software forge."[^2]

It is popular with the FOSS community in Europe, and constitutes a common alternative to GitHub, GitLab, and Bitbucket, for which Cookiecutter already has builtin repo abbreviations.

Thus, introduce "cb" as a new builtin abbreviation that expands to codeberg.org.

[^1]: https://codeberg.org/
[^2]: https://docs.codeberg.org/getting-started/what-is-codeberg/

AI declaration: no GenAI tools or LLMs were used in the creation of this patch.