### PR TITLE
Fix context overwrite isolation

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -63,6 +63,25 @@ def apply_overwrites_to_context(
     in_dictionary_variable: bool = False,
 ) -> None:
     """Modify the given context in place based on the overwrite_context."""
+    errors = []
+    _apply_overwrites_to_context(
+        context,
+        overwrite_context,
+        in_dictionary_variable=in_dictionary_variable,
+        errors=errors,
+    )
+    if errors:
+        raise ValueError('; '.join(errors))
+
+
+def _apply_overwrites_to_context(
+    context: dict[str, Any],
+    overwrite_context: dict[str, Any],
+    *,
+    in_dictionary_variable: bool,
+    errors: list[str],
+) -> None:
+    """Apply overwrites while collecting invalid entries."""
     for variable, overwrite in overwrite_context.items():
         if variable not in context:
             if not in_dictionary_variable:
@@ -86,7 +105,7 @@ def apply_overwrites_to_context(
                         f"{overwrite} provided for multi-choice variable "
                         f"{variable}, but valid choices are {context_value}"
                     )
-                    raise ValueError(msg)
+                    errors.append(msg)
             else:
                 # We are dealing with a choice variable
                 if overwrite in context_value:
@@ -100,11 +119,14 @@ def apply_overwrites_to_context(
                         f"{overwrite} provided for choice variable "
                         f"{variable}, but the choices are {context_value}."
                     )
-                    raise ValueError(msg)
+                    errors.append(msg)
         elif isinstance(context_value, dict) and isinstance(overwrite, dict):
             # Partially overwrite some keys in original dict
-            apply_overwrites_to_context(
-                context_value, overwrite, in_dictionary_variable=True
+            _apply_overwrites_to_context(
+                context_value,
+                overwrite,
+                in_dictionary_variable=True,
+                errors=errors,
             )
             context[variable] = context_value
         elif isinstance(context_value, bool) and isinstance(overwrite, str):
@@ -112,12 +134,12 @@ def apply_overwrites_to_context(
             # Convert overwrite to its boolean counterpart
             try:
                 context[variable] = YesNoPrompt().process_response(overwrite)
-            except InvalidResponse as err:
+            except InvalidResponse:
                 msg = (
                     f"{overwrite} provided for variable "
                     f"{variable} could not be converted to a boolean."
                 )
-                raise ValueError(msg) from err
+                errors.append(msg)
         else:
             # Simply overwrite the value for this variable
             context[variable] = overwrite

--- a/tests/test_generate_context.py
+++ b/tests/test_generate_context.py
@@ -202,12 +202,44 @@ def test_apply_overwrites_does_not_modify_choices_for_invalid_overwrite() -> Non
     assert generated_context == expected_context
 
 
+def test_default_context_applies_overwrites_after_invalid_overwrite() -> None:
+    """Verify invalid defaults do not prevent later defaults from applying."""
+    with pytest.warns(UserWarning, match="orientation") as warning:
+        generated_context = generate.generate_context(
+            context_file='tests/test-generate-context/choices_template.json',
+            default_context={
+                'orientation': 'foobar',
+                'project_name': 'My Project',
+                'github_username': 'octocat',
+            },
+        )
+
+    assert generated_context['choices_template']['project_name'] == 'My Project'
+    assert generated_context['choices_template']['github_username'] == 'octocat'
+    assert 'orientation' in str(warning.list[0].message)
+
+
 def test_apply_overwrites_invalid_overwrite(template_context) -> None:
     """Verify variables overwrite for list if variable not in list not ignored."""
     with pytest.raises(ValueError):
         generate.apply_overwrites_to_context(
             context=template_context, overwrite_context={'orientation': 'foobar'}
         )
+
+
+def test_apply_overwrites_reports_all_invalid_overwrites(template_context) -> None:
+    """Verify invalid overwrites do not prevent later entries from applying."""
+    with pytest.raises(ValueError, match="orientation.*deployment_regions"):
+        generate.apply_overwrites_to_context(
+            context=template_context,
+            overwrite_context={
+                'orientation': 'foobar',
+                'deployment_regions': ['na'],
+                'repo_name': 'foobar',
+            },
+        )
+
+    assert template_context['repo_name'] == 'foobar'
 
 
 def test_apply_overwrites_sets_multichoice_values(template_context) -> None:


### PR DESCRIPTION
Fixes #2219\n\nInvalid default-context overwrites are now collected per entry so later valid overrides are still applied. Nested dictionaries use the same isolation, and invalid entries are reported together.\n\nTests cover continued processing after invalid choice and multiple reported errors; the full test suite passes.