### PR TITLE
Preserve cached templates when refresh fails

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -403,7 +403,9 @@ def choose_nested_template(
     return f"{template_path}"
 
 
-def prompt_and_delete(path: Path | str, no_input: bool = False) -> bool:
+def prompt_and_delete(
+    path: Path | str, no_input: bool = False, delete: bool = True
+) -> bool:
     """
     Ask user if it's okay to delete the previously-downloaded file/directory.
 
@@ -412,7 +414,8 @@ def prompt_and_delete(path: Path | str, no_input: bool = False) -> bool:
 
     :param path: Previously downloaded zipfile.
     :param no_input: Suppress prompt to delete repo and just delete it.
-    :return: True if the content was deleted
+    :param delete: Delete the content after the user approves the refresh.
+    :return: True if the refresh was approved.
     """
     # Suppress prompt if called via API
     if no_input:
@@ -425,10 +428,11 @@ def prompt_and_delete(path: Path | str, no_input: bool = False) -> bool:
         ok_to_delete = read_user_yes_no(question, 'yes')
 
     if ok_to_delete:
-        if os.path.isdir(path):
-            rmtree(path)
-        else:
-            os.remove(path)
+        if delete:
+            if os.path.isdir(path):
+                rmtree(path)
+            else:
+                os.remove(path)
         return True
     ok_to_reuse = read_user_yes_no("Do you want to re-use the existing version?", 'yes')
 

--- a/cookiecutter/vcs.py
+++ b/cookiecutter/vcs.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING
@@ -97,15 +99,28 @@ def clone(
         repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))
     logger.debug(f'repo_dir is {repo_dir}')
 
-    if os.path.isdir(repo_dir):
-        clone = prompt_and_delete(repo_dir, no_input=no_input)
+    cached_repo = os.path.isdir(repo_dir)
+    if cached_repo:
+        clone = prompt_and_delete(repo_dir, no_input=no_input, delete=False)
     else:
         clone = True
 
     if clone:
+        temporary_dir = (
+            tempfile.TemporaryDirectory(dir=clone_to_dir) if cached_repo else None
+        )
         try:
+            if temporary_dir:
+                clone_parent = temporary_dir.name
+                cloned_repo_dir = os.path.normpath(
+                    os.path.join(clone_parent, repo_name)
+                )
+                clone_command = [repo_type, 'clone', repo_url, cloned_repo_dir]
+            else:
+                cloned_repo_dir = repo_dir
+                clone_command = [repo_type, 'clone', repo_url]
             subprocess.check_output(
-                [repo_type, 'clone', repo_url],
+                clone_command,
                 cwd=clone_to_dir,
                 stderr=subprocess.STDOUT,
             )
@@ -116,7 +131,7 @@ def clone(
                     checkout_params.insert(0, "--")
                 subprocess.check_output(
                     [repo_type, 'checkout', *checkout_params],
-                    cwd=repo_dir,
+                    cwd=cloned_repo_dir,
                     stderr=subprocess.STDOUT,
                 )
         except subprocess.CalledProcessError as clone_error:
@@ -135,5 +150,17 @@ def clone(
                 raise RepositoryCloneFailed(msg) from clone_error
             logger.exception('git clone failed with error: %s', output)
             raise
+        else:
+            if temporary_dir:
+                backup_repo_dir = os.path.join(temporary_dir.name, 'previous-repo')
+                shutil.move(repo_dir, backup_repo_dir)
+                try:
+                    shutil.move(cloned_repo_dir, repo_dir)
+                except BaseException:
+                    shutil.move(backup_repo_dir, repo_dir)
+                    raise
+        finally:
+            if temporary_dir:
+                temporary_dir.cleanup()
 
     return repo_dir

--- a/tests/vcs/test_clone.py
+++ b/tests/vcs/test_clone.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -162,6 +163,65 @@ def test_clone_handles_repo_typo(mocker, clone_dir, error_message) -> None:
     assert str(err.value) == (
         f'The repository {repository_url} could not be found, have you made a typo?'
     )
+
+
+def test_clone_failure_keeps_existing_repo(mocker, clone_dir) -> None:
+    """A failed refresh must not delete the cached repository."""
+    repo_dir = clone_dir.joinpath('cookiedozer')
+    repo_dir.mkdir()
+    marker = repo_dir.joinpath('cookiecutter.json')
+    marker.write_text('{"project_name": "cached"}')
+    mocker.patch('cookiecutter.vcs.is_vcs_installed', autospec=True, return_value=True)
+    mocker.patch(
+        'cookiecutter.vcs.subprocess.check_output',
+        autospec=True,
+        side_effect=subprocess.CalledProcessError(
+            -1,
+            'cmd',
+            output=(
+                b"fatal: repository 'https://github.com/hackebro/cookiedozer' not found"
+            ),
+        ),
+    )
+
+    with pytest.raises(exceptions.RepositoryNotFound):
+        vcs.clone(
+            'https://github.com/hackebro/cookiedozer',
+            clone_to_dir=str(clone_dir),
+            no_input=True,
+        )
+
+    assert marker.read_text() == '{"project_name": "cached"}'
+
+
+def test_clone_replaces_existing_repo_after_success(mocker, clone_dir) -> None:
+    """A successful refresh replaces the cached repository."""
+    repo_dir = clone_dir.joinpath('cookiedozer')
+    repo_dir.mkdir()
+    marker = repo_dir.joinpath('cookiecutter.json')
+    marker.write_text('{"project_name": "cached"}')
+    mocker.patch('cookiecutter.vcs.is_vcs_installed', autospec=True, return_value=True)
+
+    def clone_to_staging(command, **_kwargs) -> None:
+        staged_repo = Path(command[-1])
+        staged_repo.mkdir()
+        staged_repo.joinpath('cookiecutter.json').write_text(
+            '{"project_name": "refreshed"}'
+        )
+
+    mocker.patch(
+        'cookiecutter.vcs.subprocess.check_output',
+        autospec=True,
+        side_effect=clone_to_staging,
+    )
+
+    vcs.clone(
+        'https://github.com/hackebro/cookiedozer',
+        clone_to_dir=str(clone_dir),
+        no_input=True,
+    )
+
+    assert marker.read_text() == '{"project_name": "refreshed"}'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #2232.

Refreshing a cached VCS template no longer deletes the cache before the replacement clone has succeeded. When a cache is present, Cookiecutter now clones and checks out the replacement in a sibling temporary directory, then swaps it into place only after those operations complete. If the replacement move fails, the original cache is restored.

This preserves the existing confirmation and `--no-input` refresh behavior while preventing a failed clone (including a typo or unavailable repository) from destroying a usable cached template.

## Tests

- `python -m pytest -q` (379 passed, 6 skipped on Windows)
- `python -m ruff check .`
- `python -m ruff format --check cookiecutter/prompt.py cookiecutter/vcs.py tests/vcs/test_clone.py`
- `git diff --check`