### PR TITLE
Handle binaryornot detection failures for binary template assets

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -36,6 +36,19 @@ from cookiecutter.utils import (
 logger = logging.getLogger(__name__)
 
 
+def _is_binary_file(path: str) -> bool:
+    """Classify a file, falling back to binary on detector incompatibility."""
+    try:
+        return is_binary(path)
+    except (TypeError, NameError) as error:
+        logger.warning(
+            "Binary detection failed for %s (%s); copying without rendering",
+            path,
+            error,
+        )
+        return True
+
+
 def is_copy_only_path(path: str, context: dict[str, Any]) -> bool:
     """Check whether the given `path` should only be copied and not rendered.
 
@@ -218,7 +231,7 @@ def generate_file(
 
     # Just copy over binary files. Don't render.
     logger.debug("Check %s to see if it's a binary", infile)
-    if is_binary(infile):
+    if _is_binary_file(infile):
         logger.debug('Copying binary %s to %s without rendering', infile, outfile)
         shutil.copyfile(infile, outfile)
         shutil.copymode(infile, outfile)

--- a/tests/generate/test_binary_detection_fallback.py
+++ b/tests/generate/test_binary_detection_fallback.py
@@ -1,0 +1,19 @@
+import pytest
+
+from cookiecutter import generate
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        TypeError("decode() argument 'encoding' must be str, not None"),
+        NameError("name 'unicode' is not defined"),
+    ],
+)
+def test_binary_detection_failure_falls_back_to_binary(monkeypatch, error):
+    def fail_detection(_path):
+        raise error
+
+    monkeypatch.setattr(generate, "is_binary", fail_detection)
+
+    assert generate._is_binary_file("font.ttf") is True


### PR DESCRIPTION
## Summary

Keep template generation from crashing when `binaryornot` cannot classify opaque binary assets with newer chardet versions.

## Changes

- wrap binary detection in a narrow compatibility guard for the observed `TypeError`/`NameError` failure chain
- conservatively treat an unclassifiable file as binary so Cookiecutter copies it byte-for-byte instead of trying to render it as text
- add focused regression coverage for both failure modes

## Validation

Adds focused coverage in `tests/generate/test_binary_detection_fallback.py`. Full repository tests should run in CI.

Fixes #2197

<!-- pr-relay-job relay-57-c29301fb9bccf4821cb9 -->