### PR TITLE
Add `_force_render` option to render files that binaryornot misclassifies as binary

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -56,6 +56,30 @@ def is_copy_only_path(path: str, context: dict[str, Any]) -> bool:
     return False
 
 
+def is_force_render_path(path: str, context: dict[str, Any]) -> bool:
+    """Check whether the given `path` should always be rendered as text.
+
+    Returns True if `path` matches a pattern in ``_force_render`` inside the
+    given ``context`` dict, otherwise False.
+
+    This is useful when a file is falsely detected as binary by the underlying
+    heuristic (e.g. files starting with ``PACK``, ``BZh``, etc.) but is
+    actually a plain-text template that must be rendered.
+
+    :param path: A file-system path referring to a file that should be force-
+        rendered.
+    :param context: cookiecutter context.
+    """
+    try:
+        for pattern in context['cookiecutter']['_force_render']:
+            if fnmatch.fnmatch(path, pattern):
+                return True
+    except KeyError:
+        return False
+
+    return False
+
+
 def apply_overwrites_to_context(
     context: dict[str, Any],
     overwrite_context: dict[str, Any],
@@ -218,7 +242,11 @@ def generate_file(
 
     # Just copy over binary files. Don't render.
     logger.debug("Check %s to see if it's a binary", infile)
-    if is_binary(infile):
+    if is_force_render_path(infile, context):
+        logger.debug(
+            'Force-rendering %s as text (matched _force_render pattern)', infile
+        )
+    elif is_binary(infile):
         logger.debug('Copying binary %s to %s without rendering', infile, outfile)
         shutil.copyfile(infile, outfile)
         shutil.copymode(infile, outfile)

--- a/docs/advanced/force_render.rst
+++ b/docs/advanced/force_render.rst
@@ -1,0 +1,46 @@
+.. _force-render:
+
+Force Render
+------------
+
+*New in Cookiecutter 2.8*
+
+Cookiecutter uses the `binaryornot`_ library to detect whether a file is
+binary before attempting to render it as a Jinja2 template.  The detection is
+heuristic-based and can occasionally misclassify plain-text files as binary.
+A well-known example is a ``Makefile`` whose first token is ``PACKAGE_NAME``
+– the four-byte prefix ``PACK`` matches the magic bytes of a `git packfile`_,
+so ``binaryornot`` marks the file as binary and cookiecutter copies it
+verbatim without expanding any template variables.
+
+To work around this, add the ``_force_render`` key to ``cookiecutter.json``.
+Its value is a list of Unix shell-style wildcard patterns (identical to the
+syntax used by :ref:`copy-without-render`).  Any file whose path matches one
+of the patterns will **always** be rendered as a Jinja2 template, regardless
+of what ``binaryornot`` reports.
+
+.. code-block:: JSON
+
+    {
+        "project_slug": "sample",
+        "_force_render": [
+            "Makefile",
+            "*.mk"
+        ]
+    }
+
+With this configuration a ``Makefile`` that starts with::
+
+    PACKAGE_NAME := {{cookiecutter.project_slug}}
+
+will be correctly rendered to::
+
+    PACKAGE_NAME := sample
+
+instead of being copied as-is.
+
+**Note**: ``_force_render`` only affects the *content* of the matched files.
+Their *paths* (file names and directory names) are always rendered.
+
+.. _binaryornot: https://pypi.org/project/binaryornot/
+.. _git packfile: https://git-scm.com/book/en/v2/Git-Internals-Packfiles

--- a/docs/advanced/index.rst
+++ b/docs/advanced/index.rst
@@ -16,6 +16,7 @@ Various advanced topics regarding cookiecutter usage.
    templates_in_context
    private_variables
    copy_without_render
+   force_render
    replay
    choice_variables
    boolean_variables

--- a/tests/test-generate-force-render/{{cookiecutter.repo_name}}/Makefile
+++ b/tests/test-generate-force-render/{{cookiecutter.repo_name}}/Makefile
@@ -1,0 +1,1 @@
+PACKAGE_NAME := {{ cookiecutter.project_slug }}

--- a/tests/test-generate-force-render/{{cookiecutter.repo_name}}/README.rst
+++ b/tests/test-generate-force-render/{{cookiecutter.repo_name}}/README.rst
@@ -1,0 +1,1 @@
+{{ cookiecutter.project_slug }}

--- a/tests/test_generate_force_render.py
+++ b/tests/test_generate_force_render.py
@@ -8,7 +8,6 @@ import pytest
 from cookiecutter import generate, utils
 from cookiecutter.generate import is_force_render_path
 
-
 # ---------------------------------------------------------------------------
 # Unit tests for is_force_render_path helper
 # ---------------------------------------------------------------------------

--- a/tests/test_generate_force_render.py
+++ b/tests/test_generate_force_render.py
@@ -1,0 +1,86 @@
+"""Verify correct work of `_force_render` context option."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from cookiecutter import generate, utils
+from cookiecutter.generate import is_force_render_path
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for is_force_render_path helper
+# ---------------------------------------------------------------------------
+
+
+def test_is_force_render_path_matches_pattern():
+    """Return True when path matches a pattern in _force_render."""
+    context = {'cookiecutter': {'_force_render': ['Makefile', '*.mk']}}
+    assert is_force_render_path('Makefile', context) is True
+    assert is_force_render_path('build.mk', context) is True
+
+
+def test_is_force_render_path_no_match():
+    """Return False when path does not match any _force_render pattern."""
+    context = {'cookiecutter': {'_force_render': ['Makefile']}}
+    assert is_force_render_path('README.rst', context) is False
+
+
+def test_is_force_render_path_missing_key():
+    """Return False when _force_render key is absent from context."""
+    context = {'cookiecutter': {}}
+    assert is_force_render_path('Makefile', context) is False
+
+
+def test_is_force_render_path_empty_list():
+    """Return False when _force_render list is empty."""
+    context = {'cookiecutter': {'_force_render': []}}
+    assert is_force_render_path('Makefile', context) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration test: a file falsely detected as binary must still be rendered
+# when listed in _force_render
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def remove_test_dir():
+    """Remove the generated project directory after each test."""
+    yield
+    if os.path.exists('test_force_render'):
+        utils.rmtree('test_force_render')
+
+
+@pytest.mark.usefixtures('clean_system', 'remove_test_dir')
+def test_generate_force_render_renders_false_binary_file() -> None:
+    """_force_render causes a file detected as binary to be Jinja-rendered.
+
+    The template contains a ``Makefile`` whose first word is ``PACKAGE_NAME``
+    (starts with ``PACK``).  The ``binaryornot`` library misclassifies such
+    files as binary (they look like git packfiles) and cookiecutter would
+    normally copy them verbatim.  With ``_force_render`` the file must be
+    rendered as a Jinja2 template.
+    """
+    generate.generate_files(
+        context={
+            'cookiecutter': {
+                'repo_name': 'test_force_render',
+                'project_slug': 'my_project',
+                '_force_render': ['Makefile'],
+            }
+        },
+        repo_dir='tests/test-generate-force-render',
+    )
+
+    # README.rst is a normal text file; it should always be rendered.
+    readme = Path('test_force_render/README.rst').read_text()
+    assert 'my_project' in readme
+
+    # Makefile starts with PACKAGE_NAME (PACK…), so binaryornot marks it as
+    # binary. Without _force_render the template variable would not be
+    # expanded. With _force_render it must be rendered.
+    makefile = Path('test_force_render/Makefile').read_text()
+    assert 'my_project' in makefile
+    assert '{{' not in makefile


### PR DESCRIPTION
## Problem (fixes #2205)

`cookiecutter` relies on the [`binaryornot`](https://pypi.org/project/binaryornot/) library to decide whether a file should be Jinja2-rendered or copied verbatim.  The detection is heuristic and occasionally misclassifies plain-text files as binary.

A well-documented trigger is any file whose **content** starts with the four bytes `PACK` (e.g. a `Makefile` containing `PACKAGE_NAME := …`).  Those bytes match the magic signature of a [git packfile](https://git-scm.com/book/en/v2/Git-Internals-Packfiles), so `binaryornot.is_binary()` returns `True` and cookiecutter copies the file without expanding template variables.

## Solution

Introduce a `_force_render` key in `cookiecutter.json` – a list of Unix shell-style wildcard patterns.  Any file whose path matches a pattern is **always** rendered as a Jinja2 template, regardless of what `binaryornot` reports.

The implementation mirrors the existing `_copy_without_render` approach:

```json
{
    "project_slug": "sample",
    "_force_render": [
        "Makefile",
        "*.mk"
    ]
}
```

With this config a `Makefile` that starts with:

```makefile
PACKAGE_NAME := {{cookiecutter.project_slug}}
```

is correctly rendered to:

```makefile
PACKAGE_NAME := sample
```

## Changes

| File | Change |
|---|---|
| `cookiecutter/generate.py` | Add `is_force_render_path()` helper; consult it in `generate_file()` before the `is_binary()` check |
| `tests/test_generate_force_render.py` | Unit tests for the helper + integration test that verifies a falsely-detected binary file is rendered |
| `tests/test-generate-force-render/` | Minimal template used by the integration test |
| `docs/advanced/force_render.rst` | New documentation page |
| `docs/advanced/index.rst` | Include new page in toctree |

## Testing

```
pytest tests/test_generate_force_render.py -v
# 5 passed
```

All existing `_copy_without_render` tests continue to pass.

Made with [Cursor](https://cursor.com)