### PR TITLE
fix: collect all overwrite errors instead of stopping at first invalid entry

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -62,7 +62,14 @@ def apply_overwrites_to_context(
     *,
     in_dictionary_variable: bool = False,
 ) -> None:
-    """Modify the given context in place based on the overwrite_context."""
+    """Modify the given context in place based on the overwrite_context.
+
+    Collects validation errors from all entries instead of stopping at the
+    first invalid one. This ensures that later entries in the overwrite
+    dictionary are still processed even when an earlier one fails.
+    """
+    errors: list[str] = []
+
     for variable, overwrite in overwrite_context.items():
         if variable not in context:
             if not in_dictionary_variable:
@@ -82,11 +89,10 @@ def apply_overwrites_to_context(
                 if set(overwrite).issubset(set(context_value)):
                     context[variable] = overwrite
                 else:
-                    msg = (
+                    errors.append(
                         f"{overwrite} provided for multi-choice variable "
                         f"{variable}, but valid choices are {context_value}"
                     )
-                    raise ValueError(msg)
             else:
                 # We are dealing with a choice variable
                 if overwrite in context_value:
@@ -96,31 +102,39 @@ def apply_overwrites_to_context(
                     context_value.remove(overwrite)
                     context_value.insert(0, overwrite)
                 else:
-                    msg = (
+                    errors.append(
                         f"{overwrite} provided for choice variable "
                         f"{variable}, but the choices are {context_value}."
                     )
-                    raise ValueError(msg)
         elif isinstance(context_value, dict) and isinstance(overwrite, dict):
             # Partially overwrite some keys in original dict
-            apply_overwrites_to_context(
-                context_value, overwrite, in_dictionary_variable=True
-            )
+            try:
+                apply_overwrites_to_context(
+                    context_value, overwrite, in_dictionary_variable=True
+                )
+            except ValueError as nested_err:
+                # Prefix nested errors with the parent variable name so
+                # users can trace which sub-key the error came from.
+                errors.extend(
+                    f"{variable}: {line}" for line in str(nested_err).split("; ")
+                )
             context[variable] = context_value
         elif isinstance(context_value, bool) and isinstance(overwrite, str):
             # We are dealing with a boolean variable
             # Convert overwrite to its boolean counterpart
             try:
                 context[variable] = YesNoPrompt().process_response(overwrite)
-            except InvalidResponse as err:
-                msg = (
+            except InvalidResponse:
+                errors.append(
                     f"{overwrite} provided for variable "
                     f"{variable} could not be converted to a boolean."
                 )
-                raise ValueError(msg) from err
         else:
             # Simply overwrite the value for this variable
             context[variable] = overwrite
+
+    if errors:
+        raise ValueError("; ".join(errors))
 
 
 def generate_context(

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -388,3 +388,122 @@ def test_apply_overwrites_error_overwrite_value_as_boolean_string():
     overwrite_context = {'key': 'invalid'}
     with pytest.raises(ValueError):
         generate.apply_overwrites_to_context(context, overwrite_context)
+
+
+def test_apply_overwrites_continues_after_invalid_entry(template_context) -> None:
+    """Valid entries after an invalid one are still applied.
+
+    Regression test for gh-2219: the first invalid entry used to raise
+    ValueError immediately, causing every subsequent (potentially valid)
+    entry in the overwrite dict to be silently dropped.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        generate.apply_overwrites_to_context(
+            context=template_context,
+            overwrite_context={
+                # Invalid choice — should be collected, not raised immediately
+                'orientation': 'foobar',
+                # Valid overwrite — MUST still be applied
+                'repo_name': 'should-be-applied',
+            },
+        )
+    # The valid entry should have been applied before the error is raised
+    assert template_context['repo_name'] == 'should-be-applied'
+    # The error message should mention the offending variable
+    assert 'orientation' in str(excinfo.value)
+
+
+def test_apply_overwrites_collects_all_errors() -> None:
+    """All invalid entries are reported, not just the first one."""
+    context = OrderedDict(
+        [
+            ('choice_var', ['a', 'b', 'c']),
+            ('multi_var', ['x', 'y', 'z']),
+            ('bool_var', False),
+        ]
+    )
+    with pytest.raises(ValueError) as excinfo:
+        generate.apply_overwrites_to_context(
+            context=context,
+            overwrite_context={
+                'choice_var': 'invalid',
+                'multi_var': ['w'],
+                'bool_var': 'not-a-bool',
+            },
+        )
+    msg = str(excinfo.value)
+    assert 'choice_var' in msg
+    assert 'multi_var' in msg
+    assert 'bool_var' in msg
+
+
+def test_apply_overwrites_nested_error_collection() -> None:
+    """Errors from nested dict entries are collected with parent prefix."""
+    context = OrderedDict(
+        [
+            ('key1', 'value1'),
+            (
+                'nested',
+                OrderedDict(
+                    [
+                        ('bool_a', True),
+                        ('bool_b', False),
+                    ]
+                ),
+            ),
+        ]
+    )
+    with pytest.raises(ValueError) as excinfo:
+        generate.apply_overwrites_to_context(
+            context=context,
+            overwrite_context={
+                'nested': {
+                    'bool_a': 'invalid-a',
+                    'bool_b': 'invalid-b',
+                },
+            },
+        )
+    msg = str(excinfo.value)
+    # Both nested errors should be reported with the parent prefix
+    assert 'nested:' in msg
+    assert 'bool_a' in msg
+    assert 'bool_b' in msg
+
+
+def test_apply_overwrites_no_error_when_all_valid(template_context) -> None:
+    """No exception is raised when all overwrites are valid."""
+    generate.apply_overwrites_to_context(
+        context=template_context,
+        overwrite_context={
+            'repo_name': 'new-repo',
+            'orientation': 'landscape',
+        },
+    )
+    assert template_context['repo_name'] == 'new-repo'
+    # orientation should be moved to front (choice variable default)
+    assert template_context['orientation'][0] == 'landscape'
+
+
+def test_generate_context_reports_all_invalid_defaults() -> None:
+    """generate_context warns about all invalid default_context entries,
+    not just the first one, and still applies valid entries that follow."""
+    with pytest.warns(UserWarning, match="Invalid default received") as record:
+        generated = generate.generate_context(
+            context_file='tests/test-generate-context/choices_template.json',
+            default_context={
+                # Valid — should be applied
+                'project_name': 'Kivy Project',
+                # Invalid choice — should warn but not block later entries
+                'orientation': 'foobar',
+                # Valid — should still be applied since the loop no longer
+                # exits early on the previous invalid entry
+                'github_username': 'rayman',
+            },
+        )
+    # Only one warning (combined message) should be emitted
+    assert len(record) == 1
+    warning_msg = str(record[0].message)
+    assert 'orientation' in warning_msg
+    # Valid entries before AND after the invalid one should be applied
+    assert generated['choices_template']['project_name'] == 'Kivy Project'
+    assert generated['choices_template']['github_username'] == 'rayman'


### PR DESCRIPTION
## Summary

Fixes #2219: `apply_overwrites_to_context` now collects validation errors from **all** entries instead of raising on the first invalid one. Valid entries after an invalid one are no longer silently dropped.

## Problem

When `default_context` (from `~/.cookiecutterrc`) contains multiple overrides and one fails validation, every subsequent entry is silently discarded. For example:

```yaml
default_context:
  full_name: "valid"
  orientation: "invalid"    # ← raises, loop exits
  project_slug: "valid"     # ← silently dropped!
```

The generated project ends up with a mix of user-set and default values, with no indication which overrides were lost.

## Fix

- `apply_overwrites_to_context` accumulates errors in a list instead of raising immediately
- After the loop completes, all errors are raised as a single combined `ValueError`
- For nested dict overrides, errors are prefixed with the parent variable name
- `generate_context` still catches the ValueError and issues a single `UserWarning`

## AI Assistance Disclosure

This contribution was developed with AI assistance (Claude / Anthropic Claude Code).

## Verification Process

1. Forked → cloned to local sandbox (`~/sandbox/cookiecutter/`)
2. `uv sync --group dev` installed all dependencies
3. Ran existing test suite: 377 passed, 6 skipped (×3 for flaky detection)
4. Applied fix (29 lines changed in `generate.py`)
5. Added 5 targeted tests covering:
   - Valid entry after invalid entry is still applied
   - All errors are collected in a single message
   - Nested dict errors are prefixed with parent variable
   - No exception when all entries are valid
   - `generate_context` reports all invalid defaults
6. Full test suite: 382 passed, 6 skipped, 0 failures
7. `ruff format` + `ruff check`: all clean

## Cross-Validation

| Scenario | Before | After |
|----------|--------|-------|
| All entries valid | ✅ | ✅ |
| Single invalid entry | ⚠️ raises immediately | ✅ collected, reported |
| Invalid entry before valid entry | ❌ valid dropped | ✅ valid applied |
| Multiple invalid entries | ❌ only first reported | ✅ all reported |
| Nested dict errors | ❌ first only | ✅ all, with parent prefix |
| `extra_context` (hard failure) | ✅ | ✅ (all errors raised) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)