### PR TITLE
feat: add _force_render to override binary false positives

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -56,6 +56,25 @@ def is_copy_only_path(path: str, context: dict[str, Any]) -> bool:
     return False
 
 
+def is_force_render_path(path: str, context: dict[str, Any]) -> bool:
+    """Check whether the given `path` must be rendered even if binary detection fails.
+
+    Returns True if `path` matches a pattern in ``_force_render``, otherwise False.
+    This overrides heuristic binary classification (e.g. files starting with ``PACK``).
+
+    :param path: A file-system path referring to a file that should be rendered.
+    :param context: cookiecutter context.
+    """
+    try:
+        for force_render in context['cookiecutter']['_force_render']:
+            if fnmatch.fnmatch(path, force_render):
+                return True
+    except KeyError:
+        return False
+
+    return False
+
+
 def apply_overwrites_to_context(
     context: dict[str, Any],
     overwrite_context: dict[str, Any],
@@ -217,8 +236,10 @@ def generate_file(
     logger.debug('Created file at %s', outfile)
 
     # Just copy over binary files. Don't render.
+    # ``_force_render`` wins over binaryornot heuristics so false positives
+    # (e.g. text files starting with ``PACK``) can still be templated.
     logger.debug("Check %s to see if it's a binary", infile)
-    if is_binary(infile):
+    if not is_force_render_path(infile, context) and is_binary(infile):
         logger.debug('Copying binary %s to %s without rendering', infile, outfile)
         shutil.copyfile(infile, outfile)
         shutil.copymode(infile, outfile)

--- a/docs/advanced/force_render.rst
+++ b/docs/advanced/force_render.rst
@@ -1,0 +1,35 @@
+.. _force-render:
+
+Force Render
+------------
+
+*New in Cookiecutter (unreleased)*
+
+Binary detection is heuristic and can produce false positives (for example, a
+plain-text file that starts with ``PACKAGE_NAME`` is treated as binary because
+``binaryornot`` matches the ``PACK`` signature).
+
+To force Jinja rendering for matching paths even when binary detection would
+skip them, use the ``_force_render`` key in ``cookiecutter.json``. The value is a
+list of Unix shell-style wildcards, the same style as ``_copy_without_render``:
+
+.. code-block:: JSON
+
+    {
+        "project_slug": "sample",
+        "_force_render": [
+            "Makefile",
+            "*.mk",
+            "configs/*.ini"
+        ]
+    }
+
+**Precedence**
+
+1. Paths matching ``_copy_without_render`` are copied without rendering.
+2. Paths matching ``_force_render`` are always rendered as text.
+3. Otherwise binary detection decides whether to copy or render.
+
+**Note**:
+``_force_render`` only affects file *contents*. Path rendering still uses the
+normal Jinja path expansion for the output name.

--- a/docs/advanced/index.rst
+++ b/docs/advanced/index.rst
@@ -16,6 +16,7 @@ Various advanced topics regarding cookiecutter usage.
    templates_in_context
    private_variables
    copy_without_render
+   force_render
    replay
    choice_variables
    boolean_variables

--- a/tests/test_generate_force_render.py
+++ b/tests/test_generate_force_render.py
@@ -1,0 +1,76 @@
+"""Verify correct work of `_force_render` context option (issue #2205)."""
+
+from pathlib import Path
+
+import pytest
+
+from cookiecutter import generate
+
+
+@pytest.mark.usefixtures('clean_system')
+def test_force_render_overrides_binary_false_positive(tmp_path) -> None:
+    """Files starting with ``PACK`` are misclassified as binary by binaryornot.
+
+    ``_force_render`` must force Jinja rendering for matching paths.
+    """
+    template = tmp_path / 'template'
+    project = template / '{{cookiecutter.project_slug}}'
+    project.mkdir(parents=True)
+    # Content starts with PACK — binaryornot treats this as a binary signature.
+    (project / 'Makefile').write_text(
+        'PACKAGE_NAME := {{ cookiecutter.project_slug }}\n',
+        encoding='utf-8',
+    )
+    (project / 'other.txt').write_text(
+        'hello {{ cookiecutter.project_slug }}\n',
+        encoding='utf-8',
+    )
+
+    out = tmp_path / 'out'
+    out.mkdir()
+
+    generate.generate_files(
+        context={
+            'cookiecutter': {
+                'project_slug': 'example-package',
+                '_force_render': ['Makefile', '*.mk'],
+            }
+        },
+        repo_dir=str(template),
+        output_dir=str(out),
+    )
+
+    makefile = Path(out, 'example-package', 'Makefile')
+    assert makefile.is_file()
+    assert makefile.read_text(encoding='utf-8') == 'PACKAGE_NAME := example-package\n'
+
+    other = Path(out, 'example-package', 'other.txt')
+    assert other.read_text(encoding='utf-8') == 'hello example-package\n'
+
+
+@pytest.mark.usefixtures('clean_system')
+def test_pack_prefix_without_force_render_skips_jinja(tmp_path) -> None:
+    """Without ``_force_render``, PACK-prefixed text is still copied unrendered."""
+    template = tmp_path / 'template'
+    project = template / '{{cookiecutter.project_slug}}'
+    project.mkdir(parents=True)
+    (project / 'foo_file').write_text(
+        'PACKAGE_NAME := {{ cookiecutter.project_slug }}\n',
+        encoding='utf-8',
+    )
+
+    out = tmp_path / 'out'
+    out.mkdir()
+
+    generate.generate_files(
+        context={'cookiecutter': {'project_slug': 'example-package'}},
+        repo_dir=str(template),
+        output_dir=str(out),
+    )
+
+    foo = Path(out, 'example-package', 'foo_file')
+    assert foo.is_file()
+    # binaryornot false-positive: left unrendered
+    assert foo.read_text(encoding='utf-8') == (
+        'PACKAGE_NAME := {{ cookiecutter.project_slug }}\n'
+    )


### PR DESCRIPTION
## Description

Files that start with `PACKAGE_NAME` are misclassified as binary by `binaryornot` (signature `PACK`). Cookiecutter then copies them without Jinja rendering, leaving `{{ cookiecutter.* }}` unresolved — silent and hard to debug.

## Fix

Add a `_force_render` context option (Unix shell-style wildcards, same shape as `_copy_without_render`):

```json
{
  "project_slug": "example-package",
  "_force_render": ["Makefile", "*.mk"]
}
```

**Precedence**

1. `_copy_without_render` → copy only  
2. `_force_render` → always render as text  
3. else → `binaryornot` heuristic  

## Tests

```bash
pytest tests/test_generate_force_render.py tests/test_generate_copy_without_render.py -o addopts=
```

## Docs

- `docs/advanced/force_render.rst`
- linked from `docs/advanced/index.rst`

## Linked Issue

Closes #2205
