### PR TITLE
Fix docs typos, outdated names and update links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Cookiecutter could always use more documentation, whether as part of the officia
 If you want to review your changes on the documentation locally, you can do:
 
 ```bash
-pip install --group dev
+uv sync --group dev
 just servedocs
 ```
 
@@ -81,7 +81,7 @@ Here's how to set up `cookiecutter` for local development.
    ```bash
    cd cookiecutter/
    pip install -e .
-   pip install --group dev
+   uv sync --group dev
    ```
 
 4. Create a branch for local development:

--- a/docs/advanced/templates.rst
+++ b/docs/advanced/templates.rst
@@ -31,4 +31,4 @@ and the path should be relative from the `templates` folder like ::
     # file.txt
     {% include "base.txt" %}
 
-see more on https://jinja.palletsprojects.com/en/2.11.x/templates/
+see more on https://jinja.palletsprojects.com/en/latest/templates/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -18,7 +18,7 @@ Most Linux distributions come with Python pre-installed.
 Consult the official `Python documentation <https://docs.python.org/3/using/index.html>`_ for details.
 
 You can install the Python binaries from `python.org <https://www.python.org/downloads/>`_.
-Alternatively on macOS, you can use the `homebrew <http://brew.sh/>`_ package manager.
+Alternatively on macOS, you can use the `homebrew <https://brew.sh/>`_ package manager.
 
 .. code-block:: bash
 
@@ -58,7 +58,7 @@ You may need to restart your command prompt session to load the environment vari
 **Unix on Windows**
 
 
-You may also install  `Windows Subsystem for Linux <https://msdn.microsoft.com/en-us/commandline/wsl/install-win10>`_ or `GNU utilities for Win32 <http://unxutils.sourceforge.net>`_ to use Unix commands on Windows.
+You may also install  `Windows Subsystem for Linux <https://msdn.microsoft.com/en-us/commandline/wsl/install-win10>`_ or `GNU utilities for Win32 <https://unxutils.sourceforge.net>`_ to use Unix commands on Windows.
 
 Packaging tools
 ^^^^^^^^^^^^^^^
@@ -98,7 +98,7 @@ Once the conda-forge channel has been enabled, cookiecutter can be installed wit
 Alternate installations
 -----------------------
 
-**Homebrew (Mac OS X only):**
+**Homebrew (macOS only):**
 
 .. code-block:: bash
 
@@ -110,7 +110,7 @@ Alternate installations
 
     xbps-install cookiecutter
 
-**Pipx (Linux, OSX and Windows):**
+**Pipx (Linux, macOS and Windows):**
 
 .. code-block:: bash
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -30,7 +30,7 @@ See https://jinja.palletsprojects.com/en/latest/templates/#escaping for more inf
 You can also use the `_copy_without_render`_ key in your `cookiecutter.json`
 file to escape entire files and directories.
 
-.. _`_copy_without_render`: http://cookiecutter.readthedocs.io/en/latest/advanced/copy_without_render.html
+.. _`_copy_without_render`: https://cookiecutter.readthedocs.io/en/latest/advanced/copy_without_render.html
 
 
 Other common issues


### PR DESCRIPTION
Fix several documentation issues:

- Update "Mac OS X" and "OSX" to "macOS" in installation docs
- Update HTTP links to HTTPS (brew.sh, unxutils, readthedocs)
- Update Jinja2 docs link from 2.11.x to latest
- Fix CONTRIBUTING.md: replace incorrect `pip install --group dev` with `uv sync --group dev`