### PR TITLE
Preserve cached templates when refresh fails

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -403,7 +403,9 @@ def choose_nested_template(
     return f"{template_path}"
 
 
-def prompt_and_delete(path: Path | str, no_input: bool = False) -> bool:
+def prompt_and_delete(
+    path: Path | str, no_input: bool = False, delete: bool = True
+) -> bool:
     """
     Ask user if it's okay to delete the previously-downloaded file/directory.
 
@@ -412,7 +414,9 @@ def prompt_and_delete(path: Path | str, no_input: bool = False) -> bool:
 
     :param path: Previously downloaded zipfile.
     :param no_input: Suppress prompt to delete repo and just delete it.
-    :return: True if the content was deleted
+    :param delete: Whether to delete the content when the user agrees.
+    :return: True if the content was deleted, or if deletion was approved but
+        deferred
     """
     # Suppress prompt if called via API
     if no_input:
@@ -424,11 +428,13 @@ def prompt_and_delete(path: Path | str, no_input: bool = False) -> bool:
 
         ok_to_delete = read_user_yes_no(question, 'yes')
 
-    if ok_to_delete:
+    if ok_to_delete and delete:
         if os.path.isdir(path):
             rmtree(path)
         else:
             os.remove(path)
+        return True
+    if ok_to_delete:
         return True
     ok_to_reuse = read_user_yes_no("Do you want to re-use the existing version?", 'yes')
 

--- a/cookiecutter/vcs.py
+++ b/cookiecutter/vcs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+import tempfile
 from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING
@@ -19,7 +20,7 @@ from cookiecutter.exceptions import (
     VCSNotInstalled,
 )
 from cookiecutter.prompt import prompt_and_delete
-from cookiecutter.utils import make_sure_path_exists
+from cookiecutter.utils import make_sure_path_exists, rmtree
 
 logger = logging.getLogger(__name__)
 
@@ -97,12 +98,19 @@ def clone(
         repo_dir = os.path.normpath(os.path.join(clone_to_dir, repo_name))
     logger.debug(f'repo_dir is {repo_dir}')
 
-    if os.path.isdir(repo_dir):
-        clone = prompt_and_delete(repo_dir, no_input=no_input)
+    existing_repo = os.path.isdir(repo_dir)
+    if existing_repo:
+        # Keep the existing cache until the replacement has been downloaded
+        # successfully. This prevents a failed refresh from destroying it.
+        clone = prompt_and_delete(repo_dir, no_input=no_input, delete=False)
     else:
         clone = True
 
+    temporary_clone_to_dir = None
     if clone:
+        if existing_repo:
+            temporary_clone_to_dir = tempfile.mkdtemp(dir=clone_to_dir)
+            clone_to_dir = Path(temporary_clone_to_dir)
         try:
             subprocess.check_output(
                 [repo_type, 'clone', repo_url],
@@ -118,6 +126,12 @@ def clone(
                     [repo_type, 'checkout', *checkout_params],
                     cwd=repo_dir,
                     stderr=subprocess.STDOUT,
+                )
+            if existing_repo:
+                rmtree(repo_dir)
+                os.replace(
+                    os.path.join(clone_to_dir, repo_name),
+                    repo_dir,
                 )
         except subprocess.CalledProcessError as clone_error:
             output = clone_error.output.decode('utf-8')
@@ -135,5 +149,8 @@ def clone(
                 raise RepositoryCloneFailed(msg) from clone_error
             logger.exception('git clone failed with error: %s', output)
             raise
+        finally:
+            if temporary_clone_to_dir is not None:
+                rmtree(clone_to_dir)
 
     return repo_dir

--- a/tests/vcs/test_clone.py
+++ b/tests/vcs/test_clone.py
@@ -84,7 +84,9 @@ def test_clone_should_silent_exit_if_ok_to_reuse(mocker, tmpdir) -> None:
     assert not mock_subprocess.called
 
 
-def test_clone_should_preserve_existing_repo_if_refresh_fails(mocker, clone_dir) -> None:
+def test_clone_should_preserve_existing_repo_if_refresh_fails(
+    mocker, clone_dir
+) -> None:
     """A failed refresh must not delete the existing cached repository."""
     mocker.patch('cookiecutter.vcs.is_vcs_installed', return_value=True)
     mocker.patch('cookiecutter.vcs.prompt_and_delete', return_value=True)
@@ -136,8 +138,13 @@ def test_clone_should_replace_existing_repo_after_successful_refresh(
         no_input=True,
     )
 
-    assert result == os.path.normpath(os.path.join(clone_dir, 'cookiecutter-pytest-plugin'))
-    assert repo_dir.joinpath('cookiecutter.json').read_text() == '{"app_name": "refreshed"}'
+    assert result == os.path.normpath(
+        os.path.join(clone_dir, 'cookiecutter-pytest-plugin')
+    )
+    assert (
+        repo_dir.joinpath('cookiecutter.json').read_text()
+        == '{"app_name": "refreshed"}'
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/vcs/test_clone.py
+++ b/tests/vcs/test_clone.py
@@ -84,6 +84,62 @@ def test_clone_should_silent_exit_if_ok_to_reuse(mocker, tmpdir) -> None:
     assert not mock_subprocess.called
 
 
+def test_clone_should_preserve_existing_repo_if_refresh_fails(mocker, clone_dir) -> None:
+    """A failed refresh must not delete the existing cached repository."""
+    mocker.patch('cookiecutter.vcs.is_vcs_installed', return_value=True)
+    mocker.patch('cookiecutter.vcs.prompt_and_delete', return_value=True)
+    mocker.patch(
+        'cookiecutter.vcs.subprocess.check_output',
+        side_effect=subprocess.CalledProcessError(
+            1, ['git', 'clone'], output=b'Something went wrong'
+        ),
+    )
+
+    repo_dir = clone_dir.joinpath('cookiecutter-pytest-plugin')
+    repo_dir.mkdir()
+    marker = repo_dir.joinpath('cookiecutter.json')
+    marker.write_text('{"app_name": "existing"}')
+
+    with pytest.raises(subprocess.CalledProcessError):
+        vcs.clone(
+            'https://github.com/pytest-dev/cookiecutter-pytest-plugin.git',
+            clone_to_dir=clone_dir,
+            no_input=True,
+        )
+
+    assert marker.read_text() == '{"app_name": "existing"}'
+
+
+def test_clone_should_replace_existing_repo_after_successful_refresh(
+    mocker, clone_dir
+) -> None:
+    """A successful refresh should replace the existing cached repository."""
+    mocker.patch('cookiecutter.vcs.is_vcs_installed', return_value=True)
+    mocker.patch('cookiecutter.vcs.prompt_and_delete', return_value=True)
+
+    def clone_repo(_command, cwd, **_kwargs):
+        new_repo = cwd.joinpath('cookiecutter-pytest-plugin')
+        new_repo.mkdir()
+        new_repo.joinpath('cookiecutter.json').write_text(
+            '{"app_name": "refreshed"}'
+        )
+
+    mocker.patch('cookiecutter.vcs.subprocess.check_output', side_effect=clone_repo)
+
+    repo_dir = clone_dir.joinpath('cookiecutter-pytest-plugin')
+    repo_dir.mkdir()
+    repo_dir.joinpath('cookiecutter.json').write_text('{"app_name": "existing"}')
+
+    result = vcs.clone(
+        'https://github.com/pytest-dev/cookiecutter-pytest-plugin.git',
+        clone_to_dir=clone_dir,
+        no_input=True,
+    )
+
+    assert result == os.path.normpath(os.path.join(clone_dir, 'cookiecutter-pytest-plugin'))
+    assert repo_dir.joinpath('cookiecutter.json').read_text() == '{"app_name": "refreshed"}'
+
+
 @pytest.mark.parametrize(
     'repo_type, repo_url, repo_name',
     [


### PR DESCRIPTION
## Summary\n\n- preserve an existing cached template until a refresh clone succeeds\n- clean up temporary refresh directories on failure\n- add regression coverage for failed and successful refreshes\n\n## Tests\n\n- \n- targeted smoke tests for failed and successful refreshes\n\nFixes #2232