### PR TITLE
generate: keep applying overrides after the first invalid one

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -62,65 +62,96 @@ def apply_overwrites_to_context(
     *,
     in_dictionary_variable: bool = False,
 ) -> None:
-    """Modify the given context in place based on the overwrite_context."""
-    for variable, overwrite in overwrite_context.items():
-        if variable not in context:
-            if not in_dictionary_variable:
-                # We are dealing with a new variable on first level, ignore
-                continue
-            # We are dealing with a new dictionary variable in a deeper level
-            context[variable] = overwrite
+    """Modify the given context in place based on the overwrite_context.
 
-        context_value = context[variable]
-        if isinstance(context_value, list):
-            if in_dictionary_variable:
-                context[variable] = overwrite
-                continue
-            if isinstance(overwrite, list):
-                # We are dealing with a multichoice variable
-                # Let's confirm all choices are valid for the given context
-                if set(overwrite).issubset(set(context_value)):
-                    context[variable] = overwrite
-                else:
-                    msg = (
-                        f"{overwrite} provided for multi-choice variable "
-                        f"{variable}, but valid choices are {context_value}"
-                    )
-                    raise ValueError(msg)
-            else:
-                # We are dealing with a choice variable
-                if overwrite in context_value:
-                    # This overwrite is actually valid for the given context
-                    # Let's set it as default (by definition first item in list)
-                    # see ``cookiecutter.prompt.prompt_choice_for_config``
-                    context_value.remove(overwrite)
-                    context_value.insert(0, overwrite)
-                else:
-                    msg = (
-                        f"{overwrite} provided for choice variable "
-                        f"{variable}, but the choices are {context_value}."
-                    )
-                    raise ValueError(msg)
-        elif isinstance(context_value, dict) and isinstance(overwrite, dict):
-            # Partially overwrite some keys in original dict
-            apply_overwrites_to_context(
-                context_value, overwrite, in_dictionary_variable=True
+    Each entry is applied independently. If any entries are invalid, the
+    valid ones are still applied and a single ValueError is raised at the
+    end listing every offending entry. Previously the first invalid entry
+    aborted the loop and silently dropped every subsequent override, so
+    bad config could leave the context in a partially-merged state with
+    no clear signal which entries were skipped (#2219).
+    """
+    errors: list[str] = []
+    for variable, overwrite in overwrite_context.items():
+        try:
+            _apply_overwrite(
+                context, variable, overwrite,
+                in_dictionary_variable=in_dictionary_variable,
             )
-            context[variable] = context_value
-        elif isinstance(context_value, bool) and isinstance(overwrite, str):
-            # We are dealing with a boolean variable
-            # Convert overwrite to its boolean counterpart
-            try:
-                context[variable] = YesNoPrompt().process_response(overwrite)
-            except InvalidResponse as err:
-                msg = (
-                    f"{overwrite} provided for variable "
-                    f"{variable} could not be converted to a boolean."
-                )
-                raise ValueError(msg) from err
-        else:
-            # Simply overwrite the value for this variable
+        except ValueError as err:
+            errors.append(str(err))
+
+    if errors:
+        if len(errors) == 1:
+            raise ValueError(errors[0])
+        raise ValueError("multiple invalid overrides:\n  " + "\n  ".join(errors))
+
+
+def _apply_overwrite(
+    context: dict[str, Any],
+    variable: str,
+    overwrite: Any,
+    *,
+    in_dictionary_variable: bool,
+) -> None:
+    """Apply a single overwrite entry to context. See apply_overwrites_to_context."""
+    if variable not in context:
+        if not in_dictionary_variable:
+            # We are dealing with a new variable on first level, ignore
+            return
+        # We are dealing with a new dictionary variable in a deeper level
+        context[variable] = overwrite
+
+    context_value = context[variable]
+    if isinstance(context_value, list):
+        if in_dictionary_variable:
             context[variable] = overwrite
+            return
+        if isinstance(overwrite, list):
+            # We are dealing with a multichoice variable
+            # Let's confirm all choices are valid for the given context
+            if set(overwrite).issubset(set(context_value)):
+                context[variable] = overwrite
+            else:
+                msg = (
+                    f"{overwrite} provided for multi-choice variable "
+                    f"{variable}, but valid choices are {context_value}"
+                )
+                raise ValueError(msg)
+        else:
+            # We are dealing with a choice variable
+            if overwrite in context_value:
+                # This overwrite is actually valid for the given context
+                # Let's set it as default (by definition first item in list)
+                # see ``cookiecutter.prompt.prompt_choice_for_config``
+                context_value.remove(overwrite)
+                context_value.insert(0, overwrite)
+            else:
+                msg = (
+                    f"{overwrite} provided for choice variable "
+                    f"{variable}, but the choices are {context_value}."
+                )
+                raise ValueError(msg)
+    elif isinstance(context_value, dict) and isinstance(overwrite, dict):
+        # Partially overwrite some keys in original dict
+        apply_overwrites_to_context(
+            context_value, overwrite, in_dictionary_variable=True
+        )
+        context[variable] = context_value
+    elif isinstance(context_value, bool) and isinstance(overwrite, str):
+        # We are dealing with a boolean variable
+        # Convert overwrite to its boolean counterpart
+        try:
+            context[variable] = YesNoPrompt().process_response(overwrite)
+        except InvalidResponse as err:
+            msg = (
+                f"{overwrite} provided for variable "
+                f"{variable} could not be converted to a boolean."
+            )
+            raise ValueError(msg) from err
+    else:
+        # Simply overwrite the value for this variable
+        context[variable] = overwrite
 
 
 def generate_context(

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -237,6 +237,31 @@ def test_apply_overwrites_error_additional_values(template_context) -> None:
         )
 
 
+# https://github.com/cookiecutter/cookiecutter/issues/2219
+def test_apply_overwrites_applies_valid_entries_after_invalid_one(template_context) -> None:
+    """Don't silently drop overrides that come after a bad one."""
+    with pytest.raises(ValueError) as excinfo:
+        generate.apply_overwrites_to_context(
+            context=template_context,
+            overwrite_context=OrderedDict(
+                [
+                    ('orientation', 'foobar'),  # invalid
+                    ('full_name', 'Charlie'),  # valid
+                    ('deployment_regions', ['na']),  # invalid
+                ]
+            ),
+        )
+
+    # Valid overrides should still have been applied in place.
+    assert template_context['full_name'] == 'Charlie'
+    # Choice list shouldn't have been reordered for the bad orientation.
+    assert template_context['orientation'][0] == 'all'
+    # Both invalid entries should show up in the aggregated error.
+    msg = str(excinfo.value)
+    assert 'orientation' in msg
+    assert 'deployment_regions' in msg
+
+
 def test_apply_overwrites_in_dictionaries(template_context) -> None:
     """Verify variable overwrite for lists nested in dictionary variables."""
     generate.apply_overwrites_to_context(


### PR DESCRIPTION
Closes #2219.

`apply_overwrites_to_context` raised on the first invalid entry, so any later overrides in the same `default_context` (or `extra_context`) dict got silently dropped. With `default_context` the `ValueError` is downgraded to a single warning in `generate_context`, which only names the failing variable — users see one warning, the generated project has a confusing mix of overridden and default values, and there's no way to find out which other overrides were skipped.

Now each entry is applied independently. Valid ones still take effect in place; invalid ones get collected and the function raises a single `ValueError` at the end listing every offender (or just the one if only one failed). `extra_context`'s hard-fail behavior is preserved, just with all the error info instead of only the first.

Refactored the per-entry logic into a small helper `_apply_overwrite` so the outer loop can wrap each call in try/except cleanly. No public API change.

Regression test feeds three entries (invalid, valid, invalid) and asserts the valid one applied while the error message names both bad keys.