### PR TITLE
docs: fix grammar in EmptyDirNameException docstring

### DIFF
--- a/cookiecutter/exceptions.py
+++ b/cookiecutter/exceptions.py
@@ -99,7 +99,7 @@ class OutputDirExistsException(CookiecutterException):
 
 class EmptyDirNameException(CookiecutterException):
     """
-    Exception for a empty directory name.
+    Exception for an empty directory name.
 
     Raised when the directory name provided is empty.
     """


### PR DESCRIPTION
### Summary
- Fix minor grammar typo in `EmptyDirNameException` docstring (`for a empty` -> `for an empty`).