### PR TITLE
fix: collect all invalid default_context errors instead of failing on first

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -63,6 +63,7 @@ def apply_overwrites_to_context(
     in_dictionary_variable: bool = False,
 ) -> None:
     """Modify the given context in place based on the overwrite_context."""
+    errors: list[str] = []
     for variable, overwrite in overwrite_context.items():
         if variable not in context:
             if not in_dictionary_variable:
@@ -86,7 +87,7 @@ def apply_overwrites_to_context(
                         f"{overwrite} provided for multi-choice variable "
                         f"{variable}, but valid choices are {context_value}"
                     )
-                    raise ValueError(msg)
+                    errors.append(msg)
             else:
                 # We are dealing with a choice variable
                 if overwrite in context_value:
@@ -100,7 +101,7 @@ def apply_overwrites_to_context(
                         f"{overwrite} provided for choice variable "
                         f"{variable}, but the choices are {context_value}."
                     )
-                    raise ValueError(msg)
+                    errors.append(msg)
         elif isinstance(context_value, dict) and isinstance(overwrite, dict):
             # Partially overwrite some keys in original dict
             apply_overwrites_to_context(
@@ -117,10 +118,13 @@ def apply_overwrites_to_context(
                     f"{overwrite} provided for variable "
                     f"{variable} could not be converted to a boolean."
                 )
-                raise ValueError(msg) from err
+                errors.append(msg)
         else:
             # Simply overwrite the value for this variable
             context[variable] = overwrite
+
+    if errors:
+        raise ValueError("\n".join(errors))
 
 
 def generate_context(

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -113,7 +113,7 @@ def apply_overwrites_to_context(
             # Convert overwrite to its boolean counterpart
             try:
                 context[variable] = YesNoPrompt().process_response(overwrite)
-            except InvalidResponse as err:
+            except InvalidResponse:
                 msg = (
                     f"{overwrite} provided for variable "
                     f"{variable} could not be converted to a boolean."


### PR DESCRIPTION
## What?

Changed `apply_overwrites_to_context` to collect all invalid override errors instead of raising `ValueError` on the first one and silently dropping subsequent entries.

## Why?

When `default_context` contains multiple invalid overrides, only the first error was reported. All remaining overrides were silently discarded, producing a partial config merge without indication of which values were lost.

## How?

- Replaced immediate `raise ValueError(...)` with `errors.append(msg)`
- Continue processing remaining overrides after collecting an error
- Raise a single `ValueError` with all error messages joined by newlines after the loop

Closes #2219