### PR TITLE
docs: Add Windows Git Bash prerequisite to installation guide

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,6 +6,7 @@ Prerequisites
 -------------
 
 * Python interpreter
+* Git
 * Adjust your path
 * Packaging tools
 
@@ -24,6 +25,16 @@ Alternatively on macOS, you can use the `homebrew <http://brew.sh/>`_ package ma
 
     brew install python3
 
+
+Git
+^^^
+
+Cookiecutter uses Git to clone templates from remote repositories.
+Install Git from `git-scm.com <https://git-scm.com/downloads>`_.
+
+On Windows, use **Git Bash** (installed with Git for Windows) to run
+Cookiecutter commands. Running from Command Prompt (``cmd.exe``) may fail
+because it cannot find the ``git`` command.
 
 Adjust your path
 ^^^^^^^^^^^^^^^^

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -36,7 +36,19 @@ file to escape entire files and directories.
 Other common issues
 -------------------
 
-TODO: add a bunch of common new user issues here.
+I see ``CalledProcessError`` or ``'git' returned non-zero exit status`` on Windows
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you run Cookiecutter from Windows Command Prompt (``cmd.exe``) and see an error like::
+
+    subprocess.CalledProcessError: Command '['git', 'clone', '...']' returned non-zero exit status 128
+
+This means ``cmd.exe`` cannot find the ``git`` command. Use **Git Bash**
+(included with `Git for Windows <https://git-scm.com/downloads>`_) to run
+Cookiecutter commands instead.
+
+Alternatively, add Git to your system ``PATH`` environment variable and restart
+your command prompt.
 
 This document is incomplete. If you have knowledge that could help other users,
 adding a section or filing an issue with details would be greatly appreciated.


### PR DESCRIPTION
## Summary
- Add Git as a prerequisite in installation documentation
- Warn Windows users to use Git Bash instead of cmd.exe to avoid `'git' returned non-zero exit status 128` error
- Add troubleshooting entry for the Windows cmd.exe `CalledProcessError` with solution

## Related Issue
Closes #1280

## Changes
- `docs/installation.rst`: Added "Git" prerequisite section between "Python interpreter" and "Adjust your path", with Windows-specific Git Bash guidance
- `docs/troubleshooting.rst`: Added "I see `CalledProcessError` on Windows" section with error message and fix instructions

## Test plan
- [ ] Verify docs build correctly with `make html` in docs directory
- [ ] Check rendered output shows Git Bash warning under Windows section