### PR TITLE
Fix cleanup of copied read-only template directories

### DIFF
--- a/cookiecutter/utils.py
+++ b/cookiecutter/utils.py
@@ -28,7 +28,8 @@ def force_delete(func, path, _exc_info) -> None:  # type: ignore[no-untyped-def]
     Usage: `shutil.rmtree(path, onerror=force_delete)`
     From https://docs.python.org/3/library/shutil.html#rmtree-example
     """
-    os.chmod(path, stat.S_IWRITE)
+    mode = os.stat(path).st_mode
+    os.chmod(path, mode | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
     func(path)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,6 +30,22 @@ def test_force_delete(mocker, tmp_path) -> None:
     utils.rmtree(tmp_path)
 
 
+def test_force_delete_restores_directory_traversal(mocker, tmp_path) -> None:
+    """Verify cleanup can traverse a copied read-only directory."""
+    ro_dir = tmp_path / 'template'
+    ro_dir.mkdir()
+    (ro_dir / 'cookiecutter.json').write_text('{}')
+    ro_dir.chmod(stat.S_IWUSR)
+
+    delete = mocker.Mock()
+    utils.force_delete(delete, ro_dir, sys.exc_info())
+
+    mode = ro_dir.stat().st_mode
+    assert mode & stat.S_IXUSR
+    assert mode & stat.S_IWUSR
+    delete.assert_called_once_with(ro_dir)
+
+
 def test_rmtree(tmp_path) -> None:
     """Verify `utils.rmtree` remove files marked as read-only."""
     file_path = Path(tmp_path, "bar")


### PR DESCRIPTION
Fixes #2217.

`force_delete()` currently replaces permissions with write-only mode. That is insufficient for directories because cleanup needs owner execute permission to traverse them. Preserve the existing mode and add owner read/write/execute bits before retrying the failed removal.

Adds regression coverage for a write-only copied template directory.

<!-- pr-relay-job relay-69-18ec25223c21066e7d21 -->