### PR TITLE
Respect XDG base directories for the cache and replay directories

### DIFF
--- a/cookiecutter/config.py
+++ b/cookiecutter/config.py
@@ -19,15 +19,33 @@ logger = logging.getLogger(__name__)
 
 USER_CONFIG_PATH = os.path.expanduser('~/.cookiecutterrc')
 
+# The locations Cookiecutter used before it followed the XDG Base Directory
+# specification. They are kept only to migrate existing installs; the defaults
+# now live under the XDG cache and data directories below.
+LEGACY_COOKIECUTTERS_DIR = '~/.cookiecutters'
+LEGACY_REPLAY_DIR = '~/.cookiecutter_replay'
+
 BUILTIN_ABBREVIATIONS = {
     'gh': 'https://github.com/{0}.git',
     'gl': 'https://gitlab.com/{0}.git',
     'bb': 'https://bitbucket.org/{0}',
 }
 
+
+def xdg_dir(env_var: str, fallback: str, subdir: str) -> str:
+    """Return the path for ``subdir`` under an XDG base directory.
+
+    Honors ``env_var`` (e.g. ``XDG_CACHE_HOME``) when it is set and falls back
+    to the default from the XDG Base Directory specification otherwise, e.g.
+    ``~/.cache`` for ``XDG_CACHE_HOME``.
+    """
+    base = os.environ.get(env_var) or os.path.expanduser(fallback)
+    return os.path.join(base, subdir)
+
+
 DEFAULT_CONFIG = {
-    'cookiecutters_dir': os.path.expanduser('~/.cookiecutters/'),
-    'replay_dir': os.path.expanduser('~/.cookiecutter_replay/'),
+    'cookiecutters_dir': xdg_dir('XDG_CACHE_HOME', '~/.cache', 'cookiecutter'),
+    'replay_dir': xdg_dir('XDG_DATA_HOME', '~/.local/share', 'cookiecutter'),
     'default_context': collections.OrderedDict([]),
     'abbreviations': BUILTIN_ABBREVIATIONS,
 }
@@ -37,6 +55,53 @@ def _expand_path(path: str) -> str:
     """Expand both environment variables and user home in the given path."""
     path = os.path.expandvars(path)
     return os.path.expanduser(path)
+
+
+def _migrate_default(path: str, legacy: str, label: str) -> str:
+    """Return ``path`` unless a legacy install still holds data there.
+
+    One-way migration from the pre-XDG locations: while the legacy directory
+    exists and the new default has not been created yet, keep using the legacy
+    directory so existing users are not stranded by the move.
+    """
+    legacy_path = os.path.expanduser(legacy)
+    if os.path.isdir(legacy_path) and not os.path.isdir(path):
+        logger.info(
+            "Using legacy %s directory %s. Move it to %s or set the %r "
+            'setting in your config to migrate to the XDG location.',
+            label,
+            legacy_path,
+            path,
+            label,
+        )
+        return legacy_path
+    return path
+
+
+def _expand_or_migrate(value: str, legacy: str, label: str) -> str:
+    """Expand ``value``, migrating from the legacy location when applicable.
+
+    The migration only applies while ``value`` is still the built-in default,
+    i.e. the user did not override the setting in their config.
+    """
+    expanded = _expand_path(value)
+    if value == DEFAULT_CONFIG[label]:
+        return _migrate_default(expanded, legacy, label)
+    return expanded
+
+
+def _default_config() -> dict[str, Any]:
+    """Return a copy of the default config with legacy directories migrated."""
+    config_dict = copy.copy(DEFAULT_CONFIG)
+    config_dict['replay_dir'] = _migrate_default(
+        config_dict['replay_dir'], LEGACY_REPLAY_DIR, 'replay_dir'
+    )
+    config_dict['cookiecutters_dir'] = _migrate_default(
+        config_dict['cookiecutters_dir'],
+        LEGACY_COOKIECUTTERS_DIR,
+        'cookiecutters_dir',
+    )
+    return config_dict
 
 
 def merge_configs(default: dict[str, Any], overwrite: dict[str, Any]) -> dict[str, Any]:
@@ -77,11 +142,15 @@ def get_config(config_path: Path | str) -> dict[str, Any]:
 
     config_dict = merge_configs(DEFAULT_CONFIG, yaml_dict)
 
-    raw_replay_dir = config_dict['replay_dir']
-    config_dict['replay_dir'] = _expand_path(raw_replay_dir)
+    config_dict['replay_dir'] = _expand_or_migrate(
+        config_dict['replay_dir'], LEGACY_REPLAY_DIR, 'replay_dir'
+    )
 
-    raw_cookies_dir = config_dict['cookiecutters_dir']
-    config_dict['cookiecutters_dir'] = _expand_path(raw_cookies_dir)
+    config_dict['cookiecutters_dir'] = _expand_or_migrate(
+        config_dict['cookiecutters_dir'],
+        LEGACY_COOKIECUTTERS_DIR,
+        'cookiecutters_dir',
+    )
 
     return config_dict
 
@@ -115,7 +184,7 @@ def get_user_config(
     # Do NOT load a config. Return defaults instead.
     if default_config:
         logger.debug("Force ignoring user config with default_config switch.")
-        return copy.copy(DEFAULT_CONFIG)
+        return _default_config()
 
     # Load the given config file
     if config_file and config_file is not USER_CONFIG_PATH:
@@ -132,7 +201,7 @@ def get_user_config(
             logger.debug("Loading config from %s.", USER_CONFIG_PATH)
             return get_config(USER_CONFIG_PATH)
         logger.debug("User config not found. Loading default config.")
-        return copy.copy(DEFAULT_CONFIG)
+        return _default_config()
     else:
         # There is a config environment variable. Try to load it.
         # Do not check for existence, so invalid file paths raise an error.

--- a/docs/advanced/replay.rst
+++ b/docs/advanced/replay.rst
@@ -5,7 +5,7 @@ Replay Project Generation
 
 *New in Cookiecutter 1.1*
 
-On invocation **Cookiecutter** dumps a json file to ``~/.cookiecutter_replay/`` which enables you to *replay* later on.
+On invocation **Cookiecutter** dumps a json file to the replay directory which enables you to *replay* later on. The directory defaults to ``$XDG_DATA_HOME/cookiecutter`` (usually ``~/.local/share/cookiecutter``) and can be changed with the ``replay_dir`` setting in your :ref:`user config <user-config>`.
 
 In other words, it persists your **input** for a template and fetches it when you run the same template again.
 

--- a/docs/advanced/user_config.rst
+++ b/docs/advanced/user_config.rst
@@ -47,9 +47,17 @@ Possible settings are:
     These values are treated like the defaults in ``cookiecutter.json``, upon generation of any project.
 ``cookiecutters_dir``
     Directory where your cookiecutters are cloned to when you use Cookiecutter with a repo argument.
+    Defaults to ``$XDG_CACHE_HOME/cookiecutter`` (usually ``~/.cache/cookiecutter``).
 ``replay_dir``
     Directory where Cookiecutter dumps context data to, which you can fetch later on when using the
     :ref:`replay feature <replay-feature>`.
+    Defaults to ``$XDG_DATA_HOME/cookiecutter`` (usually ``~/.local/share/cookiecutter``).
+
+Both directories follow the `XDG Base Directory Specification
+<https://specifications.freedesktop.org/basedir/latest/>`_. For backward
+compatibility, an existing ``~/.cookiecutters`` or ``~/.cookiecutter_replay``
+directory keeps being used until the XDG location has been created, so no
+data is stranded by an upgrade.
 ``abbreviations``
     A list of abbreviations for cookiecutters.
     Abbreviations can be simple aliases for a repo name, or can be used as a prefix, in the form ``abbr:suffix``.

--- a/tests/test_get_config.py
+++ b/tests/test_get_config.py
@@ -1,6 +1,6 @@
 """Collection of tests around loading cookiecutter config."""
 
-from pathlib import Path
+import os
 
 import pytest
 import yaml
@@ -104,11 +104,9 @@ def test_invalid_config() -> None:
 def test_get_config_with_defaults() -> None:
     """A config file that overrides 1 of 3 defaults."""
     conf = config.get_config('tests/test-config/valid-partial-config.yaml')
-    default_cookiecutters_dir = Path('~/.cookiecutters').expanduser()
-    default_replay_dir = Path('~/.cookiecutter_replay').expanduser()
     expected_conf = {
-        'cookiecutters_dir': str(default_cookiecutters_dir),
-        'replay_dir': str(default_replay_dir),
+        'cookiecutters_dir': config.DEFAULT_CONFIG['cookiecutters_dir'],
+        'replay_dir': config.DEFAULT_CONFIG['replay_dir'],
         'default_context': {
             'full_name': 'Firstname Lastname',
             'email': 'firstname.lastname@gmail.com',
@@ -127,6 +125,29 @@ def test_get_config_empty_config_file() -> None:
     """An empty config file results in the default config."""
     conf = config.get_config('tests/test-config/empty-config.yaml')
     assert conf == config.DEFAULT_CONFIG
+
+
+def test_xdg_dir_uses_env_variable_when_set(monkeypatch) -> None:
+    """XDG base directory environment variables are honored when set."""
+    monkeypatch.setenv('XDG_CACHE_HOME', '/custom/cache')
+    monkeypatch.setenv('XDG_DATA_HOME', '/custom/data')
+
+    cache_dir = config.xdg_dir('XDG_CACHE_HOME', '~/.cache', 'cookiecutter')
+    data_dir = config.xdg_dir('XDG_DATA_HOME', '~/.local/share', 'cookiecutter')
+    assert cache_dir == os.path.join('/custom/cache', 'cookiecutter')
+    assert data_dir == os.path.join('/custom/data', 'cookiecutter')
+
+
+def test_xdg_dir_uses_spec_default_when_env_var_unset(monkeypatch) -> None:
+    """XDG base directory defaults are used when the env var is not set."""
+    monkeypatch.delenv('XDG_CACHE_HOME', raising=False)
+    monkeypatch.delenv('XDG_DATA_HOME', raising=False)
+    monkeypatch.setenv('HOME', '/custom/home')
+
+    cache_dir = config.xdg_dir('XDG_CACHE_HOME', '~/.cache', 'cookiecutter')
+    data_dir = config.xdg_dir('XDG_DATA_HOME', '~/.local/share', 'cookiecutter')
+    assert cache_dir == os.path.join('/custom/home', '.cache', 'cookiecutter')
+    assert data_dir == os.path.join('/custom/home', '.local', 'share', 'cookiecutter')
 
 
 def test_get_config_invalid_file_with_array_as_top_level_element() -> None:

--- a/tests/test_get_user_config.py
+++ b/tests/test_get_user_config.py
@@ -165,3 +165,50 @@ def test_specify_config_values() -> None:
     user_config = config.get_user_config(default_config={'replay_dir': replay_dir})
 
     assert user_config == custom_config_updated
+
+
+def test_legacy_directories_are_used_while_they_hold_data(
+    monkeypatch, tmp_path
+) -> None:
+    """Existing pre-XDG directories keep working until the XDG location exists."""
+    home = tmp_path.joinpath('home')
+    legacy_replay_dir = home.joinpath('.cookiecutter_replay')
+    legacy_replay_dir.mkdir(parents=True)
+    monkeypatch.setenv('HOME', str(home))
+
+    xdg_replay_dir = tmp_path.joinpath('xdg-data', 'cookiecutter')
+    monkeypatch.setitem(config.DEFAULT_CONFIG, 'replay_dir', str(xdg_replay_dir))
+
+    user_config = config.get_user_config()
+    assert user_config['replay_dir'] == str(legacy_replay_dir)
+
+
+def test_xdg_directory_wins_once_it_exists(monkeypatch, tmp_path) -> None:
+    """The XDG location is used once it has been created."""
+    home = tmp_path.joinpath('home')
+    legacy_replay_dir = home.joinpath('.cookiecutter_replay')
+    legacy_replay_dir.mkdir(parents=True)
+    monkeypatch.setenv('HOME', str(home))
+
+    xdg_replay_dir = tmp_path.joinpath('xdg-data', 'cookiecutter')
+    xdg_replay_dir.mkdir(parents=True)
+    monkeypatch.setitem(config.DEFAULT_CONFIG, 'replay_dir', str(xdg_replay_dir))
+
+    user_config = config.get_user_config()
+    assert user_config['replay_dir'] == str(xdg_replay_dir)
+
+
+def test_explicit_config_directory_is_not_migrated(monkeypatch, tmp_path) -> None:
+    """An explicitly configured directory is never replaced by the legacy one."""
+    home = tmp_path.joinpath('home')
+    legacy_replay_dir = home.joinpath('.cookiecutter_replay')
+    legacy_replay_dir.mkdir(parents=True)
+    monkeypatch.setenv('HOME', str(home))
+
+    xdg_replay_dir = tmp_path.joinpath('xdg-data', 'cookiecutter')
+    monkeypatch.setitem(config.DEFAULT_CONFIG, 'replay_dir', str(xdg_replay_dir))
+
+    user_config = config.get_user_config(
+        default_config={'replay_dir': '/custom/replay-dir'}
+    )
+    assert user_config['replay_dir'] == '/custom/replay-dir'


### PR DESCRIPTION
Fixes #2259

## Problem

Cookiecutter creates directories directly under `$HOME` (`~/.cookiecutters/` for the template cache and `~/.cookiecutter_replay/` for replay files) instead of following the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir/latest/).

## Change

The built-in defaults now live under the XDG base directories:

| Setting | Before | After |
| --- | --- | --- |
| `cookiecutters_dir` | `~/.cookiecutters/` | `$XDG_CACHE_HOME/cookiecutter` (usually `~/.cache/cookiecutter`) |
| `replay_dir` | `~/.cookiecutter_replay/` | `$XDG_DATA_HOME/cookiecutter` (usually `~/.local/share/cookiecutter`) |

**Backward compatibility:** an existing `~/.cookiecutters` or `~/.cookiecutter_replay` directory keeps being used while it holds data and the XDG location hasn't been created yet, so upgrading never strands existing caches or replay files. Settings explicitly overridden in the user config are always honored and never migrated.

## Notes

- The default config file location (`~/.cookiecutterrc`) is intentionally unchanged — it is the documented, single-file convention, and its lookup is already overridable via `COOKIECUTTER_CONFIG` / `--config-file`.
- A happy side effect: the no-config default path now returns fully-expanded paths, so the replay `dump`/`load` helpers no longer risk a literal `~` directory when no user config exists.
- The `replay_dir`/`cookiecutters_dir` docs now state the new defaults.

## Testing

- New tests for `xdg_dir` (env var honored, spec fallback used), and one-way migration (legacy dirs used while they hold data, XDG dir wins once it exists, explicit config dirs never migrated).
- Full suite: 384 passed, 4 skipped, 100% coverage. `ruff check` / `ruff format` clean.
