### PR TITLE
Fix: force_delete now adds read+execute permissions, not just write

### DIFF
--- a/cookiecutter/utils.py
+++ b/cookiecutter/utils.py
@@ -28,7 +28,7 @@ def force_delete(func, path, _exc_info) -> None:  # type: ignore[no-untyped-def]
     Usage: `shutil.rmtree(path, onerror=force_delete)`
     From https://docs.python.org/3/library/shutil.html#rmtree-example
     """
-    os.chmod(path, stat.S_IWRITE)
+    os.chmod(path, stat.S_IWRITE | stat.S_IREAD | stat.S_IEXEC)
     func(path)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,7 +24,7 @@ def test_force_delete(mocker, tmp_path) -> None:
     rmtree = mocker.Mock()
     utils.force_delete(rmtree, ro_file, sys.exc_info())
 
-    assert (ro_file.stat().st_mode & stat.S_IWRITE) == stat.S_IWRITE
+    assert (ro_file.stat().st_mode & stat.S_IRWXU) == stat.S_IRWXU
     rmtree.assert_called_once_with(ro_file)
 
     utils.rmtree(tmp_path)


### PR DESCRIPTION
## Summary

`force_delete()` in `cookiecutter/utils.py` sets `os.chmod(path, stat.S_IWRITE)` when `shutil.rmtree` encounters a permission error. On Unix, `S_IWRITE` is only `0o200` (owner-write), which is insufficient for directories: removing directory entries requires execute permission on the directory itself.

## Impact

When cookiecutter copies template files from a read-only source (e.g., Nix store) into a temp directory, the copied directory can end up with restrictive permissions (`d-w-------`). `shutil.rmtree` fails to clean it up because:
1. Without read permission, `scandir()` can't list directory contents
2. Without execute permission, `unlink()`/`rmdir()` can't access entries

This causes `PermissionError` during cleanup (issue #2217).

## Fix

Changed `os.chmod(path, stat.S_IWRITE)` to `os.chmod(path, stat.S_IWRITE | stat.S_IREAD | stat.S_IEXEC)`, which sets owner read-write-execute permissions (`rwx------`, 0o700). This is sufficient for both files and directories.

Fixes #2217