### PR TITLE
fix: exclude __main__ block from coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ module = [
 disable_error_code = ["no-untyped-def"]
 
 [tool.coverage.report]
-exclude_also = ["if TYPE_CHECKING:"]
+exclude_also = ["if TYPE_CHECKING:" , "if __name__ == .__main__.:"]
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
## What and why

The `if __name__ == "__main__"` guard at the bottom of `cli.py`
was showing as an uncovered line in the coverage report.

This is a standard Python idiom that runs only when the file is
executed directly (`python cli.py`). When pytest imports the module
to run tests, `__name__` is never `"__main__"`, so this line is
impossible to cover meaningfully through the test suite.

## Fix

Added `if __name__ == .__main__.` to the `exclude_lines` list
in `[tool.coverage.report]` inside `pyproject.toml`. This brings
the total coverage to a clean 100%.

## Testing

377 passed, 6 skipped (Windows - Linux-only tests), 0 errors.
Coverage: 100%