### PR TITLE
Keep applying default context after invalid entries

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -56,6 +56,29 @@ def is_copy_only_path(path: str, context: dict[str, Any]) -> bool:
     return False
 
 
+def _apply_overwrite_to_context_with_error(
+    context: dict[str, Any], variable: str, overwrite: Any
+) -> ValueError | None:
+    """Apply a single overwrite and return any validation error."""
+    try:
+        apply_overwrites_to_context(context, {variable: overwrite})
+    except ValueError as error:
+        return error
+    return None
+
+
+def _apply_overwrites_to_context_with_errors(
+    context: dict[str, Any], overwrite_context: dict[str, Any]
+) -> list[ValueError]:
+    """Apply overwrites to context while collecting per-variable errors."""
+    errors: list[ValueError] = []
+    for variable, overwrite in overwrite_context.items():
+        error = _apply_overwrite_to_context_with_error(context, variable, overwrite)
+        if error is not None:
+            errors.append(error)
+    return errors
+
+
 def apply_overwrites_to_context(
     context: dict[str, Any],
     overwrite_context: dict[str, Any],
@@ -161,10 +184,12 @@ def generate_context(
     # Overwrite context variable defaults with the default context from the
     # user's global config, if available
     if default_context:
-        try:
-            apply_overwrites_to_context(obj, default_context)
-        except ValueError as error:
-            warnings.warn(f"Invalid default received: {error}")
+        default_context_errors = _apply_overwrites_to_context_with_errors(
+            obj, default_context
+        )
+        if default_context_errors:
+            error_messages = "; ".join(str(error) for error in default_context_errors)
+            warnings.warn(f"Invalid default received: {error_messages}")
     if extra_context:
         apply_overwrites_to_context(obj, extra_context)
 

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -202,6 +202,54 @@ def test_apply_overwrites_does_not_modify_choices_for_invalid_overwrite() -> Non
     assert generated_context == expected_context
 
 
+def test_invalid_default_context_keeps_later_valid_overwrites() -> None:
+    """Verify invalid default values do not skip later default context entries."""
+    with pytest.warns(UserWarning, match="orientation"):
+        generated_context = generate.generate_context(
+            context_file='tests/test-generate-context/choices_template.json',
+            default_context=OrderedDict(
+                [
+                    ('orientation', 'foobar'),
+                    ('repo_name', 'valid-repo-name'),
+                ]
+            ),
+        )
+
+    assert generated_context['choices_template']['orientation'] == [
+        'all',
+        'landscape',
+        'portrait',
+    ]
+    assert generated_context['choices_template']['repo_name'] == 'valid-repo-name'
+
+
+def test_invalid_default_context_reports_all_errors(tmp_path) -> None:
+    """Verify all invalid default values are reported in one warning."""
+    context_file = tmp_path / 'cookiecutter.json'
+    context_file.write_text(
+        '{"choice": ["one", "two"], "enabled": true, "name": "default"}',
+        encoding='utf-8',
+    )
+
+    with pytest.warns(UserWarning) as warning_records:
+        generated_context = generate.generate_context(
+            context_file=str(context_file),
+            default_context=OrderedDict(
+                [
+                    ('choice', 'three'),
+                    ('enabled', 'maybe'),
+                    ('name', 'changed'),
+                ]
+            ),
+        )
+
+    assert len(warning_records) == 1
+    warning_message = str(warning_records[0].message)
+    assert 'choice' in warning_message
+    assert 'enabled' in warning_message
+    assert generated_context['cookiecutter']['name'] == 'changed'
+
+
 def test_apply_overwrites_invalid_overwrite(template_context) -> None:
     """Verify variables overwrite for list if variable not in list not ignored."""
     with pytest.raises(ValueError):


### PR DESCRIPTION
Summary:
- keep applying later `default_context` entries after an invalid default override
- report all invalid default overrides in one warning
- preserve hard failures for invalid `extra_context` overrides

Tests:
- `uv run --isolated --group lint -- ruff check cookiecutter/generate.py tests/test_generate_context.py`
- `uv run --isolated --group lint -- ruff format --check cookiecutter/generate.py tests/test_generate_context.py`
- `uv run --isolated --group test -- pytest tests/test_generate_context.py`

Fixes #2219
