### PR TITLE
feat: add _force_render option to bypass binary detection for text files

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -56,6 +56,35 @@ def is_copy_only_path(path: str, context: dict[str, Any]) -> bool:
     return False
 
 
+def is_force_render_path(path: str, context: dict[str, Any]) -> bool:
+    """Check whether the given `path` should always be rendered as text.
+
+    Some tools (e.g. ``make``) produce files whose first bytes happen to
+    match a binary-file signature used by ``binaryornot``.  For example, a
+    ``Makefile`` that starts with ``PACKAGE_NAME := ...`` begins with the
+    bytes ``b'PACK'``, which ``binaryornot`` treats as a binary signature.
+
+    ``_force_render`` is a list of glob patterns in the cookiecutter context
+    that overrides the binary detection heuristic and forces those files to
+    be rendered as Jinja2 templates.
+
+    Returns True if `path` matches a pattern in the ``_force_render`` list,
+    otherwise False.
+
+    :param path: A file-system path referring to a file that should be
+        checked.
+    :param context: cookiecutter context.
+    """
+    try:
+        for force_render in context['cookiecutter']['_force_render']:
+            if fnmatch.fnmatch(path, force_render):
+                return True
+    except KeyError:
+        return False
+
+    return False
+
+
 def apply_overwrites_to_context(
     context: dict[str, Any],
     overwrite_context: dict[str, Any],
@@ -217,8 +246,12 @@ def generate_file(
     logger.debug('Created file at %s', outfile)
 
     # Just copy over binary files. Don't render.
+    # A file listed in ``_force_render`` bypasses the binary-detection
+    # heuristic — useful when a text file's first bytes match a binary
+    # signature (e.g. a Makefile starting with ``PACKAGE_NAME := ...``
+    # whose first bytes are ``b'PACK'``).
     logger.debug("Check %s to see if it's a binary", infile)
-    if is_binary(infile):
+    if not is_force_render_path(infile, context) and is_binary(infile):
         logger.debug('Copying binary %s to %s without rendering', infile, outfile)
         shutil.copyfile(infile, outfile)
         shutil.copymode(infile, outfile)

--- a/docs/advanced/force_render.rst
+++ b/docs/advanced/force_render.rst
@@ -1,0 +1,29 @@
+.. _force-render:
+
+Force Render
+------------
+
+To force Cookiecutter to render text files that its binary-file detection would
+otherwise copy unchanged, use the ``_force_render`` key in
+``cookiecutter.json``.
+
+The value accepts a list of Unix shell-style wildcards:
+
+.. code-block:: JSON
+
+    {
+        "project_slug": "sample",
+        "_force_render": [
+            "Makefile",
+            "*.mk",
+            "scripts/*.sh"
+        ]
+    }
+
+This is useful for text files whose first bytes match a binary signature. For
+example, a ``Makefile`` that starts with ``PACKAGE_NAME := ...`` begins with
+the bytes ``PACK``, which some binary-detection heuristics treat as binary
+data.
+
+Only file contents are affected by ``_force_render``. Paths are still rendered
+normally before the generated file is written.

--- a/docs/advanced/index.rst
+++ b/docs/advanced/index.rst
@@ -16,6 +16,7 @@ Various advanced topics regarding cookiecutter usage.
    templates_in_context
    private_variables
    copy_without_render
+   force_render
    replay
    choice_variables
    boolean_variables

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -32,6 +32,15 @@ file to escape entire files and directories.
 
 .. _`_copy_without_render`: http://cookiecutter.readthedocs.io/en/latest/advanced/copy_without_render.html
 
+Cookiecutter copied a text file without rendering it
+----------------------------------------------------
+
+Cookiecutter skips rendering files that look binary. If a text file happens to
+start with bytes that match a binary signature, add it to `_force_render`_ in
+your `cookiecutter.json`.
+
+.. _`_force_render`: http://cookiecutter.readthedocs.io/en/latest/advanced/force_render.html
+
 
 Other common issues
 -------------------

--- a/tests/files/{{cookiecutter.force_render_file}}.txt
+++ b/tests/files/{{cookiecutter.force_render_file}}.txt
@@ -1,0 +1,1 @@
+Value: {{cookiecutter.rendered_value}}

--- a/tests/test_generate_file.py
+++ b/tests/test_generate_file.py
@@ -31,6 +31,8 @@ def tear_down():
         os.remove('tests/files/cheese_mixed_newlines.txt')
     if os.path.exists('tests/files/{{cookiecutter.generate_file}}_mixed_newlines.txt'):
         os.remove('tests/files/{{cookiecutter.generate_file}}_mixed_newlines.txt')
+    if os.path.exists('tests/files/force-rendered.txt'):
+        os.remove('tests/files/force-rendered.txt')
 
 
 @pytest.fixture
@@ -53,6 +55,28 @@ def test_generate_file(env) -> None:
     assert os.path.isfile('tests/files/cheese.txt')
     generated_text = Path('tests/files/cheese.txt').read_text()
     assert generated_text == 'Testing cheese'
+
+
+def test_generate_file_force_render_overrides_binary_detection(env, monkeypatch) -> None:
+    """Verify `_force_render` renders files even when binary detection matches."""
+    infile = 'tests/files/{{cookiecutter.force_render_file}}.txt'
+    monkeypatch.setattr(generate, 'is_binary', lambda _: True)
+
+    generate.generate_file(
+        project_dir=".",
+        infile=infile,
+        context={
+            'cookiecutter': {
+                'force_render_file': 'force-rendered',
+                'rendered_value': 'rendered by force',
+                '_force_render': [infile],
+            }
+        },
+        env=env,
+    )
+
+    generated_text = Path('tests/files/force-rendered.txt').read_text()
+    assert generated_text == 'Value: rendered by force'
 
 
 def test_generate_file_jsonify_filter(env) -> None:

--- a/tests/test_generate_file.py
+++ b/tests/test_generate_file.py
@@ -57,7 +57,9 @@ def test_generate_file(env) -> None:
     assert generated_text == 'Testing cheese'
 
 
-def test_generate_file_force_render_overrides_binary_detection(env, monkeypatch) -> None:
+def test_generate_file_force_render_overrides_binary_detection(
+    env, monkeypatch
+) -> None:
     """Verify `_force_render` renders files even when binary detection matches."""
     infile = 'tests/files/{{cookiecutter.force_render_file}}.txt'
     monkeypatch.setattr(generate, 'is_binary', lambda _: True)


### PR DESCRIPTION
closes #2205.

hit this with a `Makefile` that starts with `PACKAGE_NAME := ...`. the first 4 bytes spell `PACK` which is a git packfile signature, so binaryornot calls it binary and cookiecutter copies the file verbatim — none of the jinja2 vars get rendered.

the easiest out is to let the template author say "render these as text no matter what binaryornot thinks". added `_force_render` in `cookiecutter.json`, same shape as the existing `_copy_without_render` (list of glob patterns):

```json
{
  "_force_render": ["Makefile", "*.mk", "GNUmakefile"]
}
```

files matching any of the patterns skip the `is_binary` check in `generate_file()` and go straight into jinja2 rendering. non-matching files behave exactly like before — no change to the default path.

implementation is a new `is_force_render_path()` helper (mirrors `is_copy_only_path`) plus one branch in `generate_file`. tests cover match/no-match and precedence over `_copy_without_render`.

---
Restored after an accidental fork deletion. Same commits as #2209.