### PR TITLE
Handle unhashable values in choice prompt labels

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -80,6 +80,18 @@ def read_user_yes_no(var_name, default_value, prompts=None, prefix: str = ""):
     return YesNoPrompt.ask(f"{prefix}{question}", default=default_value)
 
 
+def _choice_prompt_label(prompt_labels: dict, value):
+    try:
+        return prompt_labels[value]
+    except (KeyError, TypeError):
+        return prompt_labels.get(str(value), value)
+
+
+def _choice_prompt_line(index: str, prompt_labels: dict, value):
+    label = _choice_prompt_label(prompt_labels, value)
+    return f"    [bold magenta]{index}[/] - [bold]{label}[/]"
+
+
 def read_repo_password(question: str) -> str:
     """Prompt the user to enter a password.
 
@@ -111,16 +123,14 @@ def read_user_choice(var_name: str, options: list, prompts=None, prefix: str = "
 
     # Handle if human-readable prompt is provided
     if prompts and var_name in prompts:
-        if isinstance(prompts[var_name], str):
-            question = prompts[var_name]
+        prompt_labels = prompts[var_name]
+        if isinstance(prompt_labels, str):
+            question = prompt_labels
         else:
-            if "__prompt__" in prompts[var_name]:
-                question = prompts[var_name]["__prompt__"]
+            if "__prompt__" in prompt_labels:
+                question = prompt_labels["__prompt__"]
             choice_lines = (
-                f"    [bold magenta]{i}[/] - [bold]{prompts[var_name][p]}[/]"
-                if p in prompts[var_name]
-                else f"    [bold magenta]{i}[/] - [bold]{p}[/]"
-                for i, p in choice_map.items()
+                _choice_prompt_line(i, prompt_labels, p) for i, p in choice_map.items()
             )
 
     prompt = '\n'.join(

--- a/tests/test_read_user_choice.py
+++ b/tests/test_read_user_choice.py
@@ -36,3 +36,24 @@ def test_raise_if_options_is_not_a_non_empty_list() -> None:
     """
     with pytest.raises(ValueError):
         read_user_choice('foo', [])
+
+
+def test_human_prompt_labels_support_unhashable_options(mocker) -> None:
+    """Verify custom choice labels work when options are dicts or lists."""
+    options = [{'provider': 'aws'}, ['gcp', 'central']]
+    prompt_labels = {
+        str(options[0]): "AWS East",
+        str(options[1]): "GCP Central",
+        "__prompt__": "Select cloud config",
+    }
+    expected_prompt = """Select cloud config
+    [bold magenta]1[/] - [bold]AWS East[/]
+    [bold magenta]2[/] - [bold]GCP Central[/]
+    Choose from"""
+
+    prompt = mocker.patch('rich.prompt.Prompt.ask')
+    prompt.return_value = '2'
+
+    assert read_user_choice('cloud', options, {'cloud': prompt_labels}) == options[1]
+
+    prompt.assert_called_once_with(expected_prompt, choices=['1', '2'], default='1')


### PR DESCRIPTION
Fixes #2187.

This keeps the existing choice-label lookup for hashable option values, and falls back to string keys when an option value cannot be used as a mapping key. That allows dict/list choices to render custom labels from `__prompts__` without crashing before the prompt is shown.

Tests:
- `uv run --python=3.13 --isolated --group test -- pytest tests/test_read_user_choice.py -q`
- `uv run --python=3.13 --isolated --group test -- pytest -q`
- `uv run --python=3.13 --isolated --group lint -- ruff check --no-fix .`
- `uv run --python=3.13 --isolated --group lint -- ruff format --check cookiecutter/prompt.py tests/test_read_user_choice.py`
- `git diff --check`

Note: `ruff format --check .` still reports formatting changes in four untouched files: `cookiecutter/hooks.py`, `tests/test_cli.py`, `tests/test_generate_copy_without_render.py`, and `tests/test_generate_copy_without_render_override.py`.