### PR TITLE
Update coding standards in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,8 +135,13 @@ Before you submit a pull request, check that it meets these guidelines:
 
 ### Coding Standards
 
-- PEP8
-- Functions over classes except in tests
+- Follow [PEP 8](https://peps.python.org/pep-0008/)
+- Default to functions over classes for new code
+- Use classes when appropriate—for example, Jinja2 extensions, custom exceptions, framework subclasses, grouping tests in classes, or context managers
+- Do not add classes solely to namespace functions; use modules instead
+- Prefer `pathlib.Path` over string paths for file system operations
+- On Windows, use `Path` methods (for example, `Path.read_text()`) rather than assuming POSIX path behavior
+- In tests, use the `tmp_path` fixture; avoid the legacy `tmpdir` fixture
 - Quotes via [http://stackoverflow.com/a/56190/5549](http://stackoverflow.com/a/56190/5549)
 
   - Use double quotes around strings that are used for interpolation or that are natural language messages


### PR DESCRIPTION
## Summary
- Expands the **Coding Standards** section in `CONTRIBUTING.md` to replace the outdated "Functions over classes except in tests" rule
- Clarifies when classes are appropriate (Jinja2 extensions, exceptions, framework subclasses, test class groupings, context managers)
- Adds maintainer-requested guidance on `pathlib.Path`, Windows path handling, and the `tmp_path` pytest fixture

Closes #1214

## Test plan
- [x] Docs-only change — no code or tests modified
- [x] Verified diff is limited to the Coding Standards section of `CONTRIBUTING.md`