### PR TITLE
Fix pytest parametrize iterator deprecation warnings

### DIFF
--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -15,45 +15,47 @@ from cookiecutter.exceptions import ContextDecodingException
 from cookiecutter.prompt import YesNoPrompt
 
 
-def context_data() -> Iterator[tuple[dict[str, Any], dict[str, Any]]]:
+def context_data() -> list[tuple[dict[str, Any], dict[str, Any]]]:
     """Generate pytest parametrization variables for test.
 
     Return ('input_params, expected_context') tuples.
     """
     context = (
-        {'context_file': 'tests/test-generate-context/test.json'},
-        {'test': {'1': 2, 'some_key': 'some_val'}},
+        {"context_file": "tests/test-generate-context/test.json"},
+        {"test": {"1": 2, "some_key": "some_val"}},
     )
 
     context_with_default = (
         {
-            'context_file': 'tests/test-generate-context/test.json',
-            'default_context': {'1': 3},
+            "context_file": "tests/test-generate-context/test.json",
+            "default_context": {"1": 3},
         },
-        {'test': {'1': 3, 'some_key': 'some_val'}},
+        {"test": {"1": 3, "some_key": "some_val"}},
     )
 
     context_with_extra = (
         {
-            'context_file': 'tests/test-generate-context/test.json',
-            'extra_context': {'1': 4},
+            "context_file": "tests/test-generate-context/test.json",
+            "extra_context": {"1": 4},
         },
-        {'test': {'1': 4, 'some_key': 'some_val'}},
+        {"test": {"1": 4, "some_key": "some_val"}},
     )
 
     context_with_default_and_extra = (
         {
-            'context_file': 'tests/test-generate-context/test.json',
-            'default_context': {'1': 3},
-            'extra_context': {'1': 5},
+            "context_file": "tests/test-generate-context/test.json",
+            "default_context": {"1": 3},
+            "extra_context": {"1": 5},
         },
-        {'test': {'1': 5, 'some_key': 'some_val'}},
+        {"test": {"1": 5, "some_key": "some_val"}},
     )
 
-    yield context
-    yield context_with_default
-    yield context_with_extra
-    yield context_with_default_and_extra
+    return [
+        context,
+        context_with_default,
+        context_with_extra,
+        context_with_default_and_extra,
+    ]
 
 
 @pytest.mark.usefixtures('clean_system')

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -57,7 +57,7 @@ def context_data() -> Iterator[tuple[dict[str, Any], dict[str, Any]]]:
 
 
 @pytest.mark.usefixtures('clean_system')
-@pytest.mark.parametrize('input_params, expected_context', context_data())
+@pytest.mark.parametrize('input_params, expected_context', list(context_data()))
 def test_generate_context(input_params, expected_context) -> None:
     """Verify input contexts combinations result in expected content on output."""
     assert generate.generate_context(**input_params) == expected_context

--- a/tests/test_read_user_choice.py
+++ b/tests/test_read_user_choice.py
@@ -15,7 +15,7 @@ EXPECTED_PROMPT = """Select varname
     Choose from"""
 
 
-@pytest.mark.parametrize('user_choice, expected_value', enumerate(OPTIONS, 1))
+@pytest.mark.parametrize('user_choice, expected_value', list(enumerate(OPTIONS, 1)))
 def test_click_invocation(mocker, user_choice, expected_value) -> None:
     """Test click function called correctly by cookiecutter.
 

--- a/tests/test_read_user_choice.py
+++ b/tests/test_read_user_choice.py
@@ -15,18 +15,25 @@ EXPECTED_PROMPT = """Select varname
     Choose from"""
 
 
-@pytest.mark.parametrize('user_choice, expected_value', enumerate(OPTIONS, 1))
+@pytest.mark.parametrize(
+    "user_choice, expected_value",
+    list(enumerate(OPTIONS, 1)),
+)
 def test_click_invocation(mocker, user_choice, expected_value) -> None:
     """Test click function called correctly by cookiecutter.
 
     Test for choice type invocation.
     """
-    prompt = mocker.patch('rich.prompt.Prompt.ask')
-    prompt.return_value = f'{user_choice}'
+    prompt = mocker.patch("rich.prompt.Prompt.ask")
+    prompt.return_value = f"{user_choice}"
 
-    assert read_user_choice('varname', OPTIONS) == expected_value
+    assert read_user_choice("varname", OPTIONS) == expected_value
 
-    prompt.assert_called_once_with(EXPECTED_PROMPT, choices=OPTIONS_INDEX, default='1')
+    prompt.assert_called_once_with(
+        EXPECTED_PROMPT,
+        choices=OPTIONS_INDEX,
+        default="1",
+    )
 
 
 def test_raise_if_options_is_not_a_non_empty_list() -> None:


### PR DESCRIPTION
Fixes deprecation warnings from pytest regarding non-Collection iterables passed to parametrize.

Changes:
- Convert `context_data()` generator to list in `test_generate_context`
- Convert `enumerate()` iterator to list in `test_read_user_choice`

This prevents `PytestRemovedIn10Warning` with newer pytest versions.