### PR TITLE
Fix human-readable labels for dict choices

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import re
@@ -114,12 +115,48 @@ def read_user_choice(var_name: str, options: list, prompts=None, prefix: str = "
         if isinstance(prompts[var_name], str):
             question = prompts[var_name]
         else:
-            if "__prompt__" in prompts[var_name]:
-                question = prompts[var_name]["__prompt__"]
+            prompt_config = prompts[var_name]
+            if "__prompt__" in prompt_config:
+                question = prompt_config["__prompt__"]
+
+            def normalize_choice(choice):
+                if isinstance(choice, dict):
+                    return {
+                        normalize_choice(key): normalize_choice(value)
+                        for key, value in choice.items()
+                    }
+                if isinstance(choice, list):
+                    return [normalize_choice(value) for value in choice]
+                if choice is None or isinstance(choice, bool | str):
+                    return choice
+                return str(choice)
+
+            def prompt_label(choice):
+                try:
+                    if choice in prompt_config:
+                        return prompt_config[choice]
+                except TypeError:
+                    pass
+
+                choice_str = str(choice)
+                if choice_str in prompt_config:
+                    return prompt_config[choice_str]
+
+                normalized_choice = normalize_choice(choice)
+                for prompt_key, label in prompt_config.items():
+                    if prompt_key == "__prompt__":
+                        continue
+                    try:
+                        parsed_key = ast.literal_eval(prompt_key)
+                    except (SyntaxError, TypeError, ValueError):
+                        continue
+                    if normalize_choice(parsed_key) == normalized_choice:
+                        return label
+
+                return choice
+
             choice_lines = (
-                f"    [bold magenta]{i}[/] - [bold]{prompts[var_name][p]}[/]"
-                if p in prompts[var_name]
-                else f"    [bold magenta]{i}[/] - [bold]{p}[/]"
+                f"    [bold magenta]{i}[/] - [bold]{prompt_label(p)}[/]"
                 for i, p in choice_map.items()
             )
 

--- a/tests/test_read_user_choice.py
+++ b/tests/test_read_user_choice.py
@@ -29,6 +29,34 @@ def test_click_invocation(mocker, user_choice, expected_value) -> None:
     prompt.assert_called_once_with(EXPECTED_PROMPT, choices=OPTIONS_INDEX, default='1')
 
 
+def test_click_invocation_with_stringified_unhashable_choice_labels(mocker) -> None:
+    """Use stringified labels when choice values cannot be dict keys."""
+    options = [
+        {'provider': 'aws', 'region': 'us-east-1', 'instances': '3'},
+        {'provider': 'gcp', 'region': 'us-central1', 'instances': '2'},
+    ]
+    prompt_config = {
+        'cloud_config': {
+            '__prompt__': 'Select cloud configuration',
+            "{'provider': 'aws', 'region': 'us-east-1', 'instances': 3}": 'AWS East',
+            (
+                "{'provider': 'gcp', 'region': 'us-central1', 'instances': 2}"
+            ): 'GCP Central',
+        }
+    }
+    expected_prompt = """Select cloud configuration
+    [bold magenta]1[/] - [bold]AWS East[/]
+    [bold magenta]2[/] - [bold]GCP Central[/]
+    Choose from"""
+
+    prompt = mocker.patch('rich.prompt.Prompt.ask')
+    prompt.return_value = '1'
+
+    assert read_user_choice('cloud_config', options, prompt_config) == options[0]
+
+    prompt.assert_called_once_with(expected_prompt, choices=['1', '2'], default='1')
+
+
 def test_raise_if_options_is_not_a_non_empty_list() -> None:
     """Test function called by cookiecutter raise expected errors.
 


### PR DESCRIPTION
Fixes #2187.

## Summary
- fix the `read_user_choice` crash when `__prompts__` labels are configured for dict-like choices
- match stringified prompt keys against rendered choice values so the configured labels are shown in the CLI
- add a regression test covering the reported prompt mapping shape from #2187

## Test plan
- [x] `uv run --group test pytest tests/test_read_user_choice.py`
- [x] `uv run --group test pytest tests/test_cli.py tests/test_prompt.py tests/test_read_user_choice.py`
- [x] Manual CLI repro from #2187 now shows `AWS East` / `GCP Central` and completes project generation
