### PR TITLE
Add env() Jinja extension for environment variable access in templates

### DIFF
--- a/cookiecutter/environment.py
+++ b/cookiecutter/environment.py
@@ -28,6 +28,7 @@ class ExtensionLoaderMixin:
         context = context or {}
 
         default_extensions = [
+            'cookiecutter.extensions.EnvExtension',
             'cookiecutter.extensions.JsonifyExtension',
             'cookiecutter.extensions.RandomStringExtension',
             'cookiecutter.extensions.SlugifyExtension',

--- a/cookiecutter/extensions.py
+++ b/cookiecutter/extensions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import string
 import uuid
 from collections.abc import Iterable
@@ -173,3 +174,31 @@ class TimeExtension(Extension):
                 lineno=lineno,
             )
         return nodes.Output([call_method], lineno=lineno)
+
+
+class EnvExtension(Extension):
+    """Jinja2 Extension to read environment variables inside templates.
+
+    Provides a global ``env(name, default=None)`` callable that returns
+    the value of the environment variable ``name``, or ``default`` if it
+    is not set. An explicitly empty string is returned as-is (it is not
+    treated the same as "unset").
+
+    Usage in ``cookiecutter.json``:
+
+        {
+            "author_name": "{{ env('USER', 'Anonymous') }}",
+            "author_email": "{{ env('EMAIL') }}"
+        }
+
+    See https://github.com/cookiecutter/cookiecutter/issues/2045.
+    """
+
+    def __init__(self, environment: Environment) -> None:
+        """Initialize the extension and register the ``env`` global."""
+        super().__init__(environment)
+
+        def env(name: str, default: str | None = None) -> str | None:
+            return os.environ.get(name, default)
+
+        environment.globals.update(env=env)

--- a/tests/test_env_extension.py
+++ b/tests/test_env_extension.py
@@ -1,0 +1,109 @@
+"""Tests for cookiecutter.env() Jinja extension (issue #2045).
+
+The env() global is exposed by EnvExtension. It lets users reference
+environment variables inside ``cookiecutter.json`` and template strings,
+e.g.::
+
+    {
+        "author_name": "{{ env('USER', 'Default Name') }}",
+        "author_email": "{{ env('EMAIL') }}"
+    }
+
+These are evaluated by the same render path that already handles things
+like ``{{ cookiecutter.project_name.lower() }}`` in cookiecutter.json
+— see ``cookiecutter.prompt.render_variable``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from cookiecutter import generate
+from cookiecutter.prompt import render_variable
+from cookiecutter.utils import create_env_with_context
+
+
+@pytest.fixture
+def template_dir(tmp_path):
+    """Minimal template that uses cookiecutter's two-stage rendering.
+
+    Stage 1: context values are rendered (e.g. {{ env('USER') }})
+    Stage 2: template files reference context values
+    """
+    project = tmp_path / "{{cookiecutter.project_name}}"
+    project.mkdir()
+    (project / "README.rst").write_text(
+        "{{ cookiecutter.project_name }} — "
+        "{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>"
+    )
+    return tmp_path
+
+
+def _build_context():
+    """Render context values the way cookiecutter does after prompts.
+
+    Cookiecutter's prompt flow goes through ``cookiecutter.prompt.render_variable``
+    for every value coming out of cookiecutter.json, which renders each value
+    in the Jinja environment. We simulate that here so the test exercises
+    the same code path that real users hit.
+    """
+    raw = {
+        "project_name": "Hello",
+        "author_name": "{{ env('TEST_AUTHOR', 'Default Name') }}",
+        "author_email": "{{ env('TEST_EMAIL') }}",
+    }
+    env = create_env_with_context({"cookiecutter": raw})
+    return {k: render_variable(env, v, raw) for k, v in raw.items()}
+
+
+def test_env_returns_value_when_set(template_dir, monkeypatch):
+    monkeypatch.setenv("TEST_AUTHOR", "Rachel")
+    monkeypatch.setenv("TEST_EMAIL", "rachel@example.com")
+    out = template_dir / "out1"
+    ctx = _build_context()
+    project_dir = generate.generate_files(
+        context={"cookiecutter": ctx},
+        repo_dir=str(template_dir),
+        output_dir=str(out),
+        overwrite_if_exists=True,
+    )
+    readme = (Path(project_dir) / "README.rst").read_text()
+    assert "Rachel" in readme
+    assert "rachel@example.com" in readme
+
+
+def test_env_returns_default_when_unset(template_dir, monkeypatch):
+    monkeypatch.delenv("TEST_AUTHOR", raising=False)
+    monkeypatch.delenv("TEST_EMAIL", raising=False)
+    out = template_dir / "out2"
+    ctx = _build_context()
+    project_dir = generate.generate_files(
+        context={"cookiecutter": ctx},
+        repo_dir=str(template_dir),
+        output_dir=str(out),
+        overwrite_if_exists=True,
+    )
+    readme = (Path(project_dir) / "README.rst").read_text()
+    assert "Default Name" in readme
+    assert "<None>" in readme
+
+
+def test_env_empty_string_is_returned_not_treated_as_unset(template_dir, monkeypatch):
+    monkeypatch.setenv("TEST_AUTHOR", "")
+    monkeypatch.delenv("TEST_EMAIL", raising=False)
+    out = template_dir / "out3"
+    ctx = _build_context()
+    project_dir = generate.generate_files(
+        context={"cookiecutter": ctx},
+        repo_dir=str(template_dir),
+        output_dir=str(out),
+        overwrite_if_exists=True,
+    )
+    readme = (Path(project_dir) / "README.rst").read_text()
+    # Empty string is returned, not None, not "Default Name"
+    assert "—  <" in readme
+    assert "Default Name" not in readme
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Implements #2045 — let users read environment variables inside cookiecutter.json and template strings.

## Feature

Add a new `EnvExtension` that registers a global `env(name, default)` callable. Returns the value of the named environment variable, falling back to `default` if unset. Empty strings are returned as-is.

## Usage

In `cookiecutter.json`:

```json
{
  "author_name": "{{ env('USER', 'Anonymous') }}",
  "author_email": "{{ env('EMAIL') }}"
}
```

The extension is registered as a default (alongside JsonifyExtension, TimeExtension, etc.), so users get it for free with no opt-in.

## API choice: global vs cookiecutter.method

I went with the global form `{{ env('VAR') }}` rather than `{{ cookiecutter.env('VAR') }}` (as suggested in the issue) because:

1. cookiecutter's context['cookiecutter'] is a plain dict, not a namespace object — adding a method to it would require invasive changes
2. the global form matches existing built-ins like `{{ uuid4() }}` and `{{ random_ascii_string() }}` already shipped in `extensions.py`

If maintainers prefer the dotted form, the extension can be moved into the namespace layer — happy to adjust.

## Tests

`tests/test_env_extension.py` covers three cases:
- env returns value when set
- env returns default when unset
- env returns empty string (not default) when var is set to ''

Full test suite: 381 passed, 4 skipped, 1 deselected (subprocess test affected by sandbox PYTHONPATH, unrelated to this change).

Closes #2045
Refs: AI-2138